### PR TITLE
chore(deps): bump typescript, ultracite, react-i18next

### DIFF
--- a/e2e/language.e2e.ts
+++ b/e2e/language.e2e.ts
@@ -127,9 +127,9 @@ test.describe("Language & i18n", () => {
       })
     ).toBeVisible();
 
-    const storedLang = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-language");
-    });
+    const storedLang = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-language")
+    );
 
     expect(storedLang).toBe("de");
   });

--- a/e2e/persistence.e2e.ts
+++ b/e2e/persistence.e2e.ts
@@ -15,9 +15,9 @@ test.describe("localStorage Persistence", () => {
     await page.waitForLoadState("networkidle");
 
     // Verify localStorage (Mantine's useLocalStorage stores JSON stringified values)
-    const savedStack = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-stack");
-    });
+    const savedStack = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack")
+    );
     expect(savedStack).toBe('"aronson"');
 
     // Reload page
@@ -57,9 +57,9 @@ test.describe("localStorage Persistence", () => {
     await secondarySelector.getByText("Card").click();
 
     // Verify localStorage (Mantine's useLocalStorage stores JSON stringified values)
-    const savedMode = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-flashcard-option");
-    });
+    const savedMode = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-flashcard-option")
+    );
     expect(savedMode).toBe('"cardonly"');
 
     // Close popover and reload page
@@ -68,9 +68,9 @@ test.describe("localStorage Persistence", () => {
     await page.waitForLoadState("networkidle");
 
     // Mode should still be card-only
-    const mode = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-flashcard-option");
-    });
+    const mode = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-flashcard-option")
+    );
     expect(mode).toBe('"cardonly"');
   });
 
@@ -90,9 +90,9 @@ test.describe("localStorage Persistence", () => {
     }
 
     // Verify localStorage (color scheme is stored as plain string, not JSON stringified)
-    const savedScheme = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-color-scheme");
-    });
+    const savedScheme = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-color-scheme")
+    );
     expect(savedScheme).toBe("dark");
 
     // Reload page
@@ -156,15 +156,15 @@ test.describe("localStorage Persistence", () => {
     await page.waitForLoadState("networkidle");
 
     // Check mode (Mantine's useLocalStorage stores JSON stringified values)
-    const mode = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-flashcard-option");
-    });
+    const mode = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-flashcard-option")
+    );
     expect(mode).toBe('"numberonly"');
 
     // Check theme (color scheme is stored as plain string)
-    const scheme = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-color-scheme");
-    });
+    const scheme = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-color-scheme")
+    );
     expect(scheme).toBe("dark");
   });
 
@@ -213,9 +213,9 @@ test.describe("localStorage Persistence", () => {
     await page.waitForLoadState("networkidle");
 
     // Verify it's saved (Mantine's useLocalStorage stores JSON stringified values)
-    const savedStack = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-stack");
-    });
+    const savedStack = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack")
+    );
     expect(savedStack).toBe('"memorandum"');
 
     // Clear localStorage via JavaScript
@@ -235,9 +235,9 @@ test.describe("localStorage Persistence", () => {
     expect(selectedValue).toBe("");
 
     // After reload, app re-initializes localStorage with default empty value
-    const clearedStack = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-stack");
-    });
+    const clearedStack = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack")
+    );
     expect(clearedStack).toBe('""'); // JSON stringified empty string
   });
 

--- a/e2e/theme.e2e.ts
+++ b/e2e/theme.e2e.ts
@@ -49,9 +49,9 @@ test.describe("Theme & Color Scheme", () => {
     await expect(themeSwitch).not.toBeChecked();
 
     // Check localStorage
-    const colorScheme = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-color-scheme");
-    });
+    const colorScheme = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-color-scheme")
+    );
 
     expect(colorScheme).toBe("dark");
   });
@@ -86,18 +86,18 @@ test.describe("Theme & Color Scheme", () => {
 
     // Get initial background color
     const body = page.locator("body");
-    const initialBg = await body.evaluate((el) => {
-      return window.getComputedStyle(el).backgroundColor;
-    });
+    const initialBg = await body.evaluate(
+      (el) => window.getComputedStyle(el).backgroundColor
+    );
 
     // Toggle theme by clicking the visible track
     await themeSwitchTrack.click();
 
     // Wait for background color to change (CSS transition)
     await expect(async () => {
-      const newBg = await body.evaluate((el) => {
-        return window.getComputedStyle(el).backgroundColor;
-      });
+      const newBg = await body.evaluate(
+        (el) => window.getComputedStyle(el).backgroundColor
+      );
       expect(newBg).not.toBe(initialBg);
     }).toPass();
   });

--- a/e2e/user-journeys.e2e.ts
+++ b/e2e/user-journeys.e2e.ts
@@ -213,9 +213,9 @@ test.describe("User Journeys", () => {
     }
 
     // Final state should be persisted (color scheme is stored as plain string)
-    const scheme = await page.evaluate(() => {
-      return localStorage.getItem("memdeck-app-color-scheme");
-    });
+    const scheme = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-color-scheme")
+    );
 
     const expectedScheme = isLight ? "light" : "dark";
     expect(scheme).toBe(expectedScheme);

--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
           "data-mantine-color-scheme",
           scheme
         );
-      } catch (_e) {
+      } catch {
         // Silently ignore localStorage access errors
       }
     })();

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "knip": "knip",
     "lint": "ultracite check",
+    "fix": "ultracite fix",
     "dev": "vite",
     "build": "vite build && node scripts/generate-sitemap.ts && node scripts/prerender.ts",
     "typecheck": "tsc -b",
@@ -58,8 +59,8 @@
     "postcss-preset-mantine": "1.18.0",
     "postcss-simple-vars": "7.0.1",
     "sharp": "0.34.5",
-    "typescript": "6.0.2",
-    "ultracite": "7.5.9",
+    "typescript": "6.0.3",
+    "ultracite": "7.6.0",
     "vite": "8.0.8",
     "vite-plugin-pwa": "1.2.0",
     "vitest": "4.1.4",
@@ -75,7 +76,7 @@
     "react-dom": "19.2.5",
     "react-error-boundary": "6.1.1",
     "react-ga4": "3.0.1",
-    "react-i18next": "17.0.3",
+    "react-i18next": "17.0.4",
     "react-router": "7.14.1",
     "web-vitals": "5.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 3.41.1(react@19.2.5)
       i18next:
         specifier: 26.0.5
-        version: 26.0.5(typescript@6.0.2)
+        version: 26.0.5(typescript@6.0.3)
       react:
         specifier: 19.2.5
         version: 19.2.5
@@ -36,8 +36,8 @@ importers:
         specifier: 3.0.1
         version: 3.0.1
       react-i18next:
-        specifier: 17.0.3
-        version: 17.0.3(i18next@26.0.5(typescript@6.0.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2)
+        specifier: 17.0.4
+        version: 17.0.4(i18next@26.0.5(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
       react-router:
         specifier: 7.14.1
         version: 7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -106,11 +106,11 @@ importers:
         specifier: 0.34.5
         version: 0.34.5
       typescript:
-        specifier: 6.0.2
-        version: 6.0.2
+        specifier: 6.0.3
+        version: 6.0.3
       ultracite:
-        specifier: 7.5.9
-        version: 7.5.9(oxlint@1.38.0)
+        specifier: 7.6.0
+        version: 7.6.0(oxlint@1.38.0)
       vite:
         specifier: 8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.10))(terser@5.46.1)(yaml@2.8.3)
@@ -3462,8 +3462,8 @@ packages:
   react-ga4@3.0.1:
     resolution: {integrity: sha512-GyCc01bSheWXjzGDyHsXMOqk/SP5Cf/JrcJTg4hcpKx4eeSwaJKpJUc+ipF4ffLTZkmabmf3ZGBv4OKHTXNXyA==}
 
-  react-i18next@17.0.3:
-    resolution: {integrity: sha512-x4xjvUNZ56T+zfXWNedNnCET9Xq1IBYWX7IsWo5cCQ/RT+Rm7GWqt0h9PShFi4IhyMnsdiu1C6Jc4DE+/S3PFQ==}
+  react-i18next@17.0.4:
+    resolution: {integrity: sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==}
     peerDependencies:
       i18next: '>= 26.0.1'
       react: '>= 16.8.0'
@@ -4002,13 +4002,13 @@ packages:
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ultracite@7.5.9:
-    resolution: {integrity: sha512-6UBZNXqUm9tosAQ/nBQaWeCHWBcOVZmDl9Jfg33o9jSrUSTobpphI23Wh72tc8iYPTR3tXGHWhO+GvC7w/QyQQ==}
+  ultracite@7.6.0:
+    resolution: {integrity: sha512-i8Pmi7Tgtku00/4od12nLiLjgO92+DmuRWTIFApe4f6n8osYT98QLcEdsf7xpJiZflyc8gsONWbFw0RvhO9QzQ==}
     hasBin: true
     peerDependencies:
       oxfmt: '>=0.1.0'
@@ -6928,11 +6928,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  i18next@26.0.5(typescript@6.0.2):
+  i18next@26.0.5(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   iconv-lite@0.4.24:
     dependencies:
@@ -7811,16 +7811,16 @@ snapshots:
 
   react-ga4@3.0.1: {}
 
-  react-i18next@17.0.3(i18next@26.0.5(typescript@6.0.2))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.2):
+  react-i18next@17.0.4(i18next@26.0.5(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3):
     dependencies:
       '@babel/runtime': 7.29.2
       html-parse-stringify: 3.0.1
-      i18next: 26.0.5(typescript@6.0.2)
+      i18next: 26.0.5(typescript@6.0.3)
       react: 19.2.5
       use-sync-external-store: 1.6.0(react@19.2.5)
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
-      typescript: 6.0.2
+      typescript: 6.0.3
 
   react-is@16.13.1: {}
 
@@ -8453,9 +8453,9 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript@6.0.2: {}
+  typescript@6.0.3: {}
 
-  ultracite@7.5.9(oxlint@1.38.0):
+  ultracite@7.6.0(oxlint@1.38.0):
     dependencies:
       '@clack/prompts': 1.2.0
       commander: 14.0.3

--- a/public/404.html
+++ b/public/404.html
@@ -44,7 +44,7 @@
           "data-mantine-color-scheme",
           scheme
         );
-      } catch (_e) {
+      } catch {
         // Silently ignore localStorage access errors
       }
     })();

--- a/src/components/card-spread/card-spread.tsx
+++ b/src/components/card-spread/card-spread.tsx
@@ -30,14 +30,15 @@ export const CardSpread = memo(function CardSpread(props: CardSpreadProps) {
   const rafRef = useRef<number | null>(null);
   const movementAccumulatorRef = useRef(0);
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (rafRef.current !== null) {
         cancelAnimationFrame(rafRef.current);
       }
       movementAccumulatorRef.current = 0;
-    };
-  }, []);
+    },
+    []
+  );
 
   const updateOffset = useCallback(
     (movementX: number) => {

--- a/src/components/pwa-update-notifier.tsx
+++ b/src/components/pwa-update-notifier.tsx
@@ -38,13 +38,14 @@ export const PwaUpdateNotifier = () => {
     },
   });
 
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => () => {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
       }
-    };
-  }, []);
+    },
+    []
+  );
 
   useEffect(() => {
     const storedHash = localStorage.getItem(COMMIT_HASH_LSK);

--- a/src/components/share-button.tsx
+++ b/src/components/share-button.tsx
@@ -15,9 +15,7 @@ export const ShareButton = ({ variant = "icon" }: ShareButtonProps) => {
   const [showCheck, setShowCheck] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  useEffect(() => {
-    return () => clearTimeout(timeoutRef.current);
-  }, []);
+  useEffect(() => () => clearTimeout(timeoutRef.current), []);
 
   const handleShare = useCallback(async () => {
     const result = await shareMemDeck(t("share.message"));

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -143,31 +143,29 @@ const handleRootError = (error: unknown) => {
   analytics.trackError(errorObj, "Root");
 };
 
-export const Provider = () => {
-  return (
-    <ErrorBoundary
-      FallbackComponent={OuterErrorFallback}
-      onError={handleOuterError}
+export const Provider = () => (
+  <ErrorBoundary
+    FallbackComponent={OuterErrorFallback}
+    onError={handleOuterError}
+  >
+    <MantineProvider
+      colorSchemeManager={colorSchemeManager}
+      cssVariablesResolver={cssVariablesResolver}
+      defaultColorScheme={systemColorScheme}
+      theme={theme}
     >
-      <MantineProvider
-        colorSchemeManager={colorSchemeManager}
-        cssVariablesResolver={cssVariablesResolver}
-        defaultColorScheme={systemColorScheme}
-        theme={theme}
+      <ErrorBoundary
+        FallbackComponent={RootErrorFallback}
+        onError={handleRootError}
       >
-        <ErrorBoundary
-          FallbackComponent={RootErrorFallback}
-          onError={handleRootError}
-        >
-          <Notifications />
-          <LanguageLoadNotifier />
-          <PwaUpdateNotifier />
-          <BrowserRouter>
-            <FocusOnNavigate />
-            <App />
-          </BrowserRouter>
-        </ErrorBoundary>
-      </MantineProvider>
-    </ErrorBoundary>
-  );
-};
+        <Notifications />
+        <LanguageLoadNotifier />
+        <PwaUpdateNotifier />
+        <BrowserRouter>
+          <FocusOnNavigate />
+          <App />
+        </BrowserRouter>
+      </ErrorBoundary>
+    </MantineProvider>
+  </ErrorBoundary>
+);

--- a/src/utils/acaan-scenario.ts
+++ b/src/utils/acaan-scenario.ts
@@ -67,6 +67,4 @@ export const generateAcaanScenario = (stack: Stack): AcaanScenario => {
 export const calculateCutDepth = (
   cardPosition: DeckPosition,
   targetPosition: DeckPosition
-): number => {
-  return (cardPosition - targetPosition + DECK_SIZE) % DECK_SIZE;
-};
+): number => (cardPosition - targetPosition + DECK_SIZE) % DECK_SIZE;

--- a/src/utils/session-persistence.test.ts
+++ b/src/utils/session-persistence.test.ts
@@ -35,7 +35,7 @@ vi.mock("@mantine/hooks", () => ({
   readLocalStorageValue: ({ key }: { key: string }) => {
     const raw = storage.get(key);
     if (raw === undefined || raw === null) {
-      return undefined;
+      return;
     }
     return JSON.parse(raw);
   },


### PR DESCRIPTION
## Summary

- Bump `typescript` 6.0.2 → 6.0.3, `ultracite` 7.5.9 → 7.6.0, `react-i18next` 17.0.3 → 17.0.4.
- Apply style auto-fixes from the new ultracite version — block-return arrow functions collapsed to expression arrows across `src/` and `e2e/`.
- Manually fix two `noUselessCatchBinding` errors in the inline color-scheme bootstrap scripts in `index.html` and `public/404.html` (ultracite can't auto-fix these because they're in HTML).
- Add a `pnpm fix` script wrapping `ultracite fix` for convenience.

No runtime behavior change.

## Test plan

- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run test` — 1388 tests pass (verified by pre-commit hook)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)