### PR TITLE
chore: use local ultracite binary and prefer codebase-memory-mcp for verification

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I{} sh -c 'case \"$1\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.css) npx ultracite fix \"$1\" ;; esac' _ {}"
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I{} sh -c 'case \"$1\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.css) ./node_modules/.bin/ultracite fix \"$1\" ;; esac' _ {}"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Never sacrifice readability or testability for performance unless profiling prov
 
 ## Verification Protocol
 
-- **Verify before citing.** Before referencing any file path, function name, export, or type in your response or in code you write, confirm it exists via `Read`/`Grep` in the current turn. Do not rely on this CLAUDE.md, prior-conversation recall, or memory as the source of truth for code locations — those can drift. The codebase is authoritative.
+- **Verify before citing.** Before referencing any file path, function name, export, or type in your response or in code you write, confirm it exists via `mcp__codebase-memory-mcp__search_graph` / `get_code_snippet` / `trace_path` first; fall back to `Read`/`Grep` only for text content. Do not rely on this CLAUDE.md, prior-conversation recall, or memory as the source of truth for code locations — those can drift. The codebase is authoritative.
 - **Verify before declaring done.** After changes to `src/**` or `scripts/**`, run the Definition of Done below. A passing type-check alone is not sufficient once UI, routing, or tests are involved.
 - **If you can't actually run it, say so.** For UI changes you can't exercise in a browser, state that explicitly instead of claiming success. Type-checks and unit tests verify code correctness, not feature correctness.
 


### PR DESCRIPTION
## Summary

- Swap the PostToolUse hook from `npx ultracite fix` to `./node_modules/.bin/ultracite fix` to skip the npx resolution cost on every file save.
- Update the Verification Protocol in CLAUDE.md to prefer `codebase-memory-mcp` tools (`search_graph` / `get_code_snippet` / `trace_path`) before falling back to `Read`/`Grep` for code location lookups.

## Test plan

- [ ] Save a `.ts` file with Claude Code and confirm the hook still formats it (now via the local binary).
- [ ] Confirm CLAUDE.md renders cleanly.