### PR TITLE
fix: surface localStorage write failures instead of swallowing them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage
 test-results/
 playwright-report/
 blob-report/
+.playwright-mcp/
 .auth/
 TODO.txt
 

--- a/src/components/nav-footer.tsx
+++ b/src/components/nav-footer.tsx
@@ -13,7 +13,7 @@ const commitHashStyle: React.CSSProperties = { fontFamily: "monospace" };
 
 export const NavFooter = () => {
   const { t } = useTranslation();
-  const { stackKey, stackName } = useSelectedStack();
+  const { stackKey } = useSelectedStack();
   const hasStack = stackKey !== "";
 
   return (
@@ -29,7 +29,7 @@ export const NavFooter = () => {
             <div style={{ flex: 1 }}>
               <StackPicker />
             </div>
-            <StackRangeBadge stackKey={stackKey} stackName={stackName} />
+            <StackRangeBadge stackKey={stackKey} />
           </Group>
         </>
       )}

--- a/src/components/stack-limits-control.test.tsx
+++ b/src/components/stack-limits-control.test.tsx
@@ -1,18 +1,10 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { DECK_SIZE, RANGE_PRESETS } from "../constants";
-import { eventBus } from "../services/event-bus";
 import { render } from "../test-utils";
 import type { StackLimits } from "../types/stack-limits";
 import { createDeckPosition } from "../types/stacks";
 import { StackLimitsControl } from "./stack-limits-control";
-
-vi.mock("../services/event-bus", () => ({
-  eventBus: {
-    emit: { STACK_LIMITS_CHANGED: vi.fn() },
-    subscribe: {},
-  },
-}));
 
 const fullLimits: StackLimits = {
   start: createDeckPosition(1),
@@ -26,13 +18,7 @@ const partialLimits: StackLimits = {
 
 describe("StackLimitsControl", () => {
   it("renders all preset buttons", () => {
-    render(
-      <StackLimitsControl
-        limits={fullLimits}
-        onLimitsChange={vi.fn()}
-        stackName="Mnemonica"
-      />
-    );
+    render(<StackLimitsControl limits={fullLimits} onLimitsChange={vi.fn()} />);
 
     for (const preset of RANGE_PRESETS) {
       expect(
@@ -47,11 +33,7 @@ describe("StackLimitsControl", () => {
     const handleChange = vi.fn();
 
     render(
-      <StackLimitsControl
-        limits={fullLimits}
-        onLimitsChange={handleChange}
-        stackName="Mnemonica"
-      />
+      <StackLimitsControl limits={fullLimits} onLimitsChange={handleChange} />
     );
 
     fireEvent.click(
@@ -64,27 +46,6 @@ describe("StackLimitsControl", () => {
     });
   });
 
-  it("emits STACK_LIMITS_CHANGED event when a preset button is clicked", () => {
-    render(
-      <StackLimitsControl
-        limits={fullLimits}
-        onLimitsChange={vi.fn()}
-        stackName="Mnemonica"
-      />
-    );
-
-    fireEvent.click(
-      screen.getByRole("button", { name: "Set range to first 26 cards" })
-    );
-
-    expect(eventBus.emit.STACK_LIMITS_CHANGED).toHaveBeenCalledWith({
-      start: 1,
-      end: 26,
-      rangeSize: 26,
-      stackName: "Mnemonica",
-    });
-  });
-
   it("shows the active preset with filled variant", () => {
     render(
       <StackLimitsControl
@@ -93,7 +54,6 @@ describe("StackLimitsControl", () => {
           end: createDeckPosition(26),
         }}
         onLimitsChange={vi.fn()}
-        stackName="Mnemonica"
       />
     );
 
@@ -111,37 +71,26 @@ describe("StackLimitsControl", () => {
   });
 
   it("shows full deck description when limits span the entire deck", () => {
-    render(
-      <StackLimitsControl
-        limits={fullLimits}
-        onLimitsChange={vi.fn()}
-        stackName="Mnemonica"
-      />
-    );
+    render(<StackLimitsControl limits={fullLimits} onLimitsChange={vi.fn()} />);
 
     expect(screen.getByText("Full deck (52 cards)")).toBeInTheDocument();
   });
 
   it("shows partial range description when limits do not span the entire deck", () => {
     render(
-      <StackLimitsControl
-        limits={partialLimits}
-        onLimitsChange={vi.fn()}
-        stackName="Mnemonica"
-      />
+      <StackLimitsControl limits={partialLimits} onLimitsChange={vi.fn()} />
     );
 
     expect(screen.getByText("Positions 5–20 (16 cards)")).toBeInTheDocument();
   });
 
-  it("calls onLimitsChange and emits event when slider thumb is moved via keyboard", () => {
+  it("calls onLimitsChange when slider thumb is moved via keyboard", () => {
     const handleChange = vi.fn();
 
     render(
       <StackLimitsControl
         limits={partialLimits}
         onLimitsChange={handleChange}
-        stackName="Mnemonica"
       />
     );
 
@@ -154,13 +103,6 @@ describe("StackLimitsControl", () => {
     expect(handleChange).toHaveBeenCalledWith({
       start: createDeckPosition(6),
       end: createDeckPosition(20),
-    });
-
-    expect(eventBus.emit.STACK_LIMITS_CHANGED).toHaveBeenCalledWith({
-      start: 6,
-      end: 20,
-      rangeSize: 15,
-      stackName: "Mnemonica",
     });
   });
 });

--- a/src/components/stack-limits-control.tsx
+++ b/src/components/stack-limits-control.tsx
@@ -2,20 +2,17 @@ import { Button, RangeSlider, Stack, Text } from "@mantine/core";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DECK_SIZE, MIN_FLASHCARD_RANGE, RANGE_PRESETS } from "../constants";
-import { eventBus } from "../services/event-bus";
 import type { StackLimits } from "../types/stack-limits";
 import { createDeckPosition } from "../types/stacks";
 
 type StackLimitsControlProps = {
   limits: StackLimits;
   onLimitsChange: (limits: StackLimits) => void;
-  stackName: string;
 };
 
 export const StackLimitsControl = ({
   limits,
   onLimitsChange,
-  stackName,
 }: StackLimitsControlProps) => {
   const { t } = useTranslation();
 
@@ -33,36 +30,22 @@ export const StackLimitsControl = ({
 
   const handleSliderChangeEnd = useCallback(
     (value: [number, number]) => {
-      const newLimits: StackLimits = {
+      onLimitsChange({
         start: createDeckPosition(value[0]),
         end: createDeckPosition(value[1]),
-      };
-      onLimitsChange(newLimits);
-      eventBus.emit.STACK_LIMITS_CHANGED({
-        start: value[0],
-        end: value[1],
-        rangeSize: value[1] - value[0] + 1,
-        stackName,
       });
     },
-    [onLimitsChange, stackName]
+    [onLimitsChange]
   );
 
   const handlePresetClick = useCallback(
     (preset: number) => {
-      const newLimits: StackLimits = {
+      onLimitsChange({
         start: createDeckPosition(1),
         end: createDeckPosition(preset),
-      };
-      onLimitsChange(newLimits);
-      eventBus.emit.STACK_LIMITS_CHANGED({
-        start: 1,
-        end: preset,
-        rangeSize: preset,
-        stackName,
       });
     },
-    [onLimitsChange, stackName]
+    [onLimitsChange]
   );
 
   const description = sliderIsFull

--- a/src/components/stack-range-badge.test.tsx
+++ b/src/components/stack-range-badge.test.tsx
@@ -15,13 +15,6 @@ vi.mock("../hooks/use-stack-limits", () => ({
   useStackLimits: vi.fn(),
 }));
 
-vi.mock("../services/event-bus", () => ({
-  eventBus: {
-    emit: { STACK_LIMITS_CHANGED: vi.fn() },
-    subscribe: {},
-  },
-}));
-
 const mockUseStackLimits = vi.mocked(useStackLimits);
 
 const fullDeckResult = {
@@ -58,7 +51,7 @@ describe("StackRangeBadge", () => {
   it("shows full-deck label when limits are default", () => {
     mockUseStackLimits.mockReturnValue(fullDeckResult);
 
-    render(<StackRangeBadge stackKey="mnemonica" stackName="Mnemonica" />);
+    render(<StackRangeBadge stackKey="mnemonica" />);
 
     const button = screen.getByRole("button", {
       name: `Stack range: ${DECK_SIZE} cards. Tap to adjust.`,
@@ -69,7 +62,7 @@ describe("StackRangeBadge", () => {
   it("shows partial range label when limits are custom", () => {
     mockUseStackLimits.mockReturnValue(partialResult);
 
-    render(<StackRangeBadge stackKey="mnemonica" stackName="Mnemonica" />);
+    render(<StackRangeBadge stackKey="mnemonica" />);
 
     const button = screen.getByRole("button", {
       name: "Stack range: positions 1 to 20. Tap to adjust.",
@@ -81,7 +74,7 @@ describe("StackRangeBadge", () => {
     const user = userEvent.setup();
     mockUseStackLimits.mockReturnValue(smallRangeResult);
 
-    render(<StackRangeBadge stackKey="mnemonica" stackName="Mnemonica" />);
+    render(<StackRangeBadge stackKey="mnemonica" />);
 
     await user.click(
       screen.getByRole("button", {
@@ -103,7 +96,7 @@ describe("StackRangeBadge", () => {
       rangeSize: MIN_SPOT_CHECK_RANGE,
     });
 
-    render(<StackRangeBadge stackKey="mnemonica" stackName="Mnemonica" />);
+    render(<StackRangeBadge stackKey="mnemonica" />);
 
     await user.click(
       screen.getByRole("button", {
@@ -126,7 +119,7 @@ describe("StackRangeBadge", () => {
     });
     const user = userEvent.setup();
 
-    render(<StackRangeBadge stackKey="mnemonica" stackName="Mnemonica" />);
+    render(<StackRangeBadge stackKey="mnemonica" />);
 
     await user.click(
       screen.getByRole("button", {

--- a/src/components/stack-range-badge.tsx
+++ b/src/components/stack-range-badge.tsx
@@ -9,13 +9,9 @@ import { StackLimitsControl } from "./stack-limits-control";
 
 type StackRangeBadgeProps = {
   stackKey: StackKey;
-  stackName: string;
 };
 
-export const StackRangeBadge = ({
-  stackKey,
-  stackName,
-}: StackRangeBadgeProps) => {
+export const StackRangeBadge = ({ stackKey }: StackRangeBadgeProps) => {
   const { t } = useTranslation();
   const [opened, { open, close }] = useDisclosure(false);
   const {
@@ -60,11 +56,7 @@ export const StackRangeBadge = ({
         title={t("stackLimits.label")}
       >
         <Stack gap="md">
-          <StackLimitsControl
-            limits={limits}
-            onLimitsChange={setLimits}
-            stackName={stackName}
-          />
+          <StackLimitsControl limits={limits} onLimitsChange={setLimits} />
           {rangeSize < MIN_SPOT_CHECK_RANGE && (
             <Text c="orange" role="status" size="xs">
               <IconAlertTriangle

--- a/src/hooks/use-selected-stack.test.ts
+++ b/src/hooks/use-selected-stack.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { SELECTED_STACK_LSK } from "../constants";
 import { stacks } from "../types/stacks";
 import {
   isStackKey,
@@ -93,6 +94,20 @@ describe("useSelectedStack", () => {
     result.setStackKey("");
 
     expect(mockSetValue).toHaveBeenCalledWith("");
+  });
+
+  it("calls useLocalDb with the selected-stack LSK, validator, and corruption/write-failure callbacks", () => {
+    mockedUseLocalDb.mockReturnValue(["", mockSetValue, vi.fn()]);
+
+    useSelectedStack();
+
+    expect(mockedUseLocalDb).toHaveBeenCalledWith(
+      SELECTED_STACK_LSK,
+      "",
+      expect.any(Function),
+      expect.any(Function),
+      expect.any(Function)
+    );
   });
 
   it("setStackKey handles empty string input", () => {

--- a/src/hooks/use-selected-stack.ts
+++ b/src/hooks/use-selected-stack.ts
@@ -1,7 +1,10 @@
 import { SELECTED_STACK_LSK } from "../constants";
 import { type StackKey, type StackValue, stacks } from "../types/stacks";
 import { useLocalDb } from "../utils/localstorage";
-import { reportLocalDbCorruption } from "../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
 
 export const isStackKey = (key: string): key is StackKey => key in stacks;
 
@@ -36,10 +39,11 @@ export const useSelectedStack = (): SelectedStackResult => {
     SELECTED_STACK_LSK,
     "",
     isStackKeyOrEmpty,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
-  const setStackKey = (key: StackKey | "") => {
+  const setStackKey = (key: StackKey | ""): void => {
     setSelectedStackKey(key);
   };
 

--- a/src/hooks/use-stack-limits.test.ts
+++ b/src/hooks/use-stack-limits.test.ts
@@ -5,11 +5,23 @@ import {
   DEFAULT_STACK_LIMITS,
   isStackLimitsRecord,
 } from "../types/stack-limits";
-import { createDeckPosition } from "../types/stacks";
+import { createDeckPosition, stacks } from "../types/stacks";
 import { useStackLimits } from "./use-stack-limits";
 
-const mockSetValue = vi.fn();
+// Mantine-mirroring setter: invoke `options.onSuccess` so the emit gating
+// in `useStackLimits` (which depends on a successful persisted write)
+// fires by default. Tests that need to simulate a write failure set
+// `mockSetValueSucceeds` to `false` before calling `setLimits`.
+let mockSetValueSucceeds = true;
+const mockSetValue = vi.fn(
+  (_next: unknown, options?: { onSuccess?: () => void }) => {
+    if (mockSetValueSucceeds) {
+      options?.onSuccess?.();
+    }
+  }
+);
 const mockProbeStoredValue = vi.fn();
+const mockEmitStackLimitsChanged = vi.fn();
 
 vi.mock("../utils/localstorage", () => ({
   useLocalDb: vi.fn((_, defaultValue) => [defaultValue, mockSetValue, vi.fn()]),
@@ -22,6 +34,16 @@ vi.mock("../services/analytics", () => ({
   },
 }));
 
+vi.mock("../services/event-bus", () => ({
+  eventBus: {
+    emit: {
+      STACK_LIMITS_CHANGED: (...args: unknown[]) =>
+        mockEmitStackLimitsChanged(...args),
+    },
+    subscribe: {},
+  },
+}));
+
 const { useLocalDb } = await import("../utils/localstorage");
 const mockedUseLocalDb = vi.mocked(useLocalDb);
 const { analytics } = await import("../services/analytics");
@@ -29,6 +51,7 @@ const mockedTrackError = vi.mocked(analytics.trackError);
 
 beforeEach(() => {
   mockProbeStoredValue.mockReturnValue({ status: "absent" });
+  mockSetValueSucceeds = true;
 });
 
 afterEach(() => {
@@ -108,13 +131,14 @@ describe("useStackLimits", () => {
     expect(updated).toEqual({ mnemonica: { start: 10, end: 30 } });
   });
 
-  it("passes isStackLimitsRecord as the validator to useLocalDb", () => {
+  it("passes isStackLimitsRecord as the validator and write/corrupt callbacks to useLocalDb", () => {
     renderHook(() => useStackLimits("mnemonica"));
 
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       STACK_LIMITS_LSK,
       expect.anything(),
       isStackLimitsRecord,
+      expect.any(Function),
       expect.any(Function)
     );
   });
@@ -204,5 +228,78 @@ describe("useStackLimits", () => {
     renderHook(() => useStackLimits("mnemonica"));
 
     expect(mockedTrackError).not.toHaveBeenCalled();
+  });
+
+  // Parametrized over two stacks so a regression in the `stacks[stackKey].name`
+  // lookup (e.g. swapping the indexer with `stackKey` itself) can't survive by
+  // coincidentally matching the hardcoded literal.
+  it.each([
+    "mnemonica",
+    "aronson",
+  ] as const)("emits STACK_LIMITS_CHANGED with the correct payload when setLimits succeeds (%s)", (stackKey) => {
+    const { result } = renderHook(() => useStackLimits(stackKey));
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockEmitStackLimitsChanged).toHaveBeenCalledTimes(1);
+    expect(mockEmitStackLimitsChanged).toHaveBeenCalledWith({
+      start: 5,
+      end: 25,
+      rangeSize: 21,
+      stackName: stacks[stackKey].name,
+    });
+  });
+
+  it("does not emit STACK_LIMITS_CHANGED when the corrupt-lock blocks the write", () => {
+    mockProbeStoredValue.mockReturnValue({
+      status: "corrupt",
+      raw: "garbage",
+    });
+
+    const { result } = renderHook(() => useStackLimits("mnemonica"));
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockEmitStackLimitsChanged).not.toHaveBeenCalled();
+  });
+
+  it("does not emit STACK_LIMITS_CHANGED when the stored blob read errored", () => {
+    mockProbeStoredValue.mockReturnValue({
+      status: "read-error",
+      error: new Error("boom"),
+    });
+
+    const { result } = renderHook(() => useStackLimits("mnemonica"));
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockEmitStackLimitsChanged).not.toHaveBeenCalled();
+  });
+
+  it("does not emit STACK_LIMITS_CHANGED when the wrapped setter's write fails", () => {
+    // Quota exceeded / Safari private mode / ITP eviction path: Mantine
+    // swallows the IO error and `useLocalDb` skips the onSuccess callback
+    // it received. The analytics emit must not fire — we shouldn't pretend
+    // the user's range change persisted.
+    mockSetValueSucceeds = false;
+
+    const { result } = renderHook(() => useStackLimits("mnemonica"));
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockSetValue).toHaveBeenCalledTimes(1);
+    expect(mockEmitStackLimitsChanged).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/use-stack-limits.ts
+++ b/src/hooks/use-stack-limits.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { STACK_LIMITS_LSK } from "../constants";
 import { analytics } from "../services/analytics";
+import { eventBus } from "../services/event-bus";
 import {
   DEFAULT_STACK_LIMITS,
   getRangeSize,
@@ -11,9 +12,12 @@ import {
   type StackLimits,
   type StackLimitsRecord,
 } from "../types/stack-limits";
-import { createDeckPosition, type StackKey } from "../types/stacks";
+import { createDeckPosition, type StackKey, stacks } from "../types/stacks";
 import { probeStoredValue, useLocalDb } from "../utils/localstorage";
-import { reportLocalDbCorruption } from "../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
 
 type UseStackLimitsResult = {
   limits: StackLimits;
@@ -37,7 +41,8 @@ export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
     STACK_LIMITS_LSK,
     {},
     isStackLimitsRecord,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
   // Probe once on mount; if the stored blob is corrupt, lock writes for the
@@ -83,19 +88,36 @@ export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
   );
 
   const handleSetLimits = useCallback(
-    (newLimits: StackLimits) => {
+    (newLimits: StackLimits): void => {
       // Refuse to overwrite a corrupt blob — preserves any other stacks'
-      // ranges that may still be recoverable manually.
+      // ranges that may still be recoverable manually. The user has already
+      // been notified of the corruption via the mount-effect toast.
       if (corruptRef.current === true) {
         return;
       }
-      setRecord((prev) => ({
-        ...prev,
-        [stackKey]: {
-          start: newLimits.start,
-          end: newLimits.end,
-        },
-      }));
+      setRecord(
+        (prev) => ({
+          ...prev,
+          [stackKey]: {
+            start: newLimits.start,
+            end: newLimits.end,
+          },
+        }),
+        {
+          // Gate the analytics emit on a real persisted write so quota /
+          // ITP failures don't inflate "limits changed" counts. The user
+          // sees the failure toast via `handleLocalDbWriteFailed`; GA stays
+          // consistent with what actually reached storage.
+          onSuccess: () => {
+            eventBus.emit.STACK_LIMITS_CHANGED({
+              start: newLimits.start,
+              end: newLimits.end,
+              rangeSize: newLimits.end - newLimits.start + 1,
+              stackName: stacks[stackKey].name,
+            });
+          },
+        }
+      );
     },
     [stackKey, setRecord]
   );

--- a/src/hooks/use-timer-settings.test.ts
+++ b/src/hooks/use-timer-settings.test.ts
@@ -83,6 +83,7 @@ describe("useTimerSettings", () => {
       FLASHCARD_TIMER_LSK,
       expect.any(Object),
       expect.any(Function),
+      expect.any(Function),
       expect.any(Function)
     );
   });

--- a/src/hooks/use-timer-settings.ts
+++ b/src/hooks/use-timer-settings.ts
@@ -7,7 +7,10 @@ import type {
 } from "../constants";
 import type { TimerDuration, TimerSettings } from "../types/timer";
 import { useLocalDb } from "../utils/localstorage";
-import { reportLocalDbCorruption } from "../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
 
 /**
  * Allowed timer durations as a runtime set, kept in sync with the
@@ -65,11 +68,12 @@ export const useTimerSettings = (
     storageKey,
     DEFAULT_TIMER_SETTINGS,
     isTimerSettings,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
   const setTimerEnabled = useCallback(
-    (enabled: boolean) => {
+    (enabled: boolean): void => {
       setTimerSettings((prev) => ({
         ...prev,
         enabled,
@@ -79,7 +83,7 @@ export const useTimerSettings = (
   );
 
   const setTimerDuration = useCallback(
-    (duration: TimerDuration) => {
+    (duration: TimerDuration): void => {
       setTimerSettings((prev) => ({
         ...prev,
         duration,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "Stack-Bereiche konnten nicht geladen werden",
       "message": "Deine gespeicherten Stack-Bereichsdaten haben die Validierung nicht bestanden. Bereichsänderungen sind deaktiviert, damit sie nicht überschrieben werden. Lösche den Browser-Speicher für diese Seite, um neu anzufangen — ein erneuter Versuch hilft nicht."
+    },
+    "localDbWriteFailed": {
+      "title": "Änderungen nicht gespeichert",
+      "message": "Dein Browser-Speicher ist möglicherweise voll — letzte Änderungen bleiben nach einem Neuladen nicht erhalten."
     }
   },
   "stats": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -354,6 +354,10 @@
     "stackLimitsCorrupt": {
       "title": "Stack ranges couldn't be loaded",
       "message": "Your saved per-stack range data failed validation. Range edits are disabled to avoid overwriting it. Clear browser storage for this site to start fresh — retrying won't help."
+    },
+    "localDbWriteFailed": {
+      "title": "Couldn't save",
+      "message": "Your browser storage may be full — recent changes won't persist after a refresh."
     }
   },
   "stats": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "No se pudieron cargar los rangos del stack",
       "message": "Tus rangos guardados por cada stack no pasaron la validación. La edición de rangos está desactivada para no sobrescribirlos. Borra el almacenamiento del navegador para este sitio para empezar de cero — reintentar no servirá."
+    },
+    "localDbWriteFailed": {
+      "title": "Cambios no guardados",
+      "message": "El almacenamiento del navegador puede estar lleno — los cambios recientes no se mantendrán tras recargar la página."
     }
   },
   "stats": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "Plages de stack non chargées",
       "message": "Vos plages enregistrées par stack sont invalides. L'édition des plages est désactivée pour ne pas les écraser. Effacez les données du navigateur pour ce site pour repartir à zéro — réessayer ne servira à rien."
+    },
+    "localDbWriteFailed": {
+      "title": "Modifications non enregistrées",
+      "message": "Votre stockage navigateur est peut-être plein — les modifications récentes ne seront pas conservées après un rechargement."
     }
   },
   "stats": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "Intervalli dello stack non caricati",
       "message": "I tuoi intervalli salvati per ogni stack non hanno superato la validazione. Le modifiche agli intervalli sono disabilitate per non sovrascriverli. Cancella i dati del browser per questo sito per ricominciare — riprovare non aiuterà."
+    },
+    "localDbWriteFailed": {
+      "title": "Modifiche non salvate",
+      "message": "Lo spazio di archiviazione del browser potrebbe essere pieno — le modifiche recenti non saranno mantenute dopo aver ricaricato la pagina."
     }
   },
   "stats": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "Stack-bereiken konden niet worden geladen",
       "message": "Je opgeslagen bereiken per stack zijn niet door de validatie gekomen. Bereikbewerkingen zijn uitgeschakeld om de opgeslagen gegevens niet te overschrijven. Wis de browseropslag voor deze site om opnieuw te beginnen — opnieuw proberen helpt niet."
+    },
+    "localDbWriteFailed": {
+      "title": "Wijzigingen niet opgeslagen",
+      "message": "Je browseropslag is misschien vol — recente wijzigingen gaan verloren na het herladen."
     }
   },
   "stats": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -322,6 +322,10 @@
     "stackLimitsCorrupt": {
       "title": "Não foi possível carregar os intervalos do stack",
       "message": "Os teus intervalos guardados por stack não passaram na validação. As edições de intervalo estão desativadas para não os sobrescrever. Limpa o armazenamento do navegador para este site para começar de novo — tentar de novo não vai ajudar."
+    },
+    "localDbWriteFailed": {
+      "title": "Alterações não guardadas",
+      "message": "O armazenamento do navegador pode estar cheio — as alterações recentes não serão mantidas após recarregar a página."
     }
   },
   "stats": {

--- a/src/pages/distance/use-distance-settings.test.ts
+++ b/src/pages/distance/use-distance-settings.test.ts
@@ -95,18 +95,20 @@ describe("useDistanceSettings", () => {
     expect(result.current.convention).toBe("cyclic");
   });
 
-  it("calls useLocalDb with correct keys, defaults, and validators", () => {
+  it("calls useLocalDb with correct keys, defaults, validators, and write/corrupt callbacks", () => {
     expect(mockedUseLocalDb).toHaveBeenCalledTimes(2);
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       DISTANCE_OPTION_LSK,
       "compute",
       isDistanceMode,
+      expect.any(Function),
       expect.any(Function)
     );
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       DISTANCE_CONVENTION_LSK,
       "cyclic",
       isDistanceConvention,
+      expect.any(Function),
       expect.any(Function)
     );
   });
@@ -166,24 +168,24 @@ describe("useDistanceSettings", () => {
       act(() => {
         result.current.handleTimerEnabledChange(true);
       });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Enabled",
         "Distance"
       );
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
     });
 
     it("tracks analytics and disables timer", () => {
       act(() => {
         result.current.handleTimerEnabledChange(false);
       });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Disabled",
         "Distance"
       );
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/src/pages/distance/use-distance-settings.ts
+++ b/src/pages/distance/use-distance-settings.ts
@@ -15,7 +15,10 @@ import {
 } from "../../types/distance";
 import type { TimerDuration, TimerSettings } from "../../types/timer";
 import { useLocalDb } from "../../utils/localstorage";
-import { reportLocalDbCorruption } from "../../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../../utils/localstorage-telemetry";
 
 type UseDistanceSettingsResult = {
   mode: DistanceMode;
@@ -32,13 +35,15 @@ export const useDistanceSettings = (): UseDistanceSettingsResult => {
     DISTANCE_OPTION_LSK,
     "compute",
     isDistanceMode,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
   const [convention, setConvention] = useLocalDb<DistanceConvention>(
     DISTANCE_CONVENTION_LSK,
     "cyclic",
     isDistanceConvention,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
   const { timerSettings, setTimerEnabled, setTimerDuration } =

--- a/src/pages/flashcard/use-flashcard-settings.test.ts
+++ b/src/pages/flashcard/use-flashcard-settings.test.ts
@@ -90,18 +90,20 @@ describe("useFlashcardSettings", () => {
     expect(result.current.neighborDirection).toBe("random");
   });
 
-  it("calls useLocalDb with correct keys, defaults, and validator functions", () => {
+  it("calls useLocalDb with correct keys, defaults, validators, and write/corrupt callbacks", () => {
     expect(mockedUseLocalDb).toHaveBeenCalledTimes(2);
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       FLASHCARD_OPTION_LSK,
       "bothmodes",
       isFlashcardMode,
+      expect.any(Function),
       expect.any(Function)
     );
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       NEIGHBOR_DIRECTION_LSK,
       "random",
       isNeighborDirection,
+      expect.any(Function),
       expect.any(Function)
     );
   });
@@ -228,12 +230,12 @@ describe("useFlashcardSettings", () => {
         result.current.handleTimerEnabledChange(true);
       });
 
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Enabled",
         "Flashcard"
       );
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
     });
 
     it("tracks analytics event and disables timer", () => {
@@ -241,12 +243,12 @@ describe("useFlashcardSettings", () => {
         result.current.handleTimerEnabledChange(false);
       });
 
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Disabled",
         "Flashcard"
       );
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/src/pages/flashcard/use-flashcard-settings.ts
+++ b/src/pages/flashcard/use-flashcard-settings.ts
@@ -11,7 +11,10 @@ import {
 } from "../../types/flashcard";
 import type { TimerDuration, TimerSettings } from "../../types/timer";
 import { useLocalDb } from "../../utils/localstorage";
-import { reportLocalDbCorruption } from "../../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../../utils/localstorage-telemetry";
 
 type UseFlashcardSettingsResult = {
   mode: FlashcardMode;
@@ -28,14 +31,16 @@ export const useFlashcardSettings = (): UseFlashcardSettingsResult => {
     FLASHCARD_OPTION_LSK,
     "bothmodes",
     isFlashcardMode,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
   const [neighborDirection, setNeighborDirection] =
     useLocalDb<NeighborDirection>(
       NEIGHBOR_DIRECTION_LSK,
       "random",
       isNeighborDirection,
-      reportLocalDbCorruption
+      reportLocalDbCorruption,
+      handleLocalDbWriteFailed
     );
 
   const { timerSettings, setTimerEnabled, setTimerDuration } =

--- a/src/pages/spot-check/spot-check.tsx
+++ b/src/pages/spot-check/spot-check.tsx
@@ -21,7 +21,10 @@ import {
 } from "../../types/spot-check";
 import { cardItems } from "../../types/typeguards";
 import { useLocalDb } from "../../utils/localstorage";
-import { reportLocalDbCorruption } from "../../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../../utils/localstorage-telemetry";
 import { SpotCheckSettingsContent } from "./spot-check-settings-content";
 import { useSpotCheckGame } from "./use-spot-check-game";
 
@@ -49,7 +52,8 @@ export const SpotCheck = () => {
     SPOT_CHECK_MODE_LSK,
     "missing",
     isSpotCheckMode,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
   const { limits, rangeSize } = useStackLimits(stackKey);

--- a/src/pages/toolbox/toolbox.tsx
+++ b/src/pages/toolbox/toolbox.tsx
@@ -6,7 +6,10 @@ import { SITE_URL, TOOLBOX_SECTIONS_LSK } from "../../constants";
 import { useDocumentMeta } from "../../hooks/use-document-meta";
 import { analytics } from "../../services/analytics";
 import { useLocalDb } from "../../utils/localstorage";
-import { reportLocalDbCorruption } from "../../utils/localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../../utils/localstorage-telemetry";
 import { CardSpelling } from "./card-spelling";
 import { FaroShuffle } from "./faro-shuffle";
 import { StackLookup } from "./stack-lookup";
@@ -39,7 +42,8 @@ export const Toolbox = () => {
     TOOLBOX_SECTIONS_LSK,
     [],
     isStringArray,
-    reportLocalDbCorruption
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
   );
 
   const openSectionsRef = useRef(openSections);
@@ -50,10 +54,16 @@ export const Toolbox = () => {
       const opened = sections.filter(
         (s) => !openSectionsRef.current.includes(s)
       );
-      for (const section of opened) {
-        analytics.trackFeatureUsed(`Toolbox - ${section}`);
-      }
-      setOpenSections(sections);
+      setOpenSections(sections, {
+        // Gate analytics on a real persisted write so quota / ITP failures
+        // don't inflate "Toolbox - X" feature-used counts. Mirrors the
+        // pattern used in useStackLimits for STACK_LIMITS_CHANGED.
+        onSuccess: () => {
+          for (const section of opened) {
+            analytics.trackFeatureUsed(`Toolbox - ${section}`);
+          }
+        },
+      });
     },
     [setOpenSections]
   );

--- a/src/utils/localstorage-telemetry.test.ts
+++ b/src/utils/localstorage-telemetry.test.ts
@@ -1,6 +1,19 @@
+import { notifications } from "@mantine/notifications";
+import i18next from "i18next";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { analytics } from "../services/analytics";
-import { reportLocalDbCorruption } from "./localstorage-telemetry";
+import {
+  handleLocalDbWriteFailed,
+  notifyLocalDbWriteFailed,
+  reportLocalDbCorruption,
+  reportLocalDbWriteFailed,
+} from "./localstorage-telemetry";
+
+// `as` justified: i18next.t has overloaded TFunction signatures; vi.fn's
+// mockImplementation only accepts a single signature. We don't exercise the
+// interpolation overloads in these tests.
+type TFn = typeof i18next.t;
+const makeTMock = (fn: (key: string) => string): TFn => fn as TFn;
 
 describe("reportLocalDbCorruption", () => {
   afterEach(() => {
@@ -85,5 +98,115 @@ describe("reportLocalDbCorruption", () => {
       expect.any(Error),
       "key=memdeck:flashcard-timer"
     );
+  });
+});
+
+describe("reportLocalDbWriteFailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renames the wrapper to LocalDbWriteFailed and redacts the message", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    const cause = new DOMException(
+      "quota detail leaks here",
+      "QuotaExceededError"
+    );
+    reportLocalDbWriteFailed("flashcard-mode", cause);
+
+    expect(trackErrorSpy).toHaveBeenCalledTimes(1);
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbWriteFailed");
+    expect(errArg?.message).toBe("type=Error name=QuotaExceededError");
+    expect(errArg?.message).not.toContain("quota detail");
+    expect(contextArg).toBe("key=flashcard-mode");
+  });
+
+  it("wraps a string cause by length only", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportLocalDbWriteFailed("k", "abcd");
+
+    const [errArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg?.message).toBe("type=string length=4");
+  });
+
+  it("wraps a non-Error, non-string cause by typeof", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportLocalDbWriteFailed("k", 42);
+
+    const [errArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg?.message).toBe("type=number");
+  });
+});
+
+describe("notifyLocalDbWriteFailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows a Mantine notification with a key-scoped id and yellow color", () => {
+    const showSpy = vi
+      .spyOn(notifications, "show")
+      .mockImplementation(() => "notification-id");
+    vi.spyOn(i18next, "t").mockImplementation(makeTMock((key) => `tr:${key}`));
+
+    notifyLocalDbWriteFailed("flashcard-mode");
+
+    expect(showSpy).toHaveBeenCalledTimes(1);
+    expect(showSpy).toHaveBeenCalledWith({
+      id: "local-db-write-failed-flashcard-mode",
+      color: "yellow",
+      title: "tr:errors.localDbWriteFailed.title",
+      message: "tr:errors.localDbWriteFailed.message",
+    });
+  });
+
+  it("scopes the id per key so concurrent toasts don't collide", () => {
+    const showSpy = vi
+      .spyOn(notifications, "show")
+      .mockImplementation(() => "id");
+    vi.spyOn(i18next, "t").mockImplementation(makeTMock((key) => key));
+
+    notifyLocalDbWriteFailed("a");
+    notifyLocalDbWriteFailed("b");
+
+    const ids = showSpy.mock.calls.map((args) => args[0].id);
+    expect(ids).toEqual(["local-db-write-failed-a", "local-db-write-failed-b"]);
+  });
+});
+
+describe("handleLocalDbWriteFailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches both the analytics report and the user-facing notification", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+    const showSpy = vi
+      .spyOn(notifications, "show")
+      .mockImplementation(() => "id");
+    vi.spyOn(i18next, "t").mockImplementation(makeTMock((key) => key));
+
+    const cause = new DOMException("oops", "QuotaExceededError");
+    handleLocalDbWriteFailed("flashcard-mode", cause);
+
+    expect(trackErrorSpy).toHaveBeenCalledTimes(1);
+    expect(showSpy).toHaveBeenCalledTimes(1);
+    expect(showSpy.mock.calls[0]?.[0]).toMatchObject({
+      id: "local-db-write-failed-flashcard-mode",
+      color: "yellow",
+    });
   });
 });

--- a/src/utils/localstorage-telemetry.ts
+++ b/src/utils/localstorage-telemetry.ts
@@ -1,3 +1,5 @@
+import { notifications } from "@mantine/notifications";
+import i18next from "i18next";
 import { analytics } from "../services/analytics";
 
 /**
@@ -24,4 +26,49 @@ export const reportLocalDbCorruption = (key: string, cause: unknown): void => {
   }
   wrapped.name = "LocalDbCorruption";
   analytics.trackError(wrapped, `key=${key}`);
+};
+
+/**
+ * Write-side mirror of `reportLocalDbCorruption`: forwards a quota-exceeded
+ * (or otherwise thrown) `localStorage.setItem` failure to analytics with the
+ * offending key as context. Same scrubbing discipline — never leaks the
+ * original error message to GA.
+ */
+export const reportLocalDbWriteFailed = (key: string, cause: unknown): void => {
+  let wrapped: Error;
+  if (cause instanceof Error) {
+    wrapped = new Error(`type=Error name=${cause.name}`);
+  } else if (typeof cause === "string") {
+    wrapped = new Error(`type=string length=${cause.length}`);
+  } else {
+    wrapped = new Error(`type=${typeof cause}`);
+  }
+  wrapped.name = "LocalDbWriteFailed";
+  analytics.trackError(wrapped, `key=${key}`);
+};
+
+/**
+ * Surfaces a Mantine notification when a `useLocalDb` write fails. The `id`
+ * field replaces a concurrently-visible toast for the same key (Mantine v9
+ * semantics) — it is NOT a fire-once-ever lock. The actual once-per-mount
+ * dedup lives in `useLocalDb`'s `reportedWriteKeyRef`; the id is
+ * belt-and-suspenders for racing shows from the same setter.
+ */
+export const notifyLocalDbWriteFailed = (key: string): void => {
+  notifications.show({
+    id: `local-db-write-failed-${key}`,
+    color: "yellow",
+    title: i18next.t("errors.localDbWriteFailed.title"),
+    message: i18next.t("errors.localDbWriteFailed.message"),
+  });
+};
+
+/**
+ * Combined `onWriteFailed` callback for `useLocalDb` — the canonical handler
+ * consumers should pass. Reports the failure to analytics and surfaces a
+ * Mantine notification so the user knows their change won't persist.
+ */
+export const handleLocalDbWriteFailed = (key: string, cause: unknown): void => {
+  reportLocalDbWriteFailed(key, cause);
+  notifyLocalDbWriteFailed(key);
 };

--- a/src/utils/localstorage.test.ts
+++ b/src/utils/localstorage.test.ts
@@ -453,7 +453,7 @@ describe("useLocalDb", () => {
     );
   });
 
-  it("returns tuple with value, setter, and remover", () => {
+  it("returns tuple with value, wrapped setter, and remover", () => {
     const mockSetter = vi.fn();
     const mockRemover = vi.fn();
     mockReadLocalStorageValue.mockReturnValue("value");
@@ -465,7 +465,20 @@ describe("useLocalDb", () => {
 
     const [value, setValue, removeValue] = result.current;
     expect(value).toBe("value");
-    expect(setValue).toBe(mockSetter);
+    // The setter is wrapped to add a post-write probe, so it is not the same
+    // function reference as Mantine's setter — but invoking it must still
+    // forward the value through to the underlying setter via a function
+    // updater so the probe and Mantine resolve against the same `prev`.
+    expect(setValue).toBeInstanceOf(Function);
+    expect(setValue).not.toBe(mockSetter);
+    setValue("next");
+    expect(mockSetter).toHaveBeenCalledTimes(1);
+    const cbArg = mockSetter.mock.calls[0]?.[0];
+    expect(typeof cbArg).toBe("function");
+    // `as` justified: `cbArg` is typed `unknown` from the mock's call array,
+    // but we just verified it's a function. Invoking it with any prev should
+    // resolve to the static "next" value the caller passed.
+    expect((cbArg as (prev: unknown) => unknown)("anything")).toBe("next");
     expect(removeValue).toBe(mockRemover);
   });
 
@@ -624,6 +637,24 @@ describe("useLocalDb", () => {
       expect(onCorrupt).toHaveBeenCalledWith("test-key", 123);
     });
 
+    it("resets onCorrupt dedup when key changes", () => {
+      // Both keys are corrupt — dedup must be per-key, not per-mount.
+      mockReadLocalStorageValue.mockReturnValue(123);
+      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+      const onCorrupt = vi.fn();
+
+      const { rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", isString, onCorrupt),
+        { initialProps: { k: "key-a" } }
+      );
+
+      rerender({ k: "key-b" });
+
+      expect(onCorrupt).toHaveBeenCalledTimes(2);
+      expect(onCorrupt).toHaveBeenNthCalledWith(1, "key-a", 123);
+      expect(onCorrupt).toHaveBeenNthCalledWith(2, "key-b", 123);
+    });
+
     it("calls onCorrupt from the deserialize path on JSON.parse error", () => {
       // Probe path is clean (absent), so only the deserialize callback can
       // fire onCorrupt — exercising the parse-error branch.
@@ -703,6 +734,397 @@ describe("useLocalDb", () => {
       capturedDeserialize?.(JSON.stringify("fresh-value"));
 
       expect(onCorrupt).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("setter identity stability", () => {
+    it("returns the same setter reference across re-renders when key is unchanged", () => {
+      mockReadLocalStorageValue.mockReturnValue("value");
+      mockUseLocalStorage.mockReturnValue(["value", vi.fn(), vi.fn()]);
+
+      const { result, rerender } = renderHook(() =>
+        useLocalDb("test-key", "default", isString)
+      );
+
+      const initialSetter = result.current[1];
+      rerender();
+      rerender();
+
+      expect(result.current[1]).toBe(initialSetter);
+    });
+
+    it("returns a new setter reference when key changes", () => {
+      mockReadLocalStorageValue.mockReturnValue("value");
+      mockUseLocalStorage.mockReturnValue(["value", vi.fn(), vi.fn()]);
+
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", isString),
+        { initialProps: { k: "key-a" } }
+      );
+
+      const initialSetter = result.current[1];
+      rerender({ k: "key-b" });
+
+      expect(result.current[1]).not.toBe(initialSetter);
+    });
+  });
+
+  describe("write-failure handling", () => {
+    // happy-dom's window.localStorage isn't a real Storage instance whose
+    // methods can be spied via the prototype, and `vi.spyOn` on the live
+    // localStorage object errors with "property is not defined." Replace the
+    // global with a hand-rolled mock for each test instead and restore via
+    // vi.unstubAllGlobals.
+    let setItemMock: ReturnType<typeof vi.fn>;
+
+    const useFakeLocalStorage = (
+      impl: (key: string, value: string) => void
+    ) => {
+      setItemMock = vi.fn(impl);
+      vi.stubGlobal("localStorage", {
+        setItem: setItemMock,
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        clear: vi.fn(),
+        key: vi.fn(),
+        length: 0,
+      });
+    };
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      vi.unstubAllGlobals();
+    });
+
+    const setupHook = (key = "test-key", value: unknown = "stored-value") => {
+      // The wrapped setter now invokes Mantine's setValue with a function
+      // updater unconditionally; the mock must run that callback so the
+      // closed-over `resolved` is assigned before the synchronous probe.
+      const mockSetter = vi.fn((next: unknown) => {
+        if (typeof next === "function") {
+          // `as` justified: the callback is typed against the user's T, but
+          // the test mock is generic over `unknown`. We just need to invoke
+          // it with the current value to mirror Mantine's behavior.
+          (next as (prev: unknown) => unknown)(value);
+        }
+      });
+      const mockRemover = vi.fn();
+      mockReadLocalStorageValue.mockReturnValue(value);
+      mockUseLocalStorage.mockReturnValue([value, mockSetter, mockRemover]);
+      return { mockSetter, mockRemover, key };
+    };
+
+    it("skips onWriteFailed when the probe write succeeds", () => {
+      const { key, mockSetter } = setupHook();
+      const onWriteFailed = vi.fn();
+      useFakeLocalStorage(() => {
+        // Pretend the write succeeded.
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("next-value");
+
+      expect(onWriteFailed).not.toHaveBeenCalled();
+      expect(setItemMock).toHaveBeenCalledWith(
+        key,
+        JSON.stringify("next-value")
+      );
+      expect(mockSetter).toHaveBeenCalledTimes(1);
+    });
+
+    it("forwards the error to onWriteFailed when the probe throws", () => {
+      const { key, mockSetter } = setupHook();
+      const onWriteFailed = vi.fn();
+      const quotaError = new DOMException("quota", "QuotaExceededError");
+      useFakeLocalStorage(() => {
+        throw quotaError;
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("next-value");
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(1);
+      expect(onWriteFailed).toHaveBeenCalledWith(key, quotaError);
+      expect(mockSetter).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onWriteFailed at most once per consecutive failure streak per key (dedup)", () => {
+      const { key, mockSetter } = setupHook();
+      const onWriteFailed = vi.fn();
+      useFakeLocalStorage(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("a");
+      result.current[1]("b");
+      result.current[1]("c");
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(1);
+      expect(setItemMock).toHaveBeenCalledTimes(3);
+      expect(mockSetter).toHaveBeenCalledTimes(3);
+    });
+
+    it("re-fires onWriteFailed after a successful write resets the streak", () => {
+      const { key, mockSetter } = setupHook();
+      const onWriteFailed = vi.fn();
+      const quotaError = new DOMException("quota", "QuotaExceededError");
+      const setItemImpl = vi
+        .fn<(k: string, v: string) => void>()
+        .mockImplementationOnce(() => {
+          throw quotaError;
+        })
+        .mockImplementationOnce(() => {
+          // Pretend success — should reset the dedup streak.
+        })
+        .mockImplementationOnce(() => {
+          throw quotaError;
+        });
+      useFakeLocalStorage((k, v) => setItemImpl(k, v));
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("a");
+      result.current[1]("b");
+      result.current[1]("c");
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(2);
+      expect(setItemMock).toHaveBeenCalledTimes(3);
+      expect(mockSetter).toHaveBeenCalledTimes(3);
+    });
+
+    it("fires onWriteFailed independently for each key (dedup resets on key change)", () => {
+      mockReadLocalStorageValue.mockReturnValue("v");
+      // Mantine-mirroring setter: invoke the callback so the probe runs.
+      const mockSetter = vi.fn((next: unknown) => {
+        if (typeof next === "function") {
+          // `as` justified: see setupHook — generic test mock over `unknown`.
+          (next as (prev: unknown) => unknown)("v");
+        }
+      });
+      mockUseLocalStorage.mockReturnValue(["v", mockSetter, vi.fn()]);
+      const onWriteFailed = vi.fn();
+      useFakeLocalStorage(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) =>
+          useLocalDb(k, "default", isString, undefined, onWriteFailed),
+        { initialProps: { k: "key-a" } }
+      );
+
+      result.current[1]("x");
+      rerender({ k: "key-b" });
+      result.current[1]("y");
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(2);
+      expect(onWriteFailed).toHaveBeenNthCalledWith(
+        1,
+        "key-a",
+        expect.any(Error)
+      );
+      expect(onWriteFailed).toHaveBeenNthCalledWith(
+        2,
+        "key-b",
+        expect.any(Error)
+      );
+    });
+
+    it("resolves function-updater payloads against the current value for the probe", () => {
+      mockReadLocalStorageValue.mockReturnValue(10);
+      // Mirror Mantine: invoke the callback with the current value so the
+      // closed-over `resolved` is populated before the probe runs.
+      const mockSetter = vi.fn((next: unknown) => {
+        if (typeof next === "function") {
+          // `as` justified: see setupHook — generic test mock over `unknown`.
+          (next as (prev: number) => number)(10);
+        }
+      });
+      mockUseLocalStorage.mockReturnValue([10, mockSetter, vi.fn()]);
+      useFakeLocalStorage(() => {
+        // Pretend success.
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb<number>("counter", 0, isNumber)
+      );
+
+      result.current[1]((prev) => prev + 5);
+
+      expect(setItemMock).toHaveBeenCalledWith("counter", JSON.stringify(15));
+    });
+
+    it("does not throw when no onWriteFailed callback is provided", () => {
+      setupHook();
+      useFakeLocalStorage(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb("test-key", "default", isString)
+      );
+
+      expect(() => result.current[1]("next")).not.toThrow();
+      expect(() => result.current[1]("again")).not.toThrow();
+    });
+
+    it("isolates onWriteFailed exceptions: setter does not throw and dedup latch is still set", () => {
+      // Realistic failure mode: i18next.t or notifications.show could throw
+      // (e.g. provider not yet mounted). The wrapped setter must swallow the
+      // callback exception so the consumer's UI handler doesn't crash, AND
+      // the dedup latch must still register so the next failure doesn't
+      // re-fire telemetry on every render.
+      const { key } = setupHook();
+      const onWriteFailed = vi.fn(() => {
+        throw new Error("notifications provider not mounted");
+      });
+      useFakeLocalStorage(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      expect(() => result.current[1]("next")).not.toThrow();
+      // Second consecutive failure with the same key: dedup latch was set on
+      // the first call despite the callback throwing, so onWriteFailed is
+      // not invoked again.
+      expect(() => result.current[1]("again")).not.toThrow();
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not write the literal string 'undefined' when the updater is deferred", () => {
+      // Regression for the eager-state-skipped path. React calls setState
+      // updaters lazily when there are pending lanes on the fiber (e.g.
+      // chained setters in one handler). The previous implementation read a
+      // closure variable assigned inside the updater AFTER `setValue` returned;
+      // on the deferred path the variable was still `undefined` and the
+      // probe wrote `JSON.stringify(undefined)` (i.e. the string "undefined")
+      // to localStorage. Moving the probe inside the updater eliminates the
+      // race: if the updater never runs, neither does the probe.
+      mockReadLocalStorageValue.mockReturnValue("v");
+      const deferredSetter = vi.fn(() => {
+        // Mimic React skipping eager state computation: store the updater
+        // for later (or drop it entirely). Either way, the updater MUST NOT
+        // fire synchronously inside this mock.
+      });
+      mockUseLocalStorage.mockReturnValue(["v", deferredSetter, vi.fn()]);
+      useFakeLocalStorage(() => {
+        // Should never be called — the deferred setter never invokes the
+        // updater that owns the probe.
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb("test-key", "default", isString)
+      );
+
+      result.current[1]("next-value");
+
+      expect(deferredSetter).toHaveBeenCalledTimes(1);
+      expect(setItemMock).not.toHaveBeenCalled();
+      // Belt-and-braces: even if a future mock change invokes setItem, the
+      // wrong-shaped argument we are guarding against is the string
+      // "undefined". Make that assertion explicit.
+      const calledWithUndefinedString = setItemMock.mock.calls.some(
+        (args) => args[1] === "undefined"
+      );
+      expect(calledWithUndefinedString).toBe(false);
+    });
+
+    it("fires onSuccess once when the probe write succeeds", () => {
+      const { key } = setupHook();
+      const onSuccess = vi.fn();
+      useFakeLocalStorage(() => {
+        // Pretend success.
+      });
+
+      const { result } = renderHook(() => useLocalDb(key, "default", isString));
+
+      result.current[1]("next-value", { onSuccess });
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fire onSuccess when the probe write throws", () => {
+      const { key } = setupHook();
+      const onSuccess = vi.fn();
+      const onWriteFailed = vi.fn();
+      useFakeLocalStorage(() => {
+        throw new DOMException("quota", "QuotaExceededError");
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("next-value", { onSuccess });
+
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(onWriteFailed).toHaveBeenCalledTimes(1);
+    });
+
+    it("isolates onSuccess exceptions: setter does not throw and onWriteFailed is not invoked", () => {
+      // Mirror of the onWriteFailed isolation test for the success path.
+      const { key } = setupHook();
+      const onSuccess = vi.fn(() => {
+        throw new Error("downstream emit threw");
+      });
+      const onWriteFailed = vi.fn();
+      useFakeLocalStorage(() => {
+        // Pretend success.
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+      );
+
+      expect(() => result.current[1]("next", { onSuccess })).not.toThrow();
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onWriteFailed).not.toHaveBeenCalled();
+    });
+
+    it("fires onSuccess at most once even if the updater runs twice (StrictMode)", () => {
+      // React StrictMode invokes setState updaters twice in development to
+      // surface impurity. The wrapped setter must dedup outcomes per logical
+      // call so onSuccess (which typically emits analytics) doesn't double-fire.
+      mockReadLocalStorageValue.mockReturnValue("v");
+      const doubleInvokeSetter = vi.fn((next: unknown) => {
+        if (typeof next === "function") {
+          // `as` justified: see setupHook — generic test mock over `unknown`.
+          (next as (prev: unknown) => unknown)("v");
+          (next as (prev: unknown) => unknown)("v");
+        }
+      });
+      mockUseLocalStorage.mockReturnValue(["v", doubleInvokeSetter, vi.fn()]);
+      const onSuccess = vi.fn();
+      useFakeLocalStorage(() => {
+        // Pretend success on every call.
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb("test-key", "default", isString)
+      );
+
+      result.current[1]("next-value", { onSuccess });
+
+      // The updater itself may run twice (setItem may be called twice —
+      // that's React's prerogative under StrictMode), but the user-visible
+      // outcome callback only fires once per setter invocation.
+      expect(onSuccess).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -1,5 +1,5 @@
 import { readLocalStorageValue, useLocalStorage } from "@mantine/hooks";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 /**
  * Result of probing a localStorage key: distinguishes "key absent" from "key
@@ -75,6 +75,13 @@ export const getStoredValue = <T>(
   return probe.status === "valid" ? probe.value : defaultValue;
 };
 
+export type UseLocalDbSetOptions = { onSuccess?: () => void };
+
+export type UseLocalDbSetter<T> = (
+  value: T | ((prevState: T) => T),
+  options?: UseLocalDbSetOptions
+) => void;
+
 /**
  * A wrapper around Mantine's useLocalStorage with error handling.
  * Supports any JSON-serializable type (string, number, boolean, object, array).
@@ -85,13 +92,25 @@ export const getStoredValue = <T>(
  * write — destroying potentially recoverable data with no signal to the
  * caller. Callers that own recoverable state should provide a callback so
  * they can surface a breadcrumb / telemetry event before the overwrite.
+ *
+ * Pass `onWriteFailed` to be notified when a write to localStorage throws
+ * (quota exceeded, Safari private mode, ITP eviction). Mantine's setter
+ * silently swallows these errors; the wrapper re-runs the write inside the
+ * Mantine state-updater closure to detect the failure synchronously with
+ * the resolved value.
+ *
+ * The returned setter accepts an optional `{ onSuccess }` so callers can
+ * gate side effects (analytics emits, navigation) on a real persisted
+ * write rather than the silent-success path Mantine presents after a
+ * quota failure.
  */
 export const useLocalDb = <T>(
   key: string,
   defaultValue: T,
   validate: (value: unknown) => value is T,
-  onCorrupt?: (key: string, error: unknown) => void
-): [T, (value: T | ((prevState: T) => T)) => void, () => void] => {
+  onCorrupt?: (key: string, error: unknown) => void,
+  onWriteFailed?: (key: string, error: unknown) => void
+): [T, UseLocalDbSetter<T>, () => void] => {
   // Cache the initial probe in a ref so it isn't re-executed every render.
   // Recomputed via useEffect when `key` changes.
   const probeRef = useRef<StoredValueProbe<T> | null>(null);
@@ -106,6 +125,14 @@ export const useLocalDb = <T>(
   // from probe + deserialize for the same key.
   const reportedKeyRef = useRef<string | null>(null);
 
+  // Mirror dedup for write failures: at most one `onWriteFailed` per failure
+  // streak per key. Without it, a page that retries a setter (e.g. user
+  // mashing a toggle on a quota-exceeded device) would fire a telemetry storm
+  // and stack identical toasts. Streaks reset on a successful write so a
+  // recovery-then-new-failure case still surfaces (write A fails → user
+  // clears space → write B succeeds → ref clears → write C fails fires again).
+  const reportedWriteKeyRef = useRef<string | null>(null);
+
   // Capture latest onCorrupt in a ref so the deserialize closure (created
   // once for the lifetime of useLocalStorage) can see the current callback
   // without having to re-create the hook config.
@@ -114,10 +141,18 @@ export const useLocalDb = <T>(
     onCorruptRef.current = onCorrupt;
   }, [onCorrupt]);
 
+  // Same trick for onWriteFailed: keeps the wrapped setter's identity stable
+  // (consumers memoize on it) regardless of whether the caller passes an
+  // inline arrow.
+  const onWriteFailedRef = useRef(onWriteFailed);
+  useEffect(() => {
+    onWriteFailedRef.current = onWriteFailed;
+  }, [onWriteFailed]);
+
   const probe = probeRef.current;
   const storedDefault = probe.status === "valid" ? probe.value : defaultValue;
 
-  // Recompute the probe and reset the dedup sentinel when `key` changes.
+  // Recompute the probe and reset the dedup sentinels when `key` changes.
   // We intentionally exclude `validate` from deps: it's typically a stable
   // module-level type guard, and including it would re-probe on every render
   // for callers that pass an inline guard.
@@ -125,6 +160,7 @@ export const useLocalDb = <T>(
   useEffect(() => {
     probeRef.current = probeStoredValue(key, validate);
     reportedKeyRef.current = null;
+    reportedWriteKeyRef.current = null;
   }, [key]);
 
   // Fire onCorrupt at most once per mount per corrupt key, after render —
@@ -150,7 +186,7 @@ export const useLocalDb = <T>(
     }
   }, [key]);
 
-  return useLocalStorage({
+  const [value, setValue, removeValue] = useLocalStorage({
     key,
     defaultValue: storedDefault,
     deserialize: (raw: string | undefined) => {
@@ -191,4 +227,113 @@ export const useLocalDb = <T>(
       }
     },
   });
+
+  // The probe write **must** run inside Mantine's state updater so it shares
+  // lexical scope with `resolved`. React's eager-state optimisation only fires
+  // when the fiber has no pending lanes; any queued update on the same fiber
+  // (a prior setState in the same handler, an effect-driven update mid-render)
+  // defers the updater to commit. If the probe sat outside the closure,
+  // `resolved` would be `undefined` on the deferred path and
+  // `JSON.stringify(undefined)` would coerce to `"undefined"`, silently
+  // corrupting the persisted value.
+  //
+  // The user-visible callbacks (`onSuccess`, `onWriteFailed`), however, run
+  // AFTER `setValue` returns — outside the updater closure — so React's purity
+  // contract for state-updater functions stays intact. We capture the probe
+  // outcome in a closure variable, then dispatch callbacks once the updater
+  // has resolved. The `outcome === null` guard makes the setItem idempotent
+  // across StrictMode double-invokes and concurrent rebases (only the first
+  // run records the outcome).
+  //
+  // TODO: Mantine's own setItem still runs after our probe, so each call costs
+  // two `localStorage.setItem` writes plus two `storage` events. Eliminating
+  // the duplicate would mean replacing Mantine's `useLocalStorage` with a
+  // local `useState`/`setItem` wrapper — out of scope for the silent-write fix.
+  const handleWriteSuccess = useCallback(
+    (onSuccess: (() => void) | undefined): void => {
+      reportedWriteKeyRef.current = null;
+      try {
+        onSuccess?.();
+      } catch (callbackError) {
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[localStorage] onSuccess threw for key "${key}":`,
+            callbackError
+          );
+        }
+      }
+    },
+    [key]
+  );
+
+  const handleWriteFailure = useCallback(
+    (error: unknown): void => {
+      if (reportedWriteKeyRef.current !== key) {
+        reportedWriteKeyRef.current = key;
+        try {
+          onWriteFailedRef.current?.(key, error);
+        } catch (callbackError) {
+          if (import.meta.env.DEV) {
+            console.warn(
+              `[localStorage] onWriteFailed threw for key "${key}":`,
+              callbackError
+            );
+          }
+        }
+      }
+      if (import.meta.env.DEV) {
+        console.warn(`[localStorage] Write failed for key "${key}":`, error);
+      }
+    },
+    [key]
+  );
+
+  const probedSetValue = useCallback(
+    (next: T | ((prev: T) => T), options?: UseLocalDbSetOptions): void => {
+      // Hold the outcome on an object so TypeScript doesn't narrow the
+      // closure variable to `null` by control-flow analysis (mutations
+      // through the setValue updater closure aren't tracked).
+      const outcomeBox: {
+        value: { ok: true } | { ok: false; error: unknown } | null;
+      } = { value: null };
+      setValue((prev) => {
+        const resolved =
+          typeof next === "function"
+            ? // `as` justified: typeof check cannot narrow T | ((prev: T) => T)
+              // to the function branch when T is unconstrained — TypeScript
+              // can't prove T isn't itself a function type. The hook's
+              // JSON-serializable contract makes the updater branch the only
+              // inhabitant in practice.
+              (next as (prev: T) => T)(prev)
+            : next;
+        if (outcomeBox.value === null) {
+          try {
+            localStorage.setItem(key, JSON.stringify(resolved));
+            outcomeBox.value = { ok: true };
+          } catch (error) {
+            outcomeBox.value = { ok: false, error };
+          }
+        }
+        return resolved;
+      });
+
+      // If the updater was deferred (concurrent transition) `outcome` may be
+      // null here. All current call sites invoke this from event handlers,
+      // where React 18 flushes synchronously by the end of the handler, so
+      // this branch is defensive — skip user callbacks rather than firing
+      // them with stale info.
+      const outcome = outcomeBox.value;
+      if (outcome === null) {
+        return;
+      }
+      if (outcome.ok) {
+        handleWriteSuccess(options?.onSuccess);
+        return;
+      }
+      handleWriteFailure(outcome.error);
+    },
+    [setValue, key, handleWriteSuccess, handleWriteFailure]
+  );
+
+  return [value, probedSetValue, removeValue];
 };

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -75,9 +75,9 @@ export const getStoredValue = <T>(
   return probe.status === "valid" ? probe.value : defaultValue;
 };
 
-export type UseLocalDbSetOptions = { onSuccess?: () => void };
+type UseLocalDbSetOptions = { onSuccess?: () => void };
 
-export type UseLocalDbSetter<T> = (
+type UseLocalDbSetter<T> = (
   value: T | ((prevState: T) => T),
   options?: UseLocalDbSetOptions
 ) => void;


### PR DESCRIPTION
## Summary

Adds an `onWriteFailed` callback and `{ onSuccess }` setter option to `useLocalDb` so quota-exceeded / Safari private-mode / ITP-evicted writes — which Mantine silently swallows — are now reported to analytics and surfaced to the user via a Mantine toast.

The probe runs `localStorage.setItem` inside Mantine's state-updater closure (so it shares lexical scope with the resolved value, avoiding a stale-`undefined` race on deferred updaters) and dispatches user callbacks after the updater returns.

Two highest-volume emit sites are now gated on real persistence:

- `STACK_LIMITS_CHANGED` — moved from `StackLimitsControl` into `useStackLimits` so the emit lives at the persistence boundary.
- `Toolbox - <section>` feature-used events — gated via `onSuccess`.

Tests cover the deferred-updater regression (no `JSON.stringify(undefined)` writes), StrictMode double-invoke dedup, callback exception isolation, dedup-latch semantics across success/failure streaks, and per-key dedup reset on key change.

Translations added in all 7 locales. Also gitignores `.playwright-mcp/` browser-session artifacts that were leaking into the working tree.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run knip`
- [x] `pnpm run test` — `localstorage`, `localstorage-telemetry`, `use-stack-limits`, `use-timer-settings`, `use-selected-stack`, `use-distance-settings`, `use-flashcard-settings`, `stack-limits-control`, `stack-range-badge`
- [ ] Manual: trigger a quota-exceeded write (DevTools → Application → Storage → fill quota; or Safari private mode) and confirm the yellow "Couldn't save" toast appears once per failure streak per key.

## Scope vs #625

This PR implements steps 1–3 of #625's suggested fix (the failure pathway: probe + telemetry + toast) and gates step 4 only on the two highest-volume emit sites (`STACK_LIMITS_CHANGED`, Toolbox feature-used). The remaining `*_CHANGED` emits in distance / flashcard / spot-check are tracked separately in #641 and should be closed before #625 itself is closed.

Refs #625

## Follow-ups

- #641 — Propagate the `onSuccess` gating pattern to mode/direction/timer handlers in distance, flashcard, spot-check (completes step 4 of #625).
- #642 — `useLocalDb`: deferred-updater path silently drops `onSuccess` and `onWriteFailed` (DEV warning).
- #635 — Color scheme writes bypass `useLocalDb` entirely (different mechanism).
- #637 — Consolidate the two write-error implementations (`useLocalDb` vs `safeSetItem`) so GA sees one exception taxonomy.

The TODO at `src/utils/localstorage.ts:247` documents the double-`setItem` cost (probe + Mantine's own write); not addressed here, as eliminating it requires replacing Mantine's `useLocalStorage`.