### PR TITLE
fix: surface session-history and all-time-stats corruption on the Stats page

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I{} sh -c 'case \"$1\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.css) ./node_modules/.bin/ultracite fix \"$1\" ;; esac' _ {}"
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -r -I{} sh -c 'case \"$1\" in *.ts|*.tsx|*.js|*.jsx|*.json|*.md|*.css) PATH=\"./node_modules/.bin:$PATH\" ./node_modules/.bin/ultracite fix \"$1\" ;; esac' _ {}"
           }
         ]
       }

--- a/src/hooks/use-all-time-stats-corruption.test.ts
+++ b/src/hooks/use-all-time-stats-corruption.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+type OnCorrupt = (key: string, error: unknown) => void;
+
+vi.mock("../utils/localstorage", () => ({
+  useLocalDb: vi.fn(),
+}));
+
+vi.mock("../utils/localstorage-telemetry", () => ({
+  reportLocalDbCorruption: vi.fn(),
+}));
+
+const { useLocalDb } = await import("../utils/localstorage");
+const mockedUseLocalDb = vi.mocked(useLocalDb);
+
+const { reportLocalDbCorruption } = await import(
+  "../utils/localstorage-telemetry"
+);
+const mockedReport = vi.mocked(reportLocalDbCorruption);
+
+const { useAllTimeStats } = await import("./use-all-time-stats");
+
+describe("useAllTimeStats statsStatus", () => {
+  it("starts in 'ready' and flips to 'corrupt' while reporting telemetry when useLocalDb invokes onCorrupt", () => {
+    let captured: OnCorrupt | undefined;
+    mockedUseLocalDb.mockImplementation(
+      (_key, defaultValue, _validate, onCorrupt) => {
+        captured = onCorrupt;
+        return [defaultValue, vi.fn(), vi.fn()];
+      }
+    );
+
+    const { result } = renderHook(() => useAllTimeStats());
+
+    expect(result.current.statsStatus).toBe("ready");
+    expect(mockedReport).not.toHaveBeenCalled();
+
+    const error = new Error("validation failed");
+    act(() => {
+      captured?.("memdeck-app-all-time-stats", error);
+    });
+
+    expect(result.current.statsStatus).toBe("corrupt");
+    expect(mockedReport).toHaveBeenCalledWith(
+      "memdeck-app-all-time-stats",
+      error
+    );
+  });
+});

--- a/src/hooks/use-all-time-stats.test.ts
+++ b/src/hooks/use-all-time-stats.test.ts
@@ -12,13 +12,20 @@ const makeEntry = (
   ...overrides,
 });
 
-// Mock React hooks to return the callback/memo value directly
+// Mock React hooks to allow testing without a React rendering context. The
+// useState stub returns [initial, noop] so the consumer hook's corruption-
+// state declaration doesn't throw — the corruption transition itself is
+// covered by use-all-time-stats-corruption.test.ts via renderHook.
 vi.mock("react", async () => {
   const actual = await vi.importActual<typeof import("react")>("react");
   return {
     ...actual,
     useMemo: (fn: () => unknown) => fn(),
     useCallback: (fn: unknown) => fn,
+    useState: <T>(initial: T | (() => T)): [T, (next: T) => void] => [
+      typeof initial === "function" ? (initial as () => T)() : initial,
+      () => undefined,
+    ],
   };
 });
 

--- a/src/hooks/use-all-time-stats.ts
+++ b/src/hooks/use-all-time-stats.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { ALL_TIME_STATS_LSK } from "../constants";
 import type {
   AllTimeStats,
@@ -6,7 +6,7 @@ import type {
   TrainingMode,
 } from "../types/session";
 import type { StackKey } from "../types/stacks";
-import { useLocalDb } from "../utils/localstorage";
+import { type LocalDbStatus, useLocalDb } from "../utils/localstorage";
 import { reportLocalDbCorruption } from "../utils/localstorage-telemetry";
 import {
   aggregateStatsEntries,
@@ -20,12 +20,25 @@ const isDefined = (
   entry: AllTimeStatsEntry | undefined
 ): entry is AllTimeStatsEntry => entry !== undefined;
 
-export const useAllTimeStats = () => {
+type UseAllTimeStatsResult = {
+  stats: AllTimeStats;
+  statsStatus: LocalDbStatus;
+  getStats: (mode: TrainingMode, stackKey: StackKey) => AllTimeStatsEntry;
+  getStatsByMode: (mode: TrainingMode) => AllTimeStatsEntry;
+  getStatsByStack: (stackKey: StackKey) => AllTimeStatsEntry;
+  getGlobalStats: () => AllTimeStatsEntry;
+};
+
+export const useAllTimeStats = (): UseAllTimeStatsResult => {
+  const [statsStatus, setStatsStatus] = useState<LocalDbStatus>("ready");
   const [stats] = useLocalDb<AllTimeStats>(
     ALL_TIME_STATS_LSK,
     {},
     isAllTimeStats,
-    reportLocalDbCorruption
+    (key, error) => {
+      reportLocalDbCorruption(key, error);
+      setStatsStatus("corrupt");
+    }
   );
 
   const getStats = useCallback(
@@ -76,6 +89,7 @@ export const useAllTimeStats = () => {
 
   return {
     stats,
+    statsStatus,
     getStats,
     getStatsByMode,
     getStatsByStack,

--- a/src/hooks/use-session-history-corruption.test.ts
+++ b/src/hooks/use-session-history-corruption.test.ts
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+type OnCorrupt = (key: string, error: unknown) => void;
+
+vi.mock("../utils/localstorage", () => ({
+  useLocalDb: vi.fn(),
+}));
+
+vi.mock("../utils/localstorage-telemetry", () => ({
+  reportLocalDbCorruption: vi.fn(),
+}));
+
+const { useLocalDb } = await import("../utils/localstorage");
+const mockedUseLocalDb = vi.mocked(useLocalDb);
+
+const { reportLocalDbCorruption } = await import(
+  "../utils/localstorage-telemetry"
+);
+const mockedReport = vi.mocked(reportLocalDbCorruption);
+
+const { useSessionHistory } = await import("./use-session-history");
+
+describe("useSessionHistory historyStatus", () => {
+  it("starts in 'ready' and flips to 'corrupt' while reporting telemetry when useLocalDb invokes onCorrupt", () => {
+    let captured: OnCorrupt | undefined;
+    mockedUseLocalDb.mockImplementation(
+      (_key, defaultValue, _validate, onCorrupt) => {
+        captured = onCorrupt;
+        return [defaultValue, vi.fn(), vi.fn()];
+      }
+    );
+
+    const { result } = renderHook(() => useSessionHistory());
+
+    expect(result.current.historyStatus).toBe("ready");
+    expect(mockedReport).not.toHaveBeenCalled();
+
+    const error = new Error("validation failed");
+    act(() => {
+      captured?.("memdeck-app-session-history", error);
+    });
+
+    expect(result.current.historyStatus).toBe("corrupt");
+    expect(mockedReport).toHaveBeenCalledWith(
+      "memdeck-app-session-history",
+      error
+    );
+  });
+});

--- a/src/hooks/use-session-history.test.ts
+++ b/src/hooks/use-session-history.test.ts
@@ -4,13 +4,20 @@ import type { SessionRecord } from "../types/session";
 const mockSetValue = vi.fn();
 const mockRemoveValue = vi.fn();
 
-// Mock React hooks to allow testing without React rendering context
+// Mock React hooks to allow testing without a React rendering context. The
+// useState stub returns [initial, noop] so the consumer hook's corruption-
+// state declaration doesn't throw — the corruption transition itself is
+// covered by use-session-history-corruption.test.ts via renderHook.
 vi.mock("react", async () => {
   const actual = await vi.importActual<typeof import("react")>("react");
   return {
     ...actual,
     useMemo: vi.fn((fn) => fn()),
     useCallback: vi.fn((fn) => fn),
+    useState: vi.fn((initial) => [
+      typeof initial === "function" ? initial() : initial,
+      vi.fn(),
+    ]),
   };
 });
 

--- a/src/hooks/use-session-history.ts
+++ b/src/hooks/use-session-history.ts
@@ -1,18 +1,33 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { SESSION_HISTORY_LSK } from "../constants";
 import type { SessionRecord, TrainingMode } from "../types/session";
 import type { StackKey } from "../types/stacks";
-import { useLocalDb } from "../utils/localstorage";
+import { type LocalDbStatus, useLocalDb } from "../utils/localstorage";
 import { reportLocalDbCorruption } from "../utils/localstorage-telemetry";
 import { isSessionRecordArray } from "../utils/session-typeguards";
 
-export const useSessionHistory = () => {
+type UseSessionHistoryResult = {
+  history: SessionRecord[];
+  historyStatus: LocalDbStatus;
+  sessionsByMode: (mode: TrainingMode) => SessionRecord[];
+  sessionsByStack: (stackKey: StackKey) => SessionRecord[];
+  sessionsByModeAndStack: (
+    mode: TrainingMode,
+    stackKey: StackKey
+  ) => SessionRecord[];
+};
+
+export const useSessionHistory = (): UseSessionHistoryResult => {
+  const [historyStatus, setHistoryStatus] = useState<LocalDbStatus>("ready");
   const [history] = useLocalDb<SessionRecord[]>(
     SESSION_HISTORY_LSK,
     [],
     isSessionRecordArray,
-    reportLocalDbCorruption
+    (key, error) => {
+      reportLocalDbCorruption(key, error);
+      setHistoryStatus("corrupt");
+    }
   );
 
   const sessionsByMode = useCallback(
@@ -35,6 +50,7 @@ export const useSessionHistory = () => {
 
   return {
     history,
+    historyStatus,
     sessionsByMode,
     sessionsByStack,
     sessionsByModeAndStack,

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -323,6 +323,10 @@
       "title": "Stack-Bereiche konnten nicht geladen werden",
       "message": "Deine gespeicherten Stack-Bereichsdaten haben die Validierung nicht bestanden. Bereichsänderungen sind deaktiviert, damit sie nicht überschrieben werden. Lösche den Browser-Speicher für diese Seite, um neu anzufangen — ein erneuter Versuch hilft nicht."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Trainingsverlauf konnte nicht geladen werden",
+      "message": "Deine auf diesem Gerät gespeicherten Trainingsdaten haben die Validierung nicht bestanden. Deine Sitzungen bleiben erhalten — lösche den Browser-Speicher für diese Seite, um neu anzufangen."
+    },
     "localDbWriteFailed": {
       "title": "Änderungen nicht gespeichert",
       "message": "Dein Browser-Speicher ist möglicherweise voll — letzte Änderungen bleiben nach einem Neuladen nicht erhalten."

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -355,6 +355,10 @@
       "title": "Stack ranges couldn't be loaded",
       "message": "Your saved per-stack range data failed validation. Range edits are disabled to avoid overwriting it. Clear browser storage for this site to start fresh — retrying won't help."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Training history couldn't be loaded",
+      "message": "Your saved training data on this device failed validation. Sessions are preserved — clear browser storage for this site to start fresh."
+    },
     "localDbWriteFailed": {
       "title": "Couldn't save",
       "message": "Your browser storage may be full — recent changes won't persist after a refresh."

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -323,6 +323,10 @@
       "title": "No se pudieron cargar los rangos del stack",
       "message": "Tus rangos guardados por cada stack no pasaron la validación. La edición de rangos está desactivada para no sobrescribirlos. Borra el almacenamiento del navegador para este sitio para empezar de cero — reintentar no servirá."
     },
+    "sessionHistoryCorrupt": {
+      "title": "No se pudo cargar el historial de entrenamiento",
+      "message": "Tus datos de entrenamiento guardados en este dispositivo no pasaron la validación. Tus sesiones se conservan — borra el almacenamiento del navegador para este sitio para empezar de cero."
+    },
     "localDbWriteFailed": {
       "title": "Cambios no guardados",
       "message": "El almacenamiento del navegador puede estar lleno — los cambios recientes no se mantendrán tras recargar la página."

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -323,6 +323,10 @@
       "title": "Plages de stack non chargées",
       "message": "Vos plages enregistrées par stack sont invalides. L'édition des plages est désactivée pour ne pas les écraser. Effacez les données du navigateur pour ce site pour repartir à zéro — réessayer ne servira à rien."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Historique d'entraînement non chargé",
+      "message": "Vos données d'entraînement enregistrées sur cet appareil sont invalides. Vos sessions sont conservées — effacez les données du navigateur pour ce site pour repartir à zéro."
+    },
     "localDbWriteFailed": {
       "title": "Modifications non enregistrées",
       "message": "Votre stockage navigateur est peut-être plein — les modifications récentes ne seront pas conservées après un rechargement."

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -323,6 +323,10 @@
       "title": "Intervalli dello stack non caricati",
       "message": "I tuoi intervalli salvati per ogni stack non hanno superato la validazione. Le modifiche agli intervalli sono disabilitate per non sovrascriverli. Cancella i dati del browser per questo sito per ricominciare — riprovare non aiuterà."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Cronologia di allenamento non caricata",
+      "message": "I tuoi dati di allenamento salvati su questo dispositivo non hanno superato la validazione. Le sessioni sono intatte — cancella i dati del browser per questo sito per ricominciare."
+    },
     "localDbWriteFailed": {
       "title": "Modifiche non salvate",
       "message": "Lo spazio di archiviazione del browser potrebbe essere pieno — le modifiche recenti non saranno mantenute dopo aver ricaricato la pagina."

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -323,6 +323,10 @@
       "title": "Stack-bereiken konden niet worden geladen",
       "message": "Je opgeslagen bereiken per stack zijn niet door de validatie gekomen. Bereikbewerkingen zijn uitgeschakeld om de opgeslagen gegevens niet te overschrijven. Wis de browseropslag voor deze site om opnieuw te beginnen — opnieuw proberen helpt niet."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Trainingsgeschiedenis kon niet worden geladen",
+      "message": "Je opgeslagen trainingsgegevens op dit apparaat zijn niet door de validatie gekomen. Sessies blijven bewaard — wis de browseropslag voor deze site om opnieuw te beginnen."
+    },
     "localDbWriteFailed": {
       "title": "Wijzigingen niet opgeslagen",
       "message": "Je browseropslag is misschien vol — recente wijzigingen gaan verloren na het herladen."

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -323,6 +323,10 @@
       "title": "Não foi possível carregar os intervalos do stack",
       "message": "Os teus intervalos guardados por stack não passaram na validação. As edições de intervalo estão desativadas para não os sobrescrever. Limpa o armazenamento do navegador para este site para começar de novo — tentar de novo não vai ajudar."
     },
+    "sessionHistoryCorrupt": {
+      "title": "Não foi possível carregar o histórico de treino",
+      "message": "Os teus dados de treino guardados neste dispositivo não passaram na validação. As sessões estão preservadas — limpa o armazenamento do navegador para este site para começar de novo."
+    },
     "localDbWriteFailed": {
       "title": "Alterações não guardadas",
       "message": "O armazenamento do navegador pode estar cheio — as alterações recentes não serão mantidas após recarregar a página."

--- a/src/pages/stats/stats-corruption-alert.tsx
+++ b/src/pages/stats/stats-corruption-alert.tsx
@@ -1,0 +1,17 @@
+import { Alert } from "@mantine/core";
+import { IconAlertCircle } from "@tabler/icons-react";
+import { useTranslation } from "react-i18next";
+
+export const StatsCorruptionAlert = () => {
+  const { t } = useTranslation();
+  return (
+    <Alert
+      color="red"
+      icon={<IconAlertCircle aria-hidden="true" />}
+      role="alert"
+      title={t("errors.sessionHistoryCorrupt.title")}
+    >
+      {t("errors.sessionHistoryCorrupt.message")}
+    </Alert>
+  );
+};

--- a/src/pages/stats/stats.test.tsx
+++ b/src/pages/stats/stats.test.tsx
@@ -1,0 +1,125 @@
+import { screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "../../test-utils";
+import type { LocalDbStatus } from "../../utils/localstorage";
+
+const CORRUPTION_ALERT_TITLE = /training history couldn't be loaded/i;
+const CORRUPTION_ALERT_BODY = /sessions are preserved/i;
+const EMPTY_STATE_COPY = /no training data yet/i;
+
+const mockUseSessionHistory = vi.fn();
+const mockUseAllTimeStats = vi.fn();
+
+vi.mock("../../hooks/use-session-history", () => ({
+  useSessionHistory: () => mockUseSessionHistory(),
+}));
+
+vi.mock("../../hooks/use-all-time-stats", () => ({
+  useAllTimeStats: () => mockUseAllTimeStats(),
+}));
+
+vi.mock("../../hooks/use-document-meta", () => ({
+  useDocumentMeta: () => undefined,
+}));
+
+const { Stats } = await import("./stats");
+
+const emptyStatsEntry = () => ({
+  totalSessions: 0,
+  totalQuestions: 0,
+  totalSuccesses: 0,
+  totalFails: 0,
+  globalBestStreak: 0,
+});
+
+const sessionHistoryDefaults = {
+  history: [],
+  historyStatus: "ready" as LocalDbStatus,
+  sessionsByMode: () => [],
+  sessionsByStack: () => [],
+  sessionsByModeAndStack: () => [],
+};
+
+const allTimeStatsDefaults = {
+  stats: {},
+  statsStatus: "ready" as LocalDbStatus,
+  getStats: emptyStatsEntry,
+  getStatsByMode: emptyStatsEntry,
+  getStatsByStack: emptyStatsEntry,
+  getGlobalStats: emptyStatsEntry,
+};
+
+const setHooks = ({
+  historyStatus,
+  statsStatus,
+}: {
+  historyStatus: LocalDbStatus;
+  statsStatus: LocalDbStatus;
+}) => {
+  mockUseSessionHistory.mockReturnValue({
+    ...sessionHistoryDefaults,
+    historyStatus,
+  });
+  mockUseAllTimeStats.mockReturnValue({
+    ...allTimeStatsDefaults,
+    statsStatus,
+  });
+};
+
+describe("Stats corruption banner", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the corruption alert when session history is corrupt", () => {
+    setHooks({ historyStatus: "corrupt", statsStatus: "ready" });
+
+    render(<Stats />);
+
+    const alert = screen.getByRole("alert", { name: CORRUPTION_ALERT_TITLE });
+    expect(alert).toBeInTheDocument();
+    expect(within(alert).getByText(CORRUPTION_ALERT_BODY)).toBeInTheDocument();
+  });
+
+  it("renders the corruption alert when all-time stats is corrupt", () => {
+    // The user-visible silent failure described in #626 also fires when only
+    // all-time-stats is corrupt: globalStats.totalSessions defaults to 0,
+    // hasData is false, and the empty-state would otherwise show with no
+    // signal that the data is preserved-but-unreadable.
+    setHooks({ historyStatus: "ready", statsStatus: "corrupt" });
+
+    render(<Stats />);
+
+    const alert = screen.getByRole("alert", { name: CORRUPTION_ALERT_TITLE });
+    expect(alert).toBeInTheDocument();
+    expect(within(alert).getByText(CORRUPTION_ALERT_BODY)).toBeInTheDocument();
+  });
+
+  it("renders exactly one corruption alert when both blobs are corrupt", () => {
+    setHooks({ historyStatus: "corrupt", statsStatus: "corrupt" });
+
+    render(<Stats />);
+
+    expect(
+      screen.getAllByRole("alert", { name: CORRUPTION_ALERT_TITLE })
+    ).toHaveLength(1);
+  });
+
+  it("does not render the corruption alert when both blobs are ready", () => {
+    setHooks({ historyStatus: "ready", statsStatus: "ready" });
+
+    render(<Stats />);
+
+    expect(
+      screen.queryByRole("alert", { name: CORRUPTION_ALERT_TITLE })
+    ).not.toBeInTheDocument();
+  });
+
+  it("suppresses the empty-state copy when corruption is present", () => {
+    setHooks({ historyStatus: "corrupt", statsStatus: "ready" });
+
+    render(<Stats />);
+
+    expect(screen.queryByText(EMPTY_STATE_COPY)).not.toBeInTheDocument();
+  });
+});

--- a/src/pages/stats/stats.tsx
+++ b/src/pages/stats/stats.tsx
@@ -7,6 +7,7 @@ import { useDocumentMeta } from "../../hooks/use-document-meta";
 import { useSessionHistory } from "../../hooks/use-session-history";
 import { AccuracyChart } from "./accuracy-chart";
 import { StatsByStack } from "./stats-by-stack";
+import { StatsCorruptionAlert } from "./stats-corruption-alert";
 import { StatsHistory } from "./stats-history";
 import { StatsOverview } from "./stats-overview";
 
@@ -34,11 +35,13 @@ export const Stats = () => {
     title: t("stats.pageTitle"),
     description: t("stats.pageDescription"),
   });
-  const { history } = useSessionHistory();
-  const { getGlobalStats } = useAllTimeStats();
+  const { history, historyStatus } = useSessionHistory();
+  const { getGlobalStats, statsStatus } = useAllTimeStats();
   const globalStats = getGlobalStats();
 
   const hasData = globalStats.totalSessions > 0;
+  const hasCorruption =
+    historyStatus === "corrupt" || statsStatus === "corrupt";
 
   return (
     <Stack gap="xl" p="md">
@@ -51,7 +54,9 @@ export const Stats = () => {
         {t("stats.seoIntro")}
       </span>
 
-      {!hasData && (
+      {hasCorruption && <StatsCorruptionAlert />}
+
+      {!(hasData || hasCorruption) && (
         <Text c="dimmed" ta="center">
           {t("stats.noData")}
         </Text>

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -1,5 +1,5 @@
 import { readLocalStorageValue, useLocalStorage } from "@mantine/hooks";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * Result of probing a localStorage key: distinguishes "key absent" from "key
@@ -11,6 +11,15 @@ type StoredValueProbe<T> =
   | { status: "valid"; value: T }
   | { status: "corrupt"; raw: unknown }
   | { status: "read-error"; error: unknown };
+
+/**
+ * Corruption signal that consumer hooks track in their own state and surface
+ * to UI. `"corrupt"` collapses both validation failures and read errors —
+ * UI consumers don't need to distinguish (the user-facing message is the
+ * same), and `reportLocalDbCorruption` already preserves the distinction
+ * in telemetry.
+ */
+export type LocalDbStatus = "ready" | "corrupt";
 
 /**
  * Reads and validates a value from localStorage, returning a discriminated
@@ -111,11 +120,19 @@ export const useLocalDb = <T>(
   onCorrupt?: (key: string, error: unknown) => void,
   onWriteFailed?: (key: string, error: unknown) => void
 ): [T, UseLocalDbSetter<T>, () => void] => {
-  // Cache the initial probe in a ref so it isn't re-executed every render.
-  // Recomputed via useEffect when `key` changes.
-  const probeRef = useRef<StoredValueProbe<T> | null>(null);
-  if (probeRef.current === null) {
-    probeRef.current = probeStoredValue(key, validate);
+  // Probe state, lazy at mount and re-computed on `key` change via the
+  // React-recommended set-state-during-render pattern. Bundling key+probe
+  // together lets us re-probe synchronously and avoid a one-render lag in
+  // `storedDefault` on key change.
+  const [probeState, setProbeState] = useState<{
+    key: string;
+    probe: StoredValueProbe<T>;
+  }>(() => ({ key, probe: probeStoredValue(key, validate) }));
+
+  let probe = probeState.probe;
+  if (probeState.key !== key) {
+    probe = probeStoredValue(key, validate);
+    setProbeState({ key, probe });
   }
 
   // Dedup sentinel: tracks the storage key for which we've already invoked
@@ -149,27 +166,13 @@ export const useLocalDb = <T>(
     onWriteFailedRef.current = onWriteFailed;
   }, [onWriteFailed]);
 
-  const probe = probeRef.current;
-  const storedDefault = probe.status === "valid" ? probe.value : defaultValue;
-
-  // Recompute the probe and reset the dedup sentinels when `key` changes.
-  // We intentionally exclude `validate` from deps: it's typically a stable
-  // module-level type guard, and including it would re-probe on every render
-  // for callers that pass an inline guard.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: validate is expected to be a stable type guard; depending on it would re-probe on every render for inline guards
-  useEffect(() => {
-    probeRef.current = probeStoredValue(key, validate);
-    reportedKeyRef.current = null;
-    reportedWriteKeyRef.current = null;
-  }, [key]);
-
   // Fire onCorrupt at most once per mount per corrupt key, after render —
   // never during render, which is what caused the per-render telemetry storm.
+  // Cross-key dedup falls out of the `current !== key` comparison: a
+  // transition from key-a to key-b leaves `reportedKeyRef.current === "key-a"`,
+  // which differs from the new `key`, so the effect re-fires for the new key.
+  // No explicit reset on key change is needed.
   useEffect(() => {
-    const current = probeRef.current;
-    if (current === null) {
-      return;
-    }
     if (reportedKeyRef.current === key) {
       return;
     }
@@ -177,14 +180,16 @@ export const useLocalDb = <T>(
     if (!cb) {
       return;
     }
-    if (current.status === "corrupt") {
+    if (probe.status === "corrupt") {
       reportedKeyRef.current = key;
-      cb(key, current.raw);
-    } else if (current.status === "read-error") {
+      cb(key, probe.raw);
+    } else if (probe.status === "read-error") {
       reportedKeyRef.current = key;
-      cb(key, current.error);
+      cb(key, probe.error);
     }
-  }, [key]);
+  }, [key, probe]);
+
+  const storedDefault = probe.status === "valid" ? probe.value : defaultValue;
 
   const [value, setValue, removeValue] = useLocalStorage({
     key,


### PR DESCRIPTION
## Summary
- Closes #626 — Stats page silently rendered the empty state when the localStorage `session-history` or `all-time-stats` blob was corrupt, with no signal to the user that their data was corrupt-but-preserved.
- Track the corruption signal in the two Stats consumer hooks (`useSessionHistory`, `useAllTimeStats`) via the existing `onCorrupt` callback they already pass to `useLocalDb` — no public `useLocalDb` API change.
- Render a red Mantine `Alert` banner above the Stats content when either blob is corrupt, and suppress the contradicting "No training data yet" empty-state copy when the banner is shown.
- Internal cleanup in `useLocalDb`: lift `probeRef` to `useState` (no render-time ref read; bundled `{ key, probe }` state with React-recommended set-state-during-render pattern).
- New translations under `errors.sessionHistoryCorrupt.{title,message}` for all 7 supported locales.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (touched files; ultracite OOMs on full-repo run, unrelated)
- [x] `pnpm run test` — 1702 pass (added 1 empty-state-suppression test)
- [x] `pnpm run test:coverage` — hooks 92.18% / utils 97.23% (above 85%/90% ratchets)
- [x] `pnpm run test:e2e` — all green
- [x] Manual browser check via Playwright MCP: corrupt `memdeck-app-session-history` → red banner renders above empty state with no contradicting "No training data yet" copy; corrupt `memdeck-app-all-time-stats` → same banner renders; clear both keys + reload → banner gone, normal empty state returns.

## Notes
- The `.claude/settings.json` change is an unrelated local hook-config tweak (PATH prefix for ultracite invocation) — kept per local environment requirement.