### PR TITLE
fix: stop overwriting corrupt localStorage blobs on mount

### DIFF
--- a/e2e/persistence.e2e.ts
+++ b/e2e/persistence.e2e.ts
@@ -234,11 +234,63 @@ test.describe("localStorage Persistence", () => {
       .inputValue();
     expect(selectedValue).toBe("");
 
-    // After reload, app re-initializes localStorage with default empty value
+    // After reload, the key stays absent until the user makes a selection.
+    // (Pre-#639, mounting useLocalDb auto-wrote the default value to disk —
+    // that side effect is gone; UI state still falls back to the default,
+    // but disk is left clean.)
     const clearedStack = await page.evaluate(() =>
       localStorage.getItem("memdeck-app-stack")
     );
-    expect(clearedStack).toBe('""'); // JSON stringified empty string
+    expect(clearedStack).toBeNull();
+  });
+
+  // Reset-on-write recovery contract for low-stakes single-value keys (see
+  // src/hooks/use-selected-stack.ts:34-37). A corrupt blob must not trap the
+  // user — the next normal interaction overwrites it. Distinct from the
+  // multi-record useStackLimits case (issue #639), where the consumer-level
+  // lock blocks writes to preserve other stacks' ranges.
+  test("should let the user recover from a corrupt single-value blob via normal interaction", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Plant a JSON-valid blob that fails the StackKey type guard.
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "memdeck-app-stack",
+        JSON.stringify("not-a-real-stack")
+      );
+    });
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    // The picker shows empty (default fallback) — no stack selected.
+    const stackPicker = page.locator("[data-testid='stack-picker']").first();
+    expect(await stackPicker.inputValue()).toBe("");
+
+    // Pin the invariant the fix guarantees: empty UI coexists with the
+    // corrupt blob still on disk. Distinguishes reset-on-write from a
+    // hypothetical mount-time clear regression — under the old Mantine
+    // behavior this assertion would have observed `'""'` (the
+    // deserialize-fallback that mount auto-wrote).
+    const beforePick = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack")
+    );
+    expect(beforePick).toBe(JSON.stringify("not-a-real-stack"));
+
+    // The user picks a real stack — the setter must overwrite the corrupt
+    // bytes (reset-on-write) so the selection persists.
+    await stackPicker.selectOption("aronson");
+    await page.waitForLoadState("networkidle");
+
+    expect(await stackPicker.inputValue()).toBe("aronson");
+
+    const onDisk = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack")
+    );
+    expect(onDisk).toBe(JSON.stringify("aronson"));
   });
 
   test("should not lose settings during rapid navigation", async ({ page }) => {

--- a/e2e/stack-limits.e2e.ts
+++ b/e2e/stack-limits.e2e.ts
@@ -1,6 +1,8 @@
 import { expect } from "@playwright/test";
 import { test } from "./fixtures/test-setup";
 
+const STACK_RANGE_BADGE_PATTERN = /Stack range/;
+
 test.describe("Stack Limits", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -154,5 +156,37 @@ test.describe("Stack Limits", () => {
       name: "Stack range: positions 1 to 13. Tap to adjust.",
     });
     await expect(mnemonicaBadge).toContainText("1–13");
+  });
+
+  // Issue #639 regression: a corrupt `memdeck-app-stack-limits` blob used to
+  // be silently replaced with "{}" on mount because Mantine's
+  // `useLocalStorage` wrote the deserialize-fallback to disk during its mount
+  // effect. The fix replaces that hook with `useSyncExternalStore`, which
+  // never writes on mount. This test plants a typeguard-failing blob, reloads
+  // a page that mounts `useStackLimits`, and asserts the on-disk bytes are
+  // preserved byte-for-byte.
+  test("should preserve a corrupt stack-limits blob across mount (issue #639)", async ({
+    page,
+  }) => {
+    const corrupt = JSON.stringify("garbage-not-a-record");
+
+    await page.evaluate((value) => {
+      localStorage.setItem("memdeck-app-stack-limits", value);
+    }, corrupt);
+
+    await page.reload();
+    await page.waitForLoadState("networkidle");
+
+    // The range badge mounts useStackLimits; if mount-time auto-write were
+    // still in place, the corrupt blob would now be "{}".
+    const badge = page.getByRole("button", {
+      name: STACK_RANGE_BADGE_PATTERN,
+    });
+    await expect(badge).toBeVisible();
+
+    const onDisk = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack-limits")
+    );
+    expect(onDisk).toBe(corrupt);
   });
 });

--- a/src/utils/localstorage.test.ts
+++ b/src/utils/localstorage.test.ts
@@ -1,5 +1,5 @@
-import { renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockReadLocalStorageValue = vi.fn();
 const mockUseLocalStorage = vi.fn();
@@ -420,227 +420,242 @@ describe("probeStoredValue", () => {
   });
 });
 
+// useLocalDb no longer wraps Mantine's `useLocalStorage`. It reads via
+// `useSyncExternalStore` and writes via direct `localStorage.setItem`, so
+// these tests drive `window.localStorage` directly and dispatch real DOM
+// events to simulate cross-tab and same-tab updates. The
+// `mockUseLocalStorage` / `mockReadLocalStorageValue` factories above are
+// inert for this block.
+//
+// happy-dom@20 + vitest@4 in this project's configuration exposes
+// `window.localStorage` as a plain `{}` without the Storage API methods, so
+// each test installs a hand-rolled mock via `vi.stubGlobal("localStorage", …)`
+// backed by an in-memory map. Write-failure tests override the
+// `setItemMock` implementation to throw.
 describe("useLocalDb", () => {
+  let store: Record<string, string>;
+  let getItemMock: ReturnType<typeof vi.fn>;
+  let setItemMock: ReturnType<typeof vi.fn>;
+  let removeItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = {};
+    getItemMock = vi.fn((k: string) => (k in store ? store[k] : null));
+    setItemMock = vi.fn((k: string, v: string) => {
+      store[k] = String(v);
+    });
+    removeItemMock = vi.fn((k: string) => {
+      delete store[k];
+    });
+    vi.stubGlobal("localStorage", {
+      get length() {
+        return Object.keys(store).length;
+      },
+      getItem: getItemMock,
+      setItem: setItemMock,
+      removeItem: removeItemMock,
+      clear: () => {
+        for (const k of Object.keys(store)) {
+          delete store[k];
+        }
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    });
+  });
+
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.clearAllMocks();
   });
 
-  it("calls useLocalStorage with key and resolved default value", () => {
-    mockReadLocalStorageValue.mockReturnValue(undefined);
-    mockUseLocalStorage.mockReturnValue(["value", vi.fn(), vi.fn()]);
-
-    renderHook(() => useLocalDb("test-key", "default", isString));
-
-    expect(mockUseLocalStorage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: "test-key",
-        defaultValue: "default",
-      })
-    );
-  });
-
-  it("uses stored value as default when available", () => {
-    mockReadLocalStorageValue.mockReturnValue("stored-value");
-    mockUseLocalStorage.mockReturnValue(["stored-value", vi.fn(), vi.fn()]);
-
-    renderHook(() => useLocalDb("test-key", "default", isString));
-
-    expect(mockUseLocalStorage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: "test-key",
-        defaultValue: "stored-value",
-      })
-    );
-  });
-
-  it("returns tuple with value, wrapped setter, and remover", () => {
-    const mockSetter = vi.fn();
-    const mockRemover = vi.fn();
-    mockReadLocalStorageValue.mockReturnValue("value");
-    mockUseLocalStorage.mockReturnValue(["value", mockSetter, mockRemover]);
-
-    const { result } = renderHook(() =>
-      useLocalDb("test-key", "default", isString)
-    );
-
-    const [value, setValue, removeValue] = result.current;
-    expect(value).toBe("value");
-    // The setter is wrapped to add a post-write probe, so it is not the same
-    // function reference as Mantine's setter — but invoking it must still
-    // forward the value through to the underlying setter via a function
-    // updater so the probe and Mantine resolve against the same `prev`.
-    expect(setValue).toBeInstanceOf(Function);
-    expect(setValue).not.toBe(mockSetter);
-    setValue("next");
-    expect(mockSetter).toHaveBeenCalledTimes(1);
-    const cbArg = mockSetter.mock.calls[0]?.[0];
-    expect(typeof cbArg).toBe("function");
-    // `as` justified: `cbArg` is typed `unknown` from the mock's call array,
-    // but we just verified it's a function. Invoking it with any prev should
-    // resolve to the static "next" value the caller passed.
-    expect((cbArg as (prev: unknown) => unknown)("anything")).toBe("next");
-    expect(removeValue).toBe(mockRemover);
-  });
-
-  it("works with number type", () => {
-    mockReadLocalStorageValue.mockReturnValue(42);
-    mockUseLocalStorage.mockReturnValue([42, vi.fn(), vi.fn()]);
-
-    const { result } = renderHook(() => useLocalDb("counter", 0, isNumber));
-
-    expect(result.current[0]).toBe(42);
-  });
-
-  it("works with boolean type", () => {
-    mockReadLocalStorageValue.mockReturnValue(true);
-    mockUseLocalStorage.mockReturnValue([true, vi.fn(), vi.fn()]);
-
-    const { result } = renderHook(() => useLocalDb("enabled", false, isBool));
-
-    expect(result.current[0]).toBe(true);
-  });
-
-  it("works with object type", () => {
-    const storedObject = { name: "test", value: 123 };
-    mockReadLocalStorageValue.mockReturnValue(storedObject);
-    mockUseLocalStorage.mockReturnValue([storedObject, vi.fn(), vi.fn()]);
-
-    type Settings = { name: string; value: number };
-    const isSettings = (v: unknown): v is Settings =>
-      typeof v === "object" &&
-      v !== null &&
-      "name" in v &&
-      "value" in v &&
-      typeof (v as Settings).name === "string" &&
-      typeof (v as Settings).value === "number";
-
-    const { result } = renderHook(() =>
-      useLocalDb("settings", { name: "", value: 0 }, isSettings)
-    );
-
-    expect(result.current[0]).toEqual({ name: "test", value: 123 });
-  });
-
-  it("works with array type", () => {
-    const storedArray = ["item1", "item2"];
-    mockReadLocalStorageValue.mockReturnValue(storedArray);
-    mockUseLocalStorage.mockReturnValue([storedArray, vi.fn(), vi.fn()]);
-
-    const { result } = renderHook(() =>
-      useLocalDb("items", [] as string[], isStringArray)
-    );
-
-    expect(result.current[0]).toEqual(["item1", "item2"]);
-  });
-
-  it("falls back to default when storage read fails", () => {
-    mockReadLocalStorageValue.mockImplementation(() => {
-      throw new Error("Storage error");
+  describe("read path", () => {
+    it("returns defaultValue when the key is absent", () => {
+      const { result } = renderHook(() =>
+        useLocalDb("missing", "default", isString)
+      );
+      expect(result.current[0]).toBe("default");
     });
-    mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
 
-    renderHook(() => useLocalDb("test-key", "default", isString));
+    it("returns the parsed stored value when validation passes", () => {
+      window.localStorage.setItem("k", JSON.stringify("hello"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("hello");
+    });
 
-    expect(mockUseLocalStorage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        key: "test-key",
-        defaultValue: "default",
-      })
-    );
+    it("returns defaultValue when stored bytes fail the type guard", () => {
+      window.localStorage.setItem("k", JSON.stringify(42));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("default");
+    });
+
+    it("returns defaultValue when stored bytes are malformed JSON", () => {
+      window.localStorage.setItem("k", "{not valid");
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("default");
+    });
+
+    it("returns defaultValue when localStorage.getItem throws (storage-blocked environments)", () => {
+      // Simulates Safari ITP / private mode / SecurityError. The wrapper
+      // collapses read errors to "absent" — onCorrupt is NOT called from
+      // this path (consumers needing the distinction call probeStoredValue
+      // directly; see use-stack-limits.ts).
+      getItemMock.mockImplementation(() => {
+        throw new DOMException("Access denied", "SecurityError");
+      });
+      const onCorrupt = vi.fn();
+
+      const { result } = renderHook(() =>
+        useLocalDb("k", "default", isString, onCorrupt)
+      );
+
+      expect(result.current[0]).toBe("default");
+      expect(onCorrupt).not.toHaveBeenCalled();
+    });
+
+    it("works with number type", () => {
+      window.localStorage.setItem("counter", JSON.stringify(42));
+      const { result } = renderHook(() => useLocalDb("counter", 0, isNumber));
+      expect(result.current[0]).toBe(42);
+    });
+
+    it("works with boolean type", () => {
+      window.localStorage.setItem("enabled", JSON.stringify(true));
+      const { result } = renderHook(() => useLocalDb("enabled", false, isBool));
+      expect(result.current[0]).toBe(true);
+    });
+
+    it("works with object type", () => {
+      const stored = { name: "test", value: 123 };
+      window.localStorage.setItem("settings", JSON.stringify(stored));
+      const { result } = renderHook(() =>
+        useLocalDb("settings", { name: "", value: 0 }, isTestObj)
+      );
+      expect(result.current[0]).toEqual(stored);
+    });
+
+    it("works with array type", () => {
+      window.localStorage.setItem("items", JSON.stringify(["a", "b"]));
+      const { result } = renderHook(() =>
+        useLocalDb<string[]>("items", [], isStringArray)
+      );
+      expect(result.current[0]).toEqual(["a", "b"]);
+    });
+  });
+
+  // Issue #639 regression: Mantine's useLocalStorage used to write the
+  // deserialize-fallback (e.g. {}) back to localStorage on mount, silently
+  // destroying corrupt-but-recoverable state before any consumer-level
+  // corrupt-lock could fire. The new implementation must never write to disk
+  // as a side effect of mounting.
+  describe("mount-time corrupt blob preservation (issue #639)", () => {
+    type Rec = Record<string, number>;
+    const isRec = (v: unknown): v is Rec =>
+      typeof v === "object" && v !== null && !Array.isArray(v);
+
+    it("does not overwrite a typeguard-failing JSON blob on mount", () => {
+      const corrupt = JSON.stringify("garbage-not-a-record");
+      window.localStorage.setItem("k", corrupt);
+
+      renderHook(() => useLocalDb<Rec>("k", {}, isRec));
+
+      expect(window.localStorage.getItem("k")).toBe(corrupt);
+    });
+
+    it("does not overwrite a malformed JSON blob on mount", () => {
+      const garbage = "{not valid json";
+      window.localStorage.setItem("k", garbage);
+
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      expect(window.localStorage.getItem("k")).toBe(garbage);
+    });
+
+    it("does not write defaultValue to disk when the key is absent", () => {
+      renderHook(() => useLocalDb("missing", "default", isString));
+
+      expect(window.localStorage.getItem("missing")).toBeNull();
+    });
+
+    it("does not overwrite the corrupt blob across many re-renders", () => {
+      const corrupt = JSON.stringify(42);
+      window.localStorage.setItem("k", corrupt);
+
+      const { rerender } = renderHook(() =>
+        useLocalDb("k", "default", isString)
+      );
+      for (let i = 0; i < 10; i++) {
+        rerender();
+      }
+
+      expect(window.localStorage.getItem("k")).toBe(corrupt);
+    });
   });
 
   describe("onCorrupt callback", () => {
     it("does not invoke onCorrupt when the stored value is valid", () => {
-      mockReadLocalStorageValue.mockReturnValue("stored");
-      mockUseLocalStorage.mockReturnValue(["stored", vi.fn(), vi.fn()]);
+      window.localStorage.setItem("k", JSON.stringify("ok"));
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
 
       expect(onCorrupt).not.toHaveBeenCalled();
     });
 
     it("does not invoke onCorrupt when the stored value is absent", () => {
-      mockReadLocalStorageValue.mockReturnValue(undefined);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
 
       expect(onCorrupt).not.toHaveBeenCalled();
     });
 
-    it("invokes onCorrupt with the key and raw value when validation fails", () => {
-      mockReadLocalStorageValue.mockReturnValue(123);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+    it("invokes onCorrupt with the parsed value when validation fails", () => {
+      window.localStorage.setItem("k", JSON.stringify(123));
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
-      expect(onCorrupt).toHaveBeenCalledWith("test-key", 123);
+      expect(onCorrupt).toHaveBeenCalledWith("k", 123);
     });
 
-    it("invokes onCorrupt with the read error when the storage read throws", () => {
-      const readError = new Error("Storage read denied");
-      mockReadLocalStorageValue.mockImplementation(() => {
-        throw readError;
-      });
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+    it("invokes onCorrupt with the raw bytes on JSON.parse failure", () => {
+      const garbage = "{not valid json";
+      window.localStorage.setItem("k", garbage);
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
-      expect(onCorrupt).toHaveBeenCalledWith("test-key", readError);
+      expect(onCorrupt).toHaveBeenCalledWith("k", garbage);
     });
 
-    it("falls back to defaultValue when corrupt and onCorrupt is provided", () => {
-      mockReadLocalStorageValue.mockReturnValue(123);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
-      const onCorrupt = vi.fn();
-
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
-
-      expect(mockUseLocalStorage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          key: "test-key",
-          defaultValue: "default",
-        })
-      );
-    });
-
-    it("works without onCorrupt — no throw on corrupt value", () => {
-      mockReadLocalStorageValue.mockReturnValue(123);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+    it("does not throw when no onCorrupt is provided on a corrupt blob", () => {
+      window.localStorage.setItem("k", JSON.stringify(123));
 
       expect(() =>
-        renderHook(() => useLocalDb("test-key", "default", isString))
+        renderHook(() => useLocalDb("k", "default", isString))
       ).not.toThrow();
     });
 
     it("fires onCorrupt only once across many re-renders for the same corrupt key", () => {
-      mockReadLocalStorageValue.mockReturnValue(123);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+      window.localStorage.setItem("k", JSON.stringify(123));
       const onCorrupt = vi.fn();
 
       const { rerender } = renderHook(() =>
-        useLocalDb("test-key", "default", isString, onCorrupt)
+        useLocalDb("k", "default", isString, onCorrupt)
       );
-
-      // Simulate a high-frequency render loop (e.g. 1Hz timer page).
       for (let i = 0; i < 20; i++) {
         rerender();
       }
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
-      expect(onCorrupt).toHaveBeenCalledWith("test-key", 123);
+      expect(onCorrupt).toHaveBeenCalledWith("k", 123);
     });
 
-    it("resets onCorrupt dedup when key changes", () => {
-      // Both keys are corrupt — dedup must be per-key, not per-mount.
-      mockReadLocalStorageValue.mockReturnValue(123);
-      mockUseLocalStorage.mockReturnValue(["default", vi.fn(), vi.fn()]);
+    it("re-fires onCorrupt when the key changes to another corrupt blob", () => {
+      window.localStorage.setItem("key-a", JSON.stringify(1));
+      window.localStorage.setItem("key-b", JSON.stringify(2));
       const onCorrupt = vi.fn();
 
       const { rerender } = renderHook(
@@ -651,218 +666,392 @@ describe("useLocalDb", () => {
       rerender({ k: "key-b" });
 
       expect(onCorrupt).toHaveBeenCalledTimes(2);
-      expect(onCorrupt).toHaveBeenNthCalledWith(1, "key-a", 123);
-      expect(onCorrupt).toHaveBeenNthCalledWith(2, "key-b", 123);
+      expect(onCorrupt).toHaveBeenNthCalledWith(1, "key-a", 1);
+      expect(onCorrupt).toHaveBeenNthCalledWith(2, "key-b", 2);
     });
 
-    it("calls onCorrupt from the deserialize path on JSON.parse error", () => {
-      // Probe path is clean (absent), so only the deserialize callback can
-      // fire onCorrupt — exercising the parse-error branch.
-      mockReadLocalStorageValue.mockReturnValue(undefined);
-      let capturedDeserialize:
-        | ((raw: string | undefined) => unknown)
-        | undefined;
-      mockUseLocalStorage.mockImplementation(
-        (args: { deserialize?: (raw: string | undefined) => unknown }) => {
-          capturedDeserialize = args.deserialize;
-          return ["default", vi.fn(), vi.fn()];
-        }
-      );
+    it("invokes onCorrupt with the thrown error when the validator itself throws (read-error branch)", () => {
+      // parseRawValue's `try { validate(parsed) } catch` returns
+      // { status: "read-error", error } and the corruption effect forwards
+      // the thrown error rather than the parsed value.
+      window.localStorage.setItem("k", JSON.stringify({ ok: true }));
+      const validatorError = new TypeError("validator boom");
+      const validateThrows = (_v: unknown): _v is string => {
+        throw validatorError;
+      };
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", validateThrows, onCorrupt));
 
-      expect(capturedDeserialize).toBeDefined();
-      // Probe path was clean, so no onCorrupt fired yet.
-      expect(onCorrupt).not.toHaveBeenCalled();
-
-      // Cross-tab read with malformed JSON.
-      const result = capturedDeserialize?.("{not valid json");
-
-      expect(result).toBe("default");
       expect(onCorrupt).toHaveBeenCalledTimes(1);
-      expect(onCorrupt).toHaveBeenCalledWith("test-key", expect.any(Error));
-    });
-
-    it("calls onCorrupt from the deserialize path on validate-failure", () => {
-      mockReadLocalStorageValue.mockReturnValue(undefined);
-      let capturedDeserialize:
-        | ((raw: string | undefined) => unknown)
-        | undefined;
-      mockUseLocalStorage.mockImplementation(
-        (args: { deserialize?: (raw: string | undefined) => unknown }) => {
-          capturedDeserialize = args.deserialize;
-          return ["default", vi.fn(), vi.fn()];
-        }
-      );
-      const onCorrupt = vi.fn();
-
-      renderHook(() => useLocalDb("test-key", "default", isString, onCorrupt));
-
-      expect(capturedDeserialize).toBeDefined();
-      expect(onCorrupt).not.toHaveBeenCalled();
-
-      // Valid JSON, but the parsed value fails the type guard.
-      const raw = JSON.stringify(42);
-      const result = capturedDeserialize?.(raw);
-
-      expect(result).toBe("default");
-      expect(onCorrupt).toHaveBeenCalledTimes(1);
-      expect(onCorrupt).toHaveBeenCalledWith("test-key", raw);
-    });
-
-    it("does not call onCorrupt for a clean read", () => {
-      mockReadLocalStorageValue.mockReturnValue("stored");
-      let capturedDeserialize:
-        | ((raw: string | undefined) => unknown)
-        | undefined;
-      mockUseLocalStorage.mockImplementation(
-        (args: { deserialize?: (raw: string | undefined) => unknown }) => {
-          capturedDeserialize = args.deserialize;
-          return ["stored", vi.fn(), vi.fn()];
-        }
-      );
-      const onCorrupt = vi.fn();
-
-      const { rerender } = renderHook(() =>
-        useLocalDb("test-key", "default", isString, onCorrupt)
-      );
-
-      // Multiple renders + a clean deserialize — should never fire onCorrupt.
-      rerender();
-      rerender();
-      capturedDeserialize?.(JSON.stringify("fresh-value"));
-
-      expect(onCorrupt).not.toHaveBeenCalled();
+      expect(onCorrupt).toHaveBeenCalledWith("k", validatorError);
     });
   });
 
-  describe("setter identity stability", () => {
-    it("returns the same setter reference across re-renders when key is unchanged", () => {
-      mockReadLocalStorageValue.mockReturnValue("value");
-      mockUseLocalStorage.mockReturnValue(["value", vi.fn(), vi.fn()]);
-
-      const { result, rerender } = renderHook(() =>
-        useLocalDb("test-key", "default", isString)
-      );
-
-      const initialSetter = result.current[1];
-      rerender();
-      rerender();
-
-      expect(result.current[1]).toBe(initialSetter);
-    });
-
-    it("returns a new setter reference when key changes", () => {
-      mockReadLocalStorageValue.mockReturnValue("value");
-      mockUseLocalStorage.mockReturnValue(["value", vi.fn(), vi.fn()]);
-
-      const { result, rerender } = renderHook(
-        ({ k }: { k: string }) => useLocalDb(k, "default", isString),
-        { initialProps: { k: "key-a" } }
-      );
-
-      const initialSetter = result.current[1];
-      rerender({ k: "key-b" });
-
-      expect(result.current[1]).not.toBe(initialSetter);
-    });
-  });
-
-  describe("write-failure handling", () => {
-    // happy-dom's window.localStorage isn't a real Storage instance whose
-    // methods can be spied via the prototype, and `vi.spyOn` on the live
-    // localStorage object errors with "property is not defined." Replace the
-    // global with a hand-rolled mock for each test instead and restore via
-    // vi.unstubAllGlobals.
-    let setItemMock: ReturnType<typeof vi.fn>;
-
-    const useFakeLocalStorage = (
-      impl: (key: string, value: string) => void
-    ) => {
-      setItemMock = vi.fn(impl);
-      vi.stubGlobal("localStorage", {
-        setItem: setItemMock,
-        getItem: vi.fn(),
-        removeItem: vi.fn(),
-        clear: vi.fn(),
-        key: vi.fn(),
-        length: 0,
-      });
-    };
-
-    afterEach(() => {
-      vi.clearAllMocks();
-      vi.unstubAllGlobals();
-    });
-
-    const setupHook = (key = "test-key", value: unknown = "stored-value") => {
-      // The wrapped setter now invokes Mantine's setValue with a function
-      // updater unconditionally; the mock must run that callback so the
-      // closed-over `resolved` is assigned before the synchronous probe.
-      const mockSetter = vi.fn((next: unknown) => {
-        if (typeof next === "function") {
-          // `as` justified: the callback is typed against the user's T, but
-          // the test mock is generic over `unknown`. We just need to invoke
-          // it with the current value to mirror Mantine's behavior.
-          (next as (prev: unknown) => unknown)(value);
-        }
-      });
-      const mockRemover = vi.fn();
-      mockReadLocalStorageValue.mockReturnValue(value);
-      mockUseLocalStorage.mockReturnValue([value, mockSetter, mockRemover]);
-      return { mockSetter, mockRemover, key };
-    };
-
-    it("skips onWriteFailed when the probe write succeeds", () => {
-      const { key, mockSetter } = setupHook();
-      const onWriteFailed = vi.fn();
-      useFakeLocalStorage(() => {
-        // Pretend the write succeeded.
-      });
-
-      const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
-      );
+  describe("setter (probedSetValue)", () => {
+    it("writes the JSON-serialized value to localStorage", () => {
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
 
       result.current[1]("next-value");
 
-      expect(onWriteFailed).not.toHaveBeenCalled();
-      expect(setItemMock).toHaveBeenCalledWith(
-        key,
+      expect(window.localStorage.getItem("k")).toBe(
         JSON.stringify("next-value")
       );
-      expect(mockSetter).toHaveBeenCalledTimes(1);
     });
 
-    it("forwards the error to onWriteFailed when the probe throws", () => {
-      const { key, mockSetter } = setupHook();
-      const onWriteFailed = vi.fn();
-      const quotaError = new DOMException("quota", "QuotaExceededError");
-      useFakeLocalStorage(() => {
-        throw quotaError;
-      });
-
+    it("supports function-updater form with prev = current parsed value", () => {
+      window.localStorage.setItem("counter", JSON.stringify(10));
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb<number>("counter", 0, isNumber)
       );
 
-      result.current[1]("next-value");
+      result.current[1]((prev) => prev + 5);
 
-      expect(onWriteFailed).toHaveBeenCalledTimes(1);
-      expect(onWriteFailed).toHaveBeenCalledWith(key, quotaError);
-      expect(mockSetter).toHaveBeenCalledTimes(1);
+      expect(window.localStorage.getItem("counter")).toBe(JSON.stringify(15));
     });
 
-    it("fires onWriteFailed at most once per consecutive failure streak per key (dedup)", () => {
-      const { key, mockSetter } = setupHook();
+    it("function-updater receives defaultValue when the key is absent", () => {
+      const { result } = renderHook(() =>
+        useLocalDb<number>("counter", 7, isNumber)
+      );
+
+      result.current[1]((prev) => prev * 2);
+
+      expect(window.localStorage.getItem("counter")).toBe(JSON.stringify(14));
+    });
+
+    it("dispatches a same-tab CustomEvent on a successful write", () => {
+      const listener = vi.fn<(event: Event) => void>();
+      window.addEventListener("memdeck-localstorage", listener);
+      try {
+        const { result } = renderHook(() =>
+          useLocalDb("k", "default", isString)
+        );
+
+        result.current[1]("next");
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        const event = listener.mock.calls[0]?.[0];
+        if (!(event instanceof CustomEvent)) {
+          throw new Error(
+            "expected memdeck-localstorage event to be a CustomEvent"
+          );
+        }
+        expect(event.detail).toEqual({ key: "k" });
+      } finally {
+        window.removeEventListener("memdeck-localstorage", listener);
+      }
+    });
+
+    it("returns a stable setter reference across re-renders for the same key", () => {
+      const { result, rerender } = renderHook(() =>
+        useLocalDb("k", "default", isString)
+      );
+      const initial = result.current[1];
+
+      rerender();
+      rerender();
+
+      expect(result.current[1]).toBe(initial);
+    });
+
+    it("returns a new setter when the key changes", () => {
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", isString),
+        { initialProps: { k: "a" } }
+      );
+      const initial = result.current[1];
+
+      rerender({ k: "b" });
+
+      expect(result.current[1]).not.toBe(initial);
+    });
+
+    // Pins the dispatchKeyChange throw-isolation contract: setItem succeeds
+    // but a synchronous listener throws → onSuccess fires, onWriteFailed
+    // does NOT fire, value is on disk. A future refactor that re-folds
+    // dispatch into the outer try/catch would silently regress to false
+    // write-failure toasts and a stuck dedup latch.
+    it("fires onSuccess (not onWriteFailed) when a same-tab listener throws after a successful write", () => {
+      const onSuccess = vi.fn();
       const onWriteFailed = vi.fn();
-      useFakeLocalStorage(() => {
-        throw new DOMException("quota", "QuotaExceededError");
+      const throwingListener = (): void => {
+        throw new Error("listener boom");
+      };
+      window.addEventListener("memdeck-localstorage", throwingListener);
+      try {
+        const { result } = renderHook(() =>
+          useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        );
+
+        expect(() =>
+          result.current[1]("next-value", { onSuccess })
+        ).not.toThrow();
+
+        expect(window.localStorage.getItem("k")).toBe(
+          JSON.stringify("next-value")
+        );
+        expect(onSuccess).toHaveBeenCalledTimes(1);
+        expect(onWriteFailed).not.toHaveBeenCalled();
+      } finally {
+        window.removeEventListener("memdeck-localstorage", throwingListener);
+      }
+    });
+  });
+
+  // Pins the safeJsonReviver prototype-pollution defense. The reviver strips
+  // `__proto__` / `constructor` / `prototype` keys at JSON.parse time so a
+  // tampered blob cannot pollute the prototype chain when a downstream
+  // consumer spreads the parsed value (`{ ...parsed }`). Without these
+  // tests, a future refactor that drops the reviver argument from
+  // JSON.parse, shortens the key list, or "simplifies" the function would
+  // silently re-open the prototype-pollution surface — every behavioral
+  // test still passes because the parsed VALUE is structurally fine; only
+  // the prototype chain is poisoned.
+  describe("safeJsonReviver / prototype pollution", () => {
+    type Bag = Record<string, unknown>;
+    const isBag = (value: unknown): value is Bag =>
+      typeof value === "object" && value !== null && !Array.isArray(value);
+
+    it("strips a top-level `__proto__` key without polluting Object.prototype", () => {
+      window.localStorage.setItem(
+        "k",
+        '{"__proto__":{"polluted":"yes"},"a":1}'
+      );
+
+      const { result } = renderHook(() => useLocalDb<Bag>("k", {}, isBag));
+      const parsed = result.current[0];
+
+      // Use Object.keys (own enumerable keys) — `in` walks the prototype
+      // chain and would mask a successful pollution.
+      expect(Object.keys(parsed)).not.toContain("polluted");
+      expect((parsed as Bag).polluted).toBeUndefined();
+      expect(parsed.a).toBe(1);
+      // The smoking-gun assertion: a brand-new {} must NOT have `polluted`
+      // anywhere in its prototype chain.
+      expect(({} as Bag).polluted).toBeUndefined();
+    });
+
+    it("strips a nested `__proto__` key", () => {
+      window.localStorage.setItem(
+        "k",
+        '{"a":{"__proto__":{"polluted":"yes"},"b":2}}'
+      );
+
+      const { result } = renderHook(() => useLocalDb<Bag>("k", {}, isBag));
+      const parsed = result.current[0];
+      const inner = parsed.a as Bag;
+
+      expect(Object.keys(inner)).not.toContain("polluted");
+      expect((inner as Bag).polluted).toBeUndefined();
+      expect(inner.b).toBe(2);
+      expect(({} as Bag).polluted).toBeUndefined();
+    });
+
+    it("strips `constructor` and `prototype` keys at any depth", () => {
+      window.localStorage.setItem(
+        "k",
+        '{"constructor":{"prototype":{"polluted":"yes"}},"prototype":"top","x":42}'
+      );
+
+      const { result } = renderHook(() => useLocalDb<Bag>("k", {}, isBag));
+      const parsed = result.current[0];
+
+      // Object.keys returns own enumerable keys — `"constructor" in parsed`
+      // would return true because of the inherited Object.prototype.constructor,
+      // but the reviver only strips own properties.
+      const ownKeys = Object.keys(parsed);
+      expect(ownKeys).not.toContain("constructor");
+      expect(ownKeys).not.toContain("prototype");
+      expect(parsed.x).toBe(42);
+      expect(({} as Bag).polluted).toBeUndefined();
+    });
+
+    it("preserves array elements (integer keys never match the strip list)", () => {
+      window.localStorage.setItem("items", JSON.stringify([1, 2, 3]));
+
+      const { result } = renderHook(() =>
+        useLocalDb<number[]>("items", [], isNumberArray)
+      );
+
+      expect(result.current[0]).toEqual([1, 2, 3]);
+    });
+  });
+
+  // Reset-on-write is the documented corruption-recovery path for low-stakes
+  // single-value consumers (see use-selected-stack.ts:34-37). Multi-record
+  // consumers like useStackLimits gate the setter at the consumer level.
+  // The wrapper itself must NOT block writes when storage is corrupt — that
+  // would trap users in an unrecoverable state for stack/timer/etc.
+  describe("setter overwrites a corrupt blob (reset-on-write)", () => {
+    it("overwrites a typeguard-failing blob when the consumer calls the setter", () => {
+      window.localStorage.setItem("k", JSON.stringify(42));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+
+      result.current[1]("recovered");
+
+      expect(window.localStorage.getItem("k")).toBe(
+        JSON.stringify("recovered")
+      );
+    });
+
+    it("overwrites an unparseable blob when the consumer calls the setter", () => {
+      window.localStorage.setItem("k", "{not valid");
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+
+      result.current[1]("recovered");
+
+      expect(window.localStorage.getItem("k")).toBe(
+        JSON.stringify("recovered")
+      );
+    });
+
+    it("function-updater receives defaultValue (not the corrupt parsed value) when the on-disk blob is corrupt", () => {
+      window.localStorage.setItem("counter", JSON.stringify("not a number"));
+      const { result } = renderHook(() =>
+        useLocalDb<number>("counter", 7, isNumber)
+      );
+
+      result.current[1]((prev) => prev + 1);
+
+      expect(window.localStorage.getItem("counter")).toBe(JSON.stringify(8));
+    });
+  });
+
+  describe("removeValue", () => {
+    it("removes the key from localStorage", () => {
+      window.localStorage.setItem("k", JSON.stringify("v"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+
+      result.current[2]();
+
+      expect(window.localStorage.getItem("k")).toBeNull();
+    });
+
+    it("dispatches the same-tab CustomEvent so peer subscribers re-read", () => {
+      window.localStorage.setItem("k", JSON.stringify("v"));
+      const listener = vi.fn<(event: Event) => void>();
+      window.addEventListener("memdeck-localstorage", listener);
+      try {
+        const { result } = renderHook(() =>
+          useLocalDb("k", "default", isString)
+        );
+
+        result.current[2]();
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        const event = listener.mock.calls[0]?.[0];
+        if (!(event instanceof CustomEvent)) {
+          throw new Error(
+            "expected memdeck-localstorage event to be a CustomEvent"
+          );
+        }
+        expect(event.detail).toEqual({ key: "k" });
+      } finally {
+        window.removeEventListener("memdeck-localstorage", listener);
+      }
+    });
+
+    it("does not throw when removeItem itself throws", () => {
+      window.localStorage.setItem("k", JSON.stringify("v"));
+      removeItemMock.mockImplementation(() => {
+        throw new DOMException("removeItem blocked", "SecurityError");
+      });
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+
+      expect(() => result.current[2]()).not.toThrow();
+    });
+  });
+
+  describe("reactivity", () => {
+    it("updates same-tab peer subscribers when one consumer writes", () => {
+      const { result } = renderHook(() => ({
+        a: useLocalDb("k", "default", isString),
+        b: useLocalDb("k", "default", isString),
+      }));
+
+      expect(result.current.a[0]).toBe("default");
+      expect(result.current.b[0]).toBe("default");
+
+      act(() => {
+        result.current.a[1]("hello");
+      });
+
+      expect(result.current.a[0]).toBe("hello");
+      expect(result.current.b[0]).toBe("hello");
+    });
+
+    it("updates on a cross-tab `storage` event", () => {
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("default");
+
+      act(() => {
+        window.localStorage.setItem("k", JSON.stringify("from-other-tab"));
+        // happy-dom doesn't fire `storage` for the writing tab; dispatching
+        // manually simulates the cross-tab notification.
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: "k",
+            newValue: JSON.stringify("from-other-tab"),
+            storageArea: window.localStorage,
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe("from-other-tab");
+    });
+
+    it("falls back to defaultValue when storage.clear() arrives via storage event (key === null)", () => {
+      window.localStorage.setItem("k", JSON.stringify("hello"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("hello");
+
+      act(() => {
+        window.localStorage.removeItem("k");
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: null,
+            newValue: null,
+            storageArea: window.localStorage,
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe("default");
+    });
+  });
+
+  describe("write failures", () => {
+    // The outer beforeEach already stubs window.localStorage and exposes
+    // setItemMock. These tests just override its implementation to throw.
+    const quotaError = (): DOMException =>
+      new DOMException("quota", "QuotaExceededError");
+
+    it("forwards quota errors to onWriteFailed", () => {
+      const onWriteFailed = vi.fn();
+      const err = quotaError();
+      setItemMock.mockImplementation(() => {
+        throw err;
       });
 
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+      );
+
+      result.current[1]("next");
+
+      expect(onWriteFailed).toHaveBeenCalledTimes(1);
+      expect(onWriteFailed).toHaveBeenCalledWith("k", err);
+    });
+
+    it("dedup: fires onWriteFailed once across consecutive failures for the same key", () => {
+      const onWriteFailed = vi.fn();
+      setItemMock.mockImplementation(() => {
+        throw quotaError();
+      });
+
+      const { result } = renderHook(() =>
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
       );
 
       result.current[1]("a");
@@ -871,28 +1060,23 @@ describe("useLocalDb", () => {
 
       expect(onWriteFailed).toHaveBeenCalledTimes(1);
       expect(setItemMock).toHaveBeenCalledTimes(3);
-      expect(mockSetter).toHaveBeenCalledTimes(3);
     });
 
-    it("re-fires onWriteFailed after a successful write resets the streak", () => {
-      const { key, mockSetter } = setupHook();
+    it("re-fires after a successful write resets the streak", () => {
       const onWriteFailed = vi.fn();
-      const quotaError = new DOMException("quota", "QuotaExceededError");
-      const setItemImpl = vi
-        .fn<(k: string, v: string) => void>()
+      setItemMock
         .mockImplementationOnce(() => {
-          throw quotaError;
+          throw quotaError();
         })
         .mockImplementationOnce(() => {
-          // Pretend success — should reset the dedup streak.
+          // Pretend the second write succeeded — should reset the dedup latch.
         })
         .mockImplementationOnce(() => {
-          throw quotaError;
+          throw quotaError();
         });
-      useFakeLocalStorage((k, v) => setItemImpl(k, v));
 
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
       );
 
       result.current[1]("a");
@@ -900,23 +1084,12 @@ describe("useLocalDb", () => {
       result.current[1]("c");
 
       expect(onWriteFailed).toHaveBeenCalledTimes(2);
-      expect(setItemMock).toHaveBeenCalledTimes(3);
-      expect(mockSetter).toHaveBeenCalledTimes(3);
     });
 
-    it("fires onWriteFailed independently for each key (dedup resets on key change)", () => {
-      mockReadLocalStorageValue.mockReturnValue("v");
-      // Mantine-mirroring setter: invoke the callback so the probe runs.
-      const mockSetter = vi.fn((next: unknown) => {
-        if (typeof next === "function") {
-          // `as` justified: see setupHook — generic test mock over `unknown`.
-          (next as (prev: unknown) => unknown)("v");
-        }
-      });
-      mockUseLocalStorage.mockReturnValue(["v", mockSetter, vi.fn()]);
+    it("dedup resets when the key changes", () => {
       const onWriteFailed = vi.fn();
-      useFakeLocalStorage(() => {
-        throw new DOMException("quota", "QuotaExceededError");
+      setItemMock.mockImplementation(() => {
+        throw quotaError();
       });
 
       const { result, rerender } = renderHook(
@@ -942,188 +1115,80 @@ describe("useLocalDb", () => {
       );
     });
 
-    it("resolves function-updater payloads against the current value for the probe", () => {
-      mockReadLocalStorageValue.mockReturnValue(10);
-      // Mirror Mantine: invoke the callback with the current value so the
-      // closed-over `resolved` is populated before the probe runs.
-      const mockSetter = vi.fn((next: unknown) => {
-        if (typeof next === "function") {
-          // `as` justified: see setupHook — generic test mock over `unknown`.
-          (next as (prev: number) => number)(10);
-        }
-      });
-      mockUseLocalStorage.mockReturnValue([10, mockSetter, vi.fn()]);
-      useFakeLocalStorage(() => {
-        // Pretend success.
-      });
-
-      const { result } = renderHook(() =>
-        useLocalDb<number>("counter", 0, isNumber)
-      );
-
-      result.current[1]((prev) => prev + 5);
-
-      expect(setItemMock).toHaveBeenCalledWith("counter", JSON.stringify(15));
-    });
-
     it("does not throw when no onWriteFailed callback is provided", () => {
-      setupHook();
-      useFakeLocalStorage(() => {
-        throw new DOMException("quota", "QuotaExceededError");
+      setItemMock.mockImplementation(() => {
+        throw quotaError();
       });
 
-      const { result } = renderHook(() =>
-        useLocalDb("test-key", "default", isString)
-      );
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
 
       expect(() => result.current[1]("next")).not.toThrow();
       expect(() => result.current[1]("again")).not.toThrow();
     });
 
     it("isolates onWriteFailed exceptions: setter does not throw and dedup latch is still set", () => {
-      // Realistic failure mode: i18next.t or notifications.show could throw
-      // (e.g. provider not yet mounted). The wrapped setter must swallow the
+      // Realistic failure mode: notifications.show could throw if the
+      // provider isn't mounted yet. The wrapped setter must swallow the
       // callback exception so the consumer's UI handler doesn't crash, AND
-      // the dedup latch must still register so the next failure doesn't
+      // the dedup latch must still register so a second failure doesn't
       // re-fire telemetry on every render.
-      const { key } = setupHook();
       const onWriteFailed = vi.fn(() => {
         throw new Error("notifications provider not mounted");
       });
-      useFakeLocalStorage(() => {
-        throw new DOMException("quota", "QuotaExceededError");
+      setItemMock.mockImplementation(() => {
+        throw quotaError();
       });
 
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
       );
 
       expect(() => result.current[1]("next")).not.toThrow();
-      // Second consecutive failure with the same key: dedup latch was set on
-      // the first call despite the callback throwing, so onWriteFailed is
-      // not invoked again.
       expect(() => result.current[1]("again")).not.toThrow();
 
       expect(onWriteFailed).toHaveBeenCalledTimes(1);
     });
 
-    it("does not write the literal string 'undefined' when the updater is deferred", () => {
-      // Regression for the eager-state-skipped path. React calls setState
-      // updaters lazily when there are pending lanes on the fiber (e.g.
-      // chained setters in one handler). The previous implementation read a
-      // closure variable assigned inside the updater AFTER `setValue` returned;
-      // on the deferred path the variable was still `undefined` and the
-      // probe wrote `JSON.stringify(undefined)` (i.e. the string "undefined")
-      // to localStorage. Moving the probe inside the updater eliminates the
-      // race: if the updater never runs, neither does the probe.
-      mockReadLocalStorageValue.mockReturnValue("v");
-      const deferredSetter = vi.fn(() => {
-        // Mimic React skipping eager state computation: store the updater
-        // for later (or drop it entirely). Either way, the updater MUST NOT
-        // fire synchronously inside this mock.
-      });
-      mockUseLocalStorage.mockReturnValue(["v", deferredSetter, vi.fn()]);
-      useFakeLocalStorage(() => {
-        // Should never be called — the deferred setter never invokes the
-        // updater that owns the probe.
-      });
-
-      const { result } = renderHook(() =>
-        useLocalDb("test-key", "default", isString)
-      );
-
-      result.current[1]("next-value");
-
-      expect(deferredSetter).toHaveBeenCalledTimes(1);
-      expect(setItemMock).not.toHaveBeenCalled();
-      // Belt-and-braces: even if a future mock change invokes setItem, the
-      // wrong-shaped argument we are guarding against is the string
-      // "undefined". Make that assertion explicit.
-      const calledWithUndefinedString = setItemMock.mock.calls.some(
-        (args) => args[1] === "undefined"
-      );
-      expect(calledWithUndefinedString).toBe(false);
-    });
-
-    it("fires onSuccess once when the probe write succeeds", () => {
-      const { key } = setupHook();
-      const onSuccess = vi.fn();
-      useFakeLocalStorage(() => {
-        // Pretend success.
-      });
-
-      const { result } = renderHook(() => useLocalDb(key, "default", isString));
-
-      result.current[1]("next-value", { onSuccess });
-
-      expect(onSuccess).toHaveBeenCalledTimes(1);
-    });
-
-    it("does not fire onSuccess when the probe write throws", () => {
-      const { key } = setupHook();
+    it("does not fire onSuccess when the write throws", () => {
       const onSuccess = vi.fn();
       const onWriteFailed = vi.fn();
-      useFakeLocalStorage(() => {
-        throw new DOMException("quota", "QuotaExceededError");
+      setItemMock.mockImplementation(() => {
+        throw quotaError();
       });
 
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
       );
 
-      result.current[1]("next-value", { onSuccess });
+      result.current[1]("next", { onSuccess });
 
       expect(onSuccess).not.toHaveBeenCalled();
       expect(onWriteFailed).toHaveBeenCalledTimes(1);
     });
 
     it("isolates onSuccess exceptions: setter does not throw and onWriteFailed is not invoked", () => {
-      // Mirror of the onWriteFailed isolation test for the success path.
-      const { key } = setupHook();
       const onSuccess = vi.fn(() => {
         throw new Error("downstream emit threw");
       });
       const onWriteFailed = vi.fn();
-      useFakeLocalStorage(() => {
-        // Pretend success.
-      });
 
       const { result } = renderHook(() =>
-        useLocalDb(key, "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, undefined, onWriteFailed)
       );
 
       expect(() => result.current[1]("next", { onSuccess })).not.toThrow();
       expect(onSuccess).toHaveBeenCalledTimes(1);
       expect(onWriteFailed).not.toHaveBeenCalled();
     });
+  });
 
-    it("fires onSuccess at most once even if the updater runs twice (StrictMode)", () => {
-      // React StrictMode invokes setState updaters twice in development to
-      // surface impurity. The wrapped setter must dedup outcomes per logical
-      // call so onSuccess (which typically emits analytics) doesn't double-fire.
-      mockReadLocalStorageValue.mockReturnValue("v");
-      const doubleInvokeSetter = vi.fn((next: unknown) => {
-        if (typeof next === "function") {
-          // `as` justified: see setupHook — generic test mock over `unknown`.
-          (next as (prev: unknown) => unknown)("v");
-          (next as (prev: unknown) => unknown)("v");
-        }
-      });
-      mockUseLocalStorage.mockReturnValue(["v", doubleInvokeSetter, vi.fn()]);
+  describe("onSuccess", () => {
+    it("fires once per successful setter call", () => {
       const onSuccess = vi.fn();
-      useFakeLocalStorage(() => {
-        // Pretend success on every call.
-      });
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
 
-      const { result } = renderHook(() =>
-        useLocalDb("test-key", "default", isString)
-      );
+      result.current[1]("next", { onSuccess });
 
-      result.current[1]("next-value", { onSuccess });
-
-      // The updater itself may run twice (setItem may be called twice —
-      // that's React's prerogative under StrictMode), but the user-visible
-      // outcome callback only fires once per setter invocation.
       expect(onSuccess).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -1,5 +1,11 @@
-import { readLocalStorageValue, useLocalStorage } from "@mantine/hooks";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { readLocalStorageValue } from "@mantine/hooks";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
 
 /**
  * Result of probing a localStorage key: distinguishes "key absent" from "key
@@ -91,27 +97,162 @@ type UseLocalDbSetter<T> = (
   options?: UseLocalDbSetOptions
 ) => void;
 
+// Same-tab fan-out: when one `useLocalDb` instance writes, others on the
+// same key need to re-read. The native `storage` event only fires in OTHER
+// tabs, so we dispatch our own custom event for in-tab subscribers.
+const LOCAL_STORAGE_EVENT = "memdeck-localstorage";
+
+type LocalStorageEventDetail = { key: string };
+
+const isLocalStorageEvent = (
+  event: Event
+): event is CustomEvent<LocalStorageEventDetail> => {
+  if (!(event instanceof CustomEvent)) {
+    return false;
+  }
+  const detail: unknown = event.detail;
+  if (typeof detail !== "object" || detail === null) {
+    return false;
+  }
+  if (!("key" in detail)) {
+    return false;
+  }
+  return typeof detail.key === "string";
+};
+
+const readRawValue = (key: string): string | null => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch (error) {
+    if (import.meta.env.DEV) {
+      console.warn(`[localStorage] Read failed for key "${key}":`, error);
+    }
+    // Mirrors Mantine's silent-fallback for storage-blocked environments
+    // (Safari ITP, private mode). Read errors collapse to "absent" — the
+    // wrapper has no recoverable signal to surface from this path. Callers
+    // that need to distinguish "key absent" from "read errored" (e.g.
+    // `useStackLimits`) call `probeStoredValue` directly, which preserves
+    // the read-error status because it captures the throw at its own
+    // try/catch boundary rather than collapsing it to null here.
+    return null;
+  }
+};
+
+// Defense-in-depth against prototype pollution: a tampered blob containing
+// `__proto__`, `constructor`, or `prototype` keys would otherwise survive
+// `JSON.parse` as own properties and re-attach to a real prototype the
+// moment a consumer spreads the parsed value (`{ ...parsed }`). Stripping
+// at parse time gives every consumer the guarantee uniformly. The reviver
+// returning `undefined` deletes the key from the parsed result.
+const safeJsonReviver = (key: string, value: unknown): unknown => {
+  if (key === "__proto__" || key === "constructor" || key === "prototype") {
+    return;
+  }
+  return value;
+};
+
+const parseRawValue = <T>(
+  raw: string | null,
+  validate: (value: unknown) => value is T
+): StoredValueProbe<T> => {
+  if (raw === null) {
+    return { status: "absent" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw, safeJsonReviver);
+  } catch {
+    // Malformed JSON: classify as corrupt with the raw bytes preserved for
+    // telemetry. Mirrors `probeStoredValue` semantics (where Mantine's
+    // `deserializeJSON` catches the parse error and the validator then fails
+    // on the still-string value).
+    return { status: "corrupt", raw };
+  }
+  try {
+    if (validate(parsed)) {
+      return { status: "valid", value: parsed };
+    }
+    return { status: "corrupt", raw: parsed };
+  } catch (error) {
+    return { status: "read-error", error };
+  }
+};
+
+const subscribeToKey = (key: string, onChange: () => void): (() => void) => {
+  const onStorage = (event: StorageEvent): void => {
+    // `event.key === null` is fired by `localStorage.clear()` in cross-tab
+    // scenarios — re-read the snapshot regardless because our key may have
+    // been wiped.
+    if (event.key === null || event.key === key) {
+      onChange();
+    }
+  };
+  const onCustom = (event: Event): void => {
+    if (isLocalStorageEvent(event) && event.detail.key === key) {
+      onChange();
+    }
+  };
+  window.addEventListener("storage", onStorage);
+  window.addEventListener(LOCAL_STORAGE_EVENT, onCustom);
+  return () => {
+    window.removeEventListener("storage", onStorage);
+    window.removeEventListener(LOCAL_STORAGE_EVENT, onCustom);
+  };
+};
+
+const dispatchKeyChange = (key: string): void => {
+  window.dispatchEvent(
+    new CustomEvent<LocalStorageEventDetail>(LOCAL_STORAGE_EVENT, {
+      detail: { key },
+    })
+  );
+};
+
+// `useSyncExternalStore` requires a server snapshot for SSR safety. memdeck
+// is an SPA, but the prerender pass runs in a real browser context with a
+// usable `window` — so this null is only consulted in non-browser
+// environments (test-only edge cases) and the mount snapshot will read the
+// real value once `window` is present.
+const getServerSnapshot = (): null => null;
+
 /**
- * A wrapper around Mantine's useLocalStorage with error handling.
- * Supports any JSON-serializable type (string, number, boolean, object, array).
+ * A reactive wrapper around `localStorage` for JSON-serializable values.
  *
- * Pass `onCorrupt` to be notified when the stored value exists but cannot be
- * validated (or the read itself fails). Without it, the hook silently falls
- * back to `defaultValue` and any corrupt state is overwritten on the next
- * write — destroying potentially recoverable data with no signal to the
- * caller. Callers that own recoverable state should provide a callback so
- * they can surface a breadcrumb / telemetry event before the overwrite.
+ * **Critical invariant:** never overwrites the on-disk blob as a side-effect
+ * of mounting. Mantine's `useLocalStorage` previously wrote the
+ * deserialize-fallback (e.g. `{}`) back to disk on mount, which silently
+ * destroyed corrupt-but-recoverable state before any consumer-level
+ * corrupt-lock could fire (issue #639). This implementation reads via
+ * `useSyncExternalStore` and writes only when the consumer-supplied setter
+ * is called.
  *
- * Pass `onWriteFailed` to be notified when a write to localStorage throws
- * (quota exceeded, Safari private mode, ITP eviction). Mantine's setter
- * silently swallows these errors; the wrapper re-runs the write inside the
- * Mantine state-updater closure to detect the failure synchronously with
- * the resolved value.
+ * **Reset-on-write recovery is the wrapper's only corruption discipline.**
+ * The setter does not refuse writes when the on-disk blob is corrupt —
+ * single-value consumers (`useSelectedStack`, timer settings, etc.) rely
+ * on the next user interaction overwriting corrupt bytes. Multi-record
+ * consumers that cannot tolerate that (`useStackLimits`) gate the setter
+ * at the consumer level (see `use-stack-limits.ts:50-58, 95`).
+ *
+ * Pass `onCorrupt` to be notified when the stored value exists but cannot
+ * be validated (the type guard returned `false`, or the type guard itself
+ * threw). Storage-layer read errors (Safari ITP, private mode) collapse
+ * to "absent" — `onCorrupt` is NOT fired for those. Consumers that need
+ * to distinguish "absent" from "read errored" call `probeStoredValue`
+ * directly. Without `onCorrupt`, the hook silently falls back to
+ * `defaultValue`.
+ *
+ * Pass `onWriteFailed` to be notified when a write throws (quota exceeded,
+ * Safari private mode, ITP eviction).
  *
  * The returned setter accepts an optional `{ onSuccess }` so callers can
  * gate side effects (analytics emits, navigation) on a real persisted
- * write rather than the silent-success path Mantine presents after a
- * quota failure.
+ * write rather than the silent-success path that the old Mantine setter
+ * presented after a quota failure.
+ *
+ * Cross-tab sync: the native `storage` event fires re-renders in other
+ * tabs. Same-tab sync (multiple `useLocalDb` instances on the same key)
+ * goes through a project-internal `memdeck-localstorage` `CustomEvent`
+ * dispatched on every write.
  */
 export const useLocalDb = <T>(
   key: string,
@@ -120,58 +261,59 @@ export const useLocalDb = <T>(
   onCorrupt?: (key: string, error: unknown) => void,
   onWriteFailed?: (key: string, error: unknown) => void
 ): [T, UseLocalDbSetter<T>, () => void] => {
-  // Probe state, lazy at mount and re-computed on `key` change via the
-  // React-recommended set-state-during-render pattern. Bundling key+probe
-  // together lets us re-probe synchronously and avoid a one-render lag in
-  // `storedDefault` on key change.
-  const [probeState, setProbeState] = useState<{
-    key: string;
-    probe: StoredValueProbe<T>;
-  }>(() => ({ key, probe: probeStoredValue(key, validate) }));
+  // Subscribe + snapshot for `useSyncExternalStore`. `subscribe` re-attaches
+  // listeners when `key` changes; `getSnapshot` returns the raw string so
+  // React's stable-snapshot equality (Object.is) compares cheaply by string
+  // identity rather than re-parsing on every render.
+  const subscribe = useCallback(
+    (onChange: () => void): (() => void) => subscribeToKey(key, onChange),
+    [key]
+  );
+  const getSnapshot = useCallback(
+    (): string | null => readRawValue(key),
+    [key]
+  );
+  const rawValue = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot
+  );
 
-  let probe = probeState.probe;
-  if (probeState.key !== key) {
-    probe = probeStoredValue(key, validate);
-    setProbeState({ key, probe });
-  }
+  // Parse + validate. Memoizing on (rawValue, validate) keeps `probe` (and
+  // therefore the consumer-facing `value`) referentially stable when nothing
+  // on disk has changed, even across unrelated parent re-renders.
+  const probe = useMemo<StoredValueProbe<T>>(
+    () => parseRawValue(rawValue, validate),
+    [rawValue, validate]
+  );
 
   // Dedup sentinel: tracks the storage key for which we've already invoked
   // `onCorrupt`. Without this, a 1Hz-timer page (e.g. Distance/Flashcard) on
-  // a corrupt key would fire telemetry on every render. The deserialize
-  // callback shares this ref so a transient corrupt event doesn't double-fire
-  // from probe + deserialize for the same key.
+  // a corrupt key would fire telemetry on every render.
   const reportedKeyRef = useRef<string | null>(null);
 
   // Mirror dedup for write failures: at most one `onWriteFailed` per failure
-  // streak per key. Without it, a page that retries a setter (e.g. user
-  // mashing a toggle on a quota-exceeded device) would fire a telemetry storm
-  // and stack identical toasts. Streaks reset on a successful write so a
-  // recovery-then-new-failure case still surfaces (write A fails → user
-  // clears space → write B succeeds → ref clears → write C fails fires again).
+  // streak per key. Streaks reset on a successful write so a recovery-then-
+  // new-failure case still surfaces.
   const reportedWriteKeyRef = useRef<string | null>(null);
 
-  // Capture latest onCorrupt in a ref so the deserialize closure (created
-  // once for the lifetime of useLocalStorage) can see the current callback
-  // without having to re-create the hook config.
+  // Capture latest callbacks in refs so the setter / effect closures stay
+  // stable regardless of whether the caller passes inline arrows.
   const onCorruptRef = useRef(onCorrupt);
   useEffect(() => {
     onCorruptRef.current = onCorrupt;
   }, [onCorrupt]);
 
-  // Same trick for onWriteFailed: keeps the wrapped setter's identity stable
-  // (consumers memoize on it) regardless of whether the caller passes an
-  // inline arrow.
   const onWriteFailedRef = useRef(onWriteFailed);
   useEffect(() => {
     onWriteFailedRef.current = onWriteFailed;
   }, [onWriteFailed]);
 
   // Fire onCorrupt at most once per mount per corrupt key, after render —
-  // never during render, which is what caused the per-render telemetry storm.
-  // Cross-key dedup falls out of the `current !== key` comparison: a
-  // transition from key-a to key-b leaves `reportedKeyRef.current === "key-a"`,
-  // which differs from the new `key`, so the effect re-fires for the new key.
-  // No explicit reset on key change is needed.
+  // never during render. Cross-key dedup falls out of the
+  // `current !== key` comparison: a transition from key-a to key-b leaves
+  // `reportedKeyRef.current === "key-a"`, which differs from the new `key`,
+  // so the effect re-fires for the new key.
   useEffect(() => {
     if (reportedKeyRef.current === key) {
       return;
@@ -189,71 +331,11 @@ export const useLocalDb = <T>(
     }
   }, [key, probe]);
 
-  const storedDefault = probe.status === "valid" ? probe.value : defaultValue;
+  const value = useMemo(
+    (): T => (probe.status === "valid" ? probe.value : defaultValue),
+    [probe, defaultValue]
+  );
 
-  const [value, setValue, removeValue] = useLocalStorage({
-    key,
-    defaultValue: storedDefault,
-    deserialize: (raw: string | undefined) => {
-      if (raw === undefined || raw === null) {
-        return storedDefault;
-      }
-      try {
-        const parsed: unknown = JSON.parse(raw);
-        if (validate(parsed)) {
-          return parsed;
-        }
-        // Validation failure on cross-tab/storage-event read: surface to
-        // telemetry (deduped via reportedKeyRef so we don't double-fire
-        // alongside the mount-time probe report).
-        if (reportedKeyRef.current !== key) {
-          reportedKeyRef.current = key;
-          onCorruptRef.current?.(key, raw);
-        }
-        if (import.meta.env.DEV) {
-          console.warn(
-            `[localStorage] Validation failed for key "${key}":`,
-            parsed
-          );
-        }
-        return storedDefault;
-      } catch (error) {
-        if (reportedKeyRef.current !== key) {
-          reportedKeyRef.current = key;
-          onCorruptRef.current?.(key, error);
-        }
-        if (import.meta.env.DEV) {
-          console.warn(
-            `[localStorage] Deserialize failed for key "${key}":`,
-            error
-          );
-        }
-        return storedDefault;
-      }
-    },
-  });
-
-  // The probe write **must** run inside Mantine's state updater so it shares
-  // lexical scope with `resolved`. React's eager-state optimisation only fires
-  // when the fiber has no pending lanes; any queued update on the same fiber
-  // (a prior setState in the same handler, an effect-driven update mid-render)
-  // defers the updater to commit. If the probe sat outside the closure,
-  // `resolved` would be `undefined` on the deferred path and
-  // `JSON.stringify(undefined)` would coerce to `"undefined"`, silently
-  // corrupting the persisted value.
-  //
-  // The user-visible callbacks (`onSuccess`, `onWriteFailed`), however, run
-  // AFTER `setValue` returns — outside the updater closure — so React's purity
-  // contract for state-updater functions stays intact. We capture the probe
-  // outcome in a closure variable, then dispatch callbacks once the updater
-  // has resolved. The `outcome === null` guard makes the setItem idempotent
-  // across StrictMode double-invokes and concurrent rebases (only the first
-  // run records the outcome).
-  //
-  // TODO: Mantine's own setItem still runs after our probe, so each call costs
-  // two `localStorage.setItem` writes plus two `storage` events. Eliminating
-  // the duplicate would mean replacing Mantine's `useLocalStorage` with a
-  // local `useState`/`setItem` wrapper — out of scope for the silent-write fix.
   const handleWriteSuccess = useCallback(
     (onSuccess: (() => void) | undefined): void => {
       reportedWriteKeyRef.current = null;
@@ -293,52 +375,77 @@ export const useLocalDb = <T>(
     [key]
   );
 
-  const probedSetValue = useCallback(
-    (next: T | ((prev: T) => T), options?: UseLocalDbSetOptions): void => {
-      // Hold the outcome on an object so TypeScript doesn't narrow the
-      // closure variable to `null` by control-flow analysis (mutations
-      // through the setValue updater closure aren't tracked).
-      const outcomeBox: {
-        value: { ok: true } | { ok: false; error: unknown } | null;
-      } = { value: null };
-      setValue((prev) => {
-        const resolved =
-          typeof next === "function"
-            ? // `as` justified: typeof check cannot narrow T | ((prev: T) => T)
-              // to the function branch when T is unconstrained — TypeScript
-              // can't prove T isn't itself a function type. The hook's
-              // JSON-serializable contract makes the updater branch the only
-              // inhabitant in practice.
-              (next as (prev: T) => T)(prev)
-            : next;
-        if (outcomeBox.value === null) {
-          try {
-            localStorage.setItem(key, JSON.stringify(resolved));
-            outcomeBox.value = { ok: true };
-          } catch (error) {
-            outcomeBox.value = { ok: false, error };
-          }
-        }
-        return resolved;
-      });
+  const probedSetValue = useCallback<UseLocalDbSetter<T>>(
+    (next, options): void => {
+      // Reset-on-write is the corruption-recovery path for low-stakes
+      // single-value consumers (see use-selected-stack.ts:34-37 and
+      // use-timer-settings.ts:63-66): a corrupt blob is overwritten by the
+      // next user interaction. Multi-record consumers that can't tolerate
+      // that — namely useStackLimits, where one byte-flip would otherwise
+      // destroy every other stack's saved range — gate writes at the
+      // CONSUMER level (use-stack-limits.ts:50-58, 95). Don't add a
+      // wrapper-level corrupt-lock here: it would silently break recovery
+      // for the single-value consumers without buying any new protection
+      // for the multi-record ones.
+      const currentProbe = parseRawValue(readRawValue(key), validate);
+      const prev =
+        currentProbe.status === "valid" ? currentProbe.value : defaultValue;
+      const resolved =
+        typeof next === "function"
+          ? // `as` justified: typeof check cannot narrow `T | ((prev: T) => T)`
+            // to the function branch when T is unconstrained — TypeScript
+            // can't prove T isn't itself a function type. The hook's
+            // JSON-serializable contract makes the updater branch the only
+            // inhabitant in practice.
+            (next as (prev: T) => T)(prev)
+          : next;
 
-      // If the updater was deferred (concurrent transition) `outcome` may be
-      // null here. All current call sites invoke this from event handlers,
-      // where React 18 flushes synchronously by the end of the handler, so
-      // this branch is defensive — skip user callbacks rather than firing
-      // them with stale info.
-      const outcome = outcomeBox.value;
-      if (outcome === null) {
+      // Persistence is the only thing whose failure should surface as a
+      // write failure. A throw from `dispatchKeyChange` (or from a
+      // synchronous listener it triggers) AFTER `setItem` already
+      // persisted is an event-bus glitch, not a storage failure — folding
+      // it into `handleWriteFailure` would falsely fire the user-facing
+      // failure toast, skip `onSuccess` (e.g. analytics emits), and stick
+      // the dedup latch so a subsequent real write failure on the same
+      // key would be silently suppressed.
+      //
+      // Cost of accepting the dispatch throw silently: same-tab subscribers
+      // (including this hook instance) keep stale state until the next
+      // unrelated re-render triggers `getSnapshot`. The native `storage`
+      // event does not fire same-tab, so the custom event is the only
+      // same-tab sync path. We accept that stale-render window because it
+      // is strictly less harmful than a false write-failure toast plus a
+      // dedup latch that masks the next real failure.
+      try {
+        window.localStorage.setItem(key, JSON.stringify(resolved));
+      } catch (error) {
+        handleWriteFailure(error);
         return;
       }
-      if (outcome.ok) {
-        handleWriteSuccess(options?.onSuccess);
-        return;
+      try {
+        dispatchKeyChange(key);
+      } catch (dispatchError) {
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[localStorage] dispatchKeyChange threw for key "${key}":`,
+            dispatchError
+          );
+        }
       }
-      handleWriteFailure(outcome.error);
+      handleWriteSuccess(options?.onSuccess);
     },
-    [setValue, key, handleWriteSuccess, handleWriteFailure]
+    [key, validate, defaultValue, handleWriteSuccess, handleWriteFailure]
   );
+
+  const removeValue = useCallback((): void => {
+    try {
+      window.localStorage.removeItem(key);
+      dispatchKeyChange(key);
+    } catch {
+      // No caller currently surfaces remove failures (no `onSuccess` wired
+      // through remove), so swallow to mirror prior Mantine behavior.
+    }
+  }, [key]);
 
   return [value, probedSetValue, removeValue];
 };


### PR DESCRIPTION
## Summary

Replaces Mantine's `useLocalStorage` inside `useLocalDb` with `useSyncExternalStore` plus a manual write path. The Mantine hook wrote its deserialize-fallback (e.g. `{}`) to disk during its mount effect, silently destroying corrupt-but-recoverable state before any consumer-level corrupt-lock could fire — the root cause of issue #639.

Key changes in `src/utils/localstorage.ts`:

- Read via `useSyncExternalStore` — never writes on mount.
- Write only when the consumer-supplied setter runs.
- Same-tab fan-out via a `memdeck-localstorage` `CustomEvent` (the native `storage` event only fires in *other* tabs).
- `safeJsonReviver` strips `__proto__` / `constructor` / `prototype` keys at parse time to defend against prototype pollution from tampered blobs.
- Setter splits persist-failure (`onWriteFailed`) from dispatch-failure (event-bus glitch, swallowed) so a same-tab listener throw can't masquerade as a quota error.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 1718/1718 passing, including new tests covering:
  - mount-time corrupt blob preservation (issue #639 regression)
  - `safeJsonReviver` prototype-pollution defense (top-level, nested, `constructor`/`prototype`)
  - setter dispatch-vs-persist failure split (listener throw fires `onSuccess`, not `onWriteFailed`)
  - `onWriteFailed` dedup-streak reset on success and on key change
  - validator-throw routing through the `read-error` branch
- [x] `pnpm exec ultracite check` on the four changed files (full-repo lint OOMs on this project, unrelated)
- [ ] `pnpm run test:e2e` — new e2e tests pin issue #639 on `useStackLimits` (multi-record consumer) and reset-on-write recovery on `memdeck-app-stack` (single-value consumer)

Closes #639