### PR TITLE
fix: gate settings side effects on localStorage persistence

### DIFF
--- a/src/hooks/use-timer-settings.test.ts
+++ b/src/hooks/use-timer-settings.test.ts
@@ -123,11 +123,50 @@ describe("useTimerSettings", () => {
       const { setTimerEnabled } = useTimerSettings(FLASHCARD_TIMER_LSK);
       setTimerEnabled(true);
 
-      expect(mockSetSettings).toHaveBeenCalledWith(expect.any(Function));
-
       const updater = mockSetSettings.mock.calls[0][0];
       const result = updater({ enabled: false, duration: 15 });
       expect(result).toEqual({ enabled: true, duration: 15 });
+    });
+
+    it("runs the caller's onSuccess when the timer setting is persisted", () => {
+      const setSettingsSucceeding = vi.fn(
+        (_updater: unknown, opts?: { onSuccess?: () => void }) => {
+          opts?.onSuccess?.();
+        }
+      );
+      mockedUseLocalDb.mockReturnValue([
+        { enabled: false, duration: 15 },
+        setSettingsSucceeding,
+        vi.fn(),
+      ]);
+
+      const { setTimerEnabled } = useTimerSettings(FLASHCARD_TIMER_LSK);
+      const onSuccess = vi.fn();
+      setTimerEnabled(true, { onSuccess });
+
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips the caller's onSuccess when the persisted write is rejected", () => {
+      // Mirrors useLocalDb's "failed write" path: the setter receives the
+      // updater and options as usual but skips invoking onSuccess. A buggy
+      // useTimerSettings that called onSuccess synchronously (instead of
+      // forwarding it to the inner setter) would fail this test.
+      // Receives the updater + options like the real setter, but never
+      // invokes onSuccess (mirrors a Mantine-swallowed quota-exceeded write).
+      const setSettingsRejecting = vi.fn();
+      mockedUseLocalDb.mockReturnValue([
+        { enabled: false, duration: 15 },
+        setSettingsRejecting,
+        vi.fn(),
+      ]);
+
+      const { setTimerEnabled } = useTimerSettings(FLASHCARD_TIMER_LSK);
+      const onSuccess = vi.fn();
+      setTimerEnabled(true, { onSuccess });
+
+      expect(setSettingsRejecting).toHaveBeenCalledTimes(1);
+      expect(onSuccess).not.toHaveBeenCalled();
     });
 
     it("disables the timer", () => {

--- a/src/hooks/use-timer-settings.ts
+++ b/src/hooks/use-timer-settings.ts
@@ -6,7 +6,7 @@ import type {
   SPOT_CHECK_TIMER_LSK,
 } from "../constants";
 import type { TimerDuration, TimerSettings } from "../types/timer";
-import { useLocalDb } from "../utils/localstorage";
+import { type UseLocalDbSetOptions, useLocalDb } from "../utils/localstorage";
 import {
   handleLocalDbWriteFailed,
   reportLocalDbCorruption,
@@ -41,7 +41,7 @@ export const isTimerSettings = (value: unknown): value is TimerSettings =>
 
 export type UseTimerSettingsResult = {
   timerSettings: TimerSettings;
-  setTimerEnabled: (enabled: boolean) => void;
+  setTimerEnabled: (enabled: boolean, options?: UseLocalDbSetOptions) => void;
   setTimerDuration: (duration: TimerDuration) => void;
 };
 
@@ -73,11 +73,14 @@ export const useTimerSettings = (
   );
 
   const setTimerEnabled = useCallback(
-    (enabled: boolean): void => {
-      setTimerSettings((prev) => ({
-        ...prev,
-        enabled,
-      }));
+    (enabled: boolean, options?: UseLocalDbSetOptions): void => {
+      setTimerSettings(
+        (prev) => ({
+          ...prev,
+          enabled,
+        }),
+        options
+      );
     },
     [setTimerSettings]
   );

--- a/src/pages/acaan/acaan.tsx
+++ b/src/pages/acaan/acaan.tsx
@@ -18,13 +18,13 @@ import { TimerDisplay } from "../../components/timer-display";
 import { TimerSettingsControl } from "../../components/timer-settings-control";
 import { TrainingHeader } from "../../components/training-header";
 import { CARD_HEIGHT, CARD_WIDTH, SITE_URL } from "../../constants";
-import { useAcaanTimer } from "../../hooks/use-acaan-timer";
 import { useDocumentMeta } from "../../hooks/use-document-meta";
 import { useRequiredStack } from "../../hooks/use-selected-stack";
 import { useSession } from "../../hooks/use-session";
 import { analytics } from "../../services/analytics";
 import { formatCardName } from "../../utils/card-formatting";
 import { useAcaanGame } from "./use-acaan-game";
+import { useAcaanSettings } from "./use-acaan-settings";
 import { useCutDepthInput } from "./use-cut-depth-input";
 
 const breadcrumbSchema = {
@@ -73,19 +73,8 @@ export const Acaan = () => {
     revealAnswer,
   } = useAcaanGame(stackOrder, stackName, { onAnswer: handleAnswer });
 
-  const { timerSettings, setTimerEnabled, setTimerDuration } = useAcaanTimer();
-
-  const handleTimerEnabledChange = useCallback(
-    (enabled: boolean) => {
-      analytics.trackEvent(
-        "Settings",
-        `Timer ${enabled ? "Enabled" : "Disabled"}`,
-        "ACAAN"
-      );
-      setTimerEnabled(enabled);
-    },
-    [setTimerEnabled]
-  );
+  const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
+    useAcaanSettings();
 
   const handleRevealAnswer = useCallback(() => {
     analytics.trackFeatureUsed("Reveal Answer - ACAAN");

--- a/src/pages/acaan/use-acaan-settings.test.ts
+++ b/src/pages/acaan/use-acaan-settings.test.ts
@@ -1,0 +1,94 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGatedSetterMock } from "../../test-utils/mock-local-db-setter";
+
+let mockSetValueSucceeds = true;
+const succeeds = () => mockSetValueSucceeds;
+
+const mockSetTimerEnabled = createGatedSetterMock<boolean>(succeeds);
+const mockSetTimerDuration = vi.fn();
+const mockTrackEvent = vi.fn();
+
+vi.mock("../../hooks/use-acaan-timer", () => ({
+  useAcaanTimer: vi.fn(() => ({
+    timerSettings: { enabled: false, duration: 15 },
+    setTimerEnabled: mockSetTimerEnabled,
+    setTimerDuration: mockSetTimerDuration,
+  })),
+}));
+
+vi.mock("../../services/analytics", () => ({
+  analytics: {
+    trackEvent: mockTrackEvent,
+  },
+}));
+
+const { useAcaanSettings } = await import("./use-acaan-settings");
+
+describe("useAcaanSettings", () => {
+  let result: { current: ReturnType<typeof useAcaanSettings> };
+
+  beforeEach(() => {
+    mockSetValueSucceeds = true;
+    ({ result } = renderHook(() => useAcaanSettings()));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns timer settings from useAcaanTimer", () => {
+    expect(result.current.timerSettings).toEqual({
+      enabled: false,
+      duration: 15,
+    });
+  });
+
+  it("delegates setTimerDuration to useAcaanTimer", () => {
+    act(() => {
+      result.current.setTimerDuration(30);
+    });
+    expect(mockSetTimerDuration).toHaveBeenCalledWith(30);
+  });
+
+  describe("handleTimerEnabledChange", () => {
+    it("tracks analytics and persists when enabling the timer", () => {
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "Settings",
+        "Timer Enabled",
+        "ACAAN"
+      );
+    });
+
+    it("tracks analytics and persists when disabling the timer", () => {
+      act(() => {
+        result.current.handleTimerEnabledChange(false);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "Settings",
+        "Timer Disabled",
+        "ACAAN"
+      );
+    });
+
+    it("does not track analytics when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/pages/acaan/use-acaan-settings.ts
+++ b/src/pages/acaan/use-acaan-settings.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+import { useAcaanTimer } from "../../hooks/use-acaan-timer";
+import { analytics } from "../../services/analytics";
+import type { TimerDuration, TimerSettings } from "../../types/timer";
+
+type UseAcaanSettingsResult = {
+  timerSettings: TimerSettings;
+  setTimerDuration: (duration: TimerDuration) => void;
+  handleTimerEnabledChange: (enabled: boolean) => void;
+};
+
+export const useAcaanSettings = (): UseAcaanSettingsResult => {
+  const { timerSettings, setTimerEnabled, setTimerDuration } = useAcaanTimer();
+
+  const handleTimerEnabledChange = useCallback(
+    (enabled: boolean) => {
+      setTimerEnabled(enabled, {
+        onSuccess: () => {
+          analytics.trackEvent(
+            "Settings",
+            `Timer ${enabled ? "Enabled" : "Disabled"}`,
+            "ACAAN"
+          );
+        },
+      });
+    },
+    [setTimerEnabled]
+  );
+
+  return {
+    timerSettings,
+    setTimerDuration,
+    handleTimerEnabledChange,
+  };
+};

--- a/src/pages/distance/use-distance-settings.test.ts
+++ b/src/pages/distance/use-distance-settings.test.ts
@@ -5,6 +5,7 @@ import {
   DISTANCE_OPTION_LSK,
   DISTANCE_TIMER_LSK,
 } from "../../constants";
+import { createGatedSetterMock } from "../../test-utils/mock-local-db-setter";
 import {
   type DistanceConvention,
   type DistanceMode,
@@ -15,13 +16,21 @@ import {
 let currentMode: DistanceMode = "compute";
 let currentConvention: DistanceConvention = "cyclic";
 
-const mockSetMode = vi.fn((value: DistanceMode) => {
-  currentMode = value;
+// `mockSetValueSucceeds` gates all three setters together — flip to false
+// before a handler call to simulate a Mantine-swallowed quota-exceeded write.
+let mockSetValueSucceeds = true;
+const succeeds = () => mockSetValueSucceeds;
+
+const mockSetMode = createGatedSetterMock<DistanceMode>(succeeds, (v) => {
+  currentMode = v;
 });
-const mockSetConvention = vi.fn((value: DistanceConvention) => {
-  currentConvention = value;
-});
-const mockSetTimerEnabled = vi.fn();
+const mockSetConvention = createGatedSetterMock<DistanceConvention>(
+  succeeds,
+  (v) => {
+    currentConvention = v;
+  }
+);
+const mockSetTimerEnabled = createGatedSetterMock<boolean>(succeeds);
 const mockSetTimerDuration = vi.fn();
 const mockTrackEvent = vi.fn();
 const mockEmitDistanceModeChanged = vi.fn();
@@ -66,6 +75,7 @@ describe("useDistanceSettings", () => {
   beforeEach(() => {
     currentMode = "compute";
     currentConvention = "cyclic";
+    mockSetValueSucceeds = true;
 
     // Cast intentional: mockImplementation cannot satisfy generic useLocalDb<T> for multiple T.
     (mockedUseLocalDb.mockImplementation as (fn: unknown) => unknown)(
@@ -137,7 +147,10 @@ describe("useDistanceSettings", () => {
         act(() => {
           result.current.handleModeChange(value);
         });
-        expect(mockSetMode).toHaveBeenCalledWith(value);
+        expect(mockSetMode).toHaveBeenCalledWith(
+          value,
+          expect.objectContaining({ onSuccess: expect.any(Function) })
+        );
         expect(mockEmitDistanceModeChanged).toHaveBeenCalledWith({
           mode: value,
         });
@@ -146,6 +159,16 @@ describe("useDistanceSettings", () => {
     // Runtime input validation lives in DistanceSettingsContent, where the
     // SegmentedControl emits a raw string. By the time handleModeChange is
     // reached, the value is already narrowed to DistanceMode.
+
+    it("does not emit DISTANCE_MODE_CHANGED when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleModeChange("apply");
+      });
+      expect(mockSetMode).toHaveBeenCalledTimes(1);
+      expect(mockEmitDistanceModeChanged).not.toHaveBeenCalled();
+      expect(currentMode).toBe("compute");
+    });
   });
 
   describe("handleConventionChange", () => {
@@ -154,13 +177,26 @@ describe("useDistanceSettings", () => {
         act(() => {
           result.current.handleConventionChange(value);
         });
-        expect(mockSetConvention).toHaveBeenCalledWith(value);
+        expect(mockSetConvention).toHaveBeenCalledWith(
+          value,
+          expect.objectContaining({ onSuccess: expect.any(Function) })
+        );
         expect(mockEmitDistanceConventionChanged).toHaveBeenCalledWith({
           convention: value,
         });
       });
     }
     // Runtime input validation lives in DistanceSettingsContent.
+
+    it("does not emit DISTANCE_CONVENTION_CHANGED when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleConventionChange("signed");
+      });
+      expect(mockSetConvention).toHaveBeenCalledTimes(1);
+      expect(mockEmitDistanceConventionChanged).not.toHaveBeenCalled();
+      expect(currentConvention).toBe("cyclic");
+    });
   });
 
   describe("handleTimerEnabledChange", () => {
@@ -168,7 +204,10 @@ describe("useDistanceSettings", () => {
       act(() => {
         result.current.handleTimerEnabledChange(true);
       });
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Enabled",
@@ -180,12 +219,24 @@ describe("useDistanceSettings", () => {
       act(() => {
         result.current.handleTimerEnabledChange(false);
       });
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Disabled",
         "Distance"
       );
+    });
+
+    it("does not track analytics when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/distance/use-distance-settings.ts
+++ b/src/pages/distance/use-distance-settings.ts
@@ -51,28 +51,37 @@ export const useDistanceSettings = (): UseDistanceSettingsResult => {
 
   const handleModeChange = useCallback(
     (value: DistanceMode) => {
-      setMode(value);
-      eventBus.emit.DISTANCE_MODE_CHANGED({ mode: value });
+      setMode(value, {
+        onSuccess: () => {
+          eventBus.emit.DISTANCE_MODE_CHANGED({ mode: value });
+        },
+      });
     },
     [setMode]
   );
 
   const handleConventionChange = useCallback(
     (value: DistanceConvention) => {
-      setConvention(value);
-      eventBus.emit.DISTANCE_CONVENTION_CHANGED({ convention: value });
+      setConvention(value, {
+        onSuccess: () => {
+          eventBus.emit.DISTANCE_CONVENTION_CHANGED({ convention: value });
+        },
+      });
     },
     [setConvention]
   );
 
   const handleTimerEnabledChange = useCallback(
     (enabled: boolean) => {
-      analytics.trackEvent(
-        "Settings",
-        `Timer ${enabled ? "Enabled" : "Disabled"}`,
-        "Distance"
-      );
-      setTimerEnabled(enabled);
+      setTimerEnabled(enabled, {
+        onSuccess: () => {
+          analytics.trackEvent(
+            "Settings",
+            `Timer ${enabled ? "Enabled" : "Disabled"}`,
+            "Distance"
+          );
+        },
+      });
     },
     [setTimerEnabled]
   );

--- a/src/pages/flashcard/use-flashcard-settings.test.ts
+++ b/src/pages/flashcard/use-flashcard-settings.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { FLASHCARD_OPTION_LSK, NEIGHBOR_DIRECTION_LSK } from "../../constants";
+import { createGatedSetterMock } from "../../test-utils/mock-local-db-setter";
 import {
   type FlashcardMode,
   isFlashcardMode,
@@ -11,13 +12,21 @@ import {
 let currentMode: FlashcardMode = "bothmodes";
 let currentDirection: NeighborDirection = "random";
 
-const mockSetMode = vi.fn((value: FlashcardMode) => {
-  currentMode = value;
+// `mockSetValueSucceeds` gates all three setters together — flip to false
+// before a handler call to simulate a Mantine-swallowed quota-exceeded write.
+let mockSetValueSucceeds = true;
+const succeeds = () => mockSetValueSucceeds;
+
+const mockSetMode = createGatedSetterMock<FlashcardMode>(succeeds, (v) => {
+  currentMode = v;
 });
-const mockSetNeighborDirection = vi.fn((value: NeighborDirection) => {
-  currentDirection = value;
-});
-const mockSetTimerEnabled = vi.fn();
+const mockSetNeighborDirection = createGatedSetterMock<NeighborDirection>(
+  succeeds,
+  (v) => {
+    currentDirection = v;
+  }
+);
+const mockSetTimerEnabled = createGatedSetterMock<boolean>(succeeds);
 const mockSetTimerDuration = vi.fn();
 const mockTrackEvent = vi.fn();
 const mockEmitFlashcardModeChanged = vi.fn();
@@ -60,6 +69,7 @@ describe("useFlashcardSettings", () => {
   beforeEach(() => {
     currentMode = "bothmodes";
     currentDirection = "random";
+    mockSetValueSucceeds = true;
 
     // Cast intentional: mockImplementation cannot satisfy the generic useLocalDb<T> signature
     // for multiple T values. Argument matching by key avoids fragile call-order dependency.
@@ -129,7 +139,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleModeChange("cardonly");
       });
 
-      expect(mockSetMode).toHaveBeenCalledWith("cardonly");
+      expect(mockSetMode).toHaveBeenCalledWith(
+        "cardonly",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitFlashcardModeChanged).toHaveBeenCalledWith({
         mode: "cardonly",
       });
@@ -140,7 +153,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleModeChange("numberonly");
       });
 
-      expect(mockSetMode).toHaveBeenCalledWith("numberonly");
+      expect(mockSetMode).toHaveBeenCalledWith(
+        "numberonly",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitFlashcardModeChanged).toHaveBeenCalledWith({
         mode: "numberonly",
       });
@@ -151,7 +167,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleModeChange("bothmodes");
       });
 
-      expect(mockSetMode).toHaveBeenCalledWith("bothmodes");
+      expect(mockSetMode).toHaveBeenCalledWith(
+        "bothmodes",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitFlashcardModeChanged).toHaveBeenCalledWith({
         mode: "bothmodes",
       });
@@ -162,7 +181,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleModeChange("neighbor");
       });
 
-      expect(mockSetMode).toHaveBeenCalledWith("neighbor");
+      expect(mockSetMode).toHaveBeenCalledWith(
+        "neighbor",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitFlashcardModeChanged).toHaveBeenCalledWith({
         mode: "neighbor",
       });
@@ -177,6 +199,16 @@ describe("useFlashcardSettings", () => {
       expect(mockSetMode).not.toHaveBeenCalled();
       expect(mockEmitFlashcardModeChanged).not.toHaveBeenCalled();
     });
+
+    it("does not emit FLASHCARD_MODE_CHANGED when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleModeChange("cardonly");
+      });
+      expect(mockSetMode).toHaveBeenCalledTimes(1);
+      expect(mockEmitFlashcardModeChanged).not.toHaveBeenCalled();
+      expect(currentMode).toBe("bothmodes");
+    });
   });
 
   describe("handleDirectionChange", () => {
@@ -185,7 +217,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleDirectionChange("before");
       });
 
-      expect(mockSetNeighborDirection).toHaveBeenCalledWith("before");
+      expect(mockSetNeighborDirection).toHaveBeenCalledWith(
+        "before",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitNeighborDirectionChanged).toHaveBeenCalledWith({
         direction: "before",
       });
@@ -196,7 +231,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleDirectionChange("after");
       });
 
-      expect(mockSetNeighborDirection).toHaveBeenCalledWith("after");
+      expect(mockSetNeighborDirection).toHaveBeenCalledWith(
+        "after",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitNeighborDirectionChanged).toHaveBeenCalledWith({
         direction: "after",
       });
@@ -207,7 +245,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleDirectionChange("random");
       });
 
-      expect(mockSetNeighborDirection).toHaveBeenCalledWith("random");
+      expect(mockSetNeighborDirection).toHaveBeenCalledWith(
+        "random",
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockEmitNeighborDirectionChanged).toHaveBeenCalledWith({
         direction: "random",
       });
@@ -222,6 +263,16 @@ describe("useFlashcardSettings", () => {
       expect(mockSetNeighborDirection).not.toHaveBeenCalled();
       expect(mockEmitNeighborDirectionChanged).not.toHaveBeenCalled();
     });
+
+    it("does not emit NEIGHBOR_DIRECTION_CHANGED when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleDirectionChange("before");
+      });
+      expect(mockSetNeighborDirection).toHaveBeenCalledTimes(1);
+      expect(mockEmitNeighborDirectionChanged).not.toHaveBeenCalled();
+      expect(currentDirection).toBe("random");
+    });
   });
 
   describe("handleTimerEnabledChange", () => {
@@ -230,7 +281,10 @@ describe("useFlashcardSettings", () => {
         result.current.handleTimerEnabledChange(true);
       });
 
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(true);
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Enabled",
@@ -243,12 +297,24 @@ describe("useFlashcardSettings", () => {
         result.current.handleTimerEnabledChange(false);
       });
 
-      expect(mockSetTimerEnabled).toHaveBeenCalledWith(false);
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
       expect(mockTrackEvent).toHaveBeenCalledWith(
         "Settings",
         "Timer Disabled",
         "Flashcard"
       );
+    });
+
+    it("does not track analytics when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pages/flashcard/use-flashcard-settings.ts
+++ b/src/pages/flashcard/use-flashcard-settings.ts
@@ -51,8 +51,11 @@ export const useFlashcardSettings = (): UseFlashcardSettingsResult => {
       if (!isFlashcardMode(value)) {
         return;
       }
-      setMode(value);
-      eventBus.emit.FLASHCARD_MODE_CHANGED({ mode: value });
+      setMode(value, {
+        onSuccess: () => {
+          eventBus.emit.FLASHCARD_MODE_CHANGED({ mode: value });
+        },
+      });
     },
     [setMode]
   );
@@ -62,20 +65,26 @@ export const useFlashcardSettings = (): UseFlashcardSettingsResult => {
       if (!isNeighborDirection(value)) {
         return;
       }
-      setNeighborDirection(value);
-      eventBus.emit.NEIGHBOR_DIRECTION_CHANGED({ direction: value });
+      setNeighborDirection(value, {
+        onSuccess: () => {
+          eventBus.emit.NEIGHBOR_DIRECTION_CHANGED({ direction: value });
+        },
+      });
     },
     [setNeighborDirection]
   );
 
   const handleTimerEnabledChange = useCallback(
     (enabled: boolean) => {
-      analytics.trackEvent(
-        "Settings",
-        `Timer ${enabled ? "Enabled" : "Disabled"}`,
-        "Flashcard"
-      );
-      setTimerEnabled(enabled);
+      setTimerEnabled(enabled, {
+        onSuccess: () => {
+          analytics.trackEvent(
+            "Settings",
+            `Timer ${enabled ? "Enabled" : "Disabled"}`,
+            "Flashcard"
+          );
+        },
+      });
     },
     [setTimerEnabled]
   );

--- a/src/pages/spot-check/spot-check.tsx
+++ b/src/pages/spot-check/spot-check.tsx
@@ -6,27 +6,16 @@ import { RevealButton } from "../../components/reveal-button";
 import { SessionSummaryModal } from "../../components/session-summary-modal";
 import { TimerDisplay } from "../../components/timer-display";
 import { TrainingHeader } from "../../components/training-header";
-import { SPOT_CHECK_MODE_LSK } from "../../constants";
 import { useDocumentMeta } from "../../hooks/use-document-meta";
 import { useRequiredStack } from "../../hooks/use-selected-stack";
 import { useSession } from "../../hooks/use-session";
-import { useSpotCheckTimer } from "../../hooks/use-spot-check-timer";
 import { useStackLimits } from "../../hooks/use-stack-limits";
 import { analytics } from "../../services/analytics";
-import { eventBus } from "../../services/event-bus";
-import {
-  isSpotCheckMode,
-  type SpotCheckI18nKey,
-  type SpotCheckMode,
-} from "../../types/spot-check";
+import type { SpotCheckI18nKey, SpotCheckMode } from "../../types/spot-check";
 import { cardItems } from "../../types/typeguards";
-import { useLocalDb } from "../../utils/localstorage";
-import {
-  handleLocalDbWriteFailed,
-  reportLocalDbCorruption,
-} from "../../utils/localstorage-telemetry";
 import { SpotCheckSettingsContent } from "./spot-check-settings-content";
 import { useSpotCheckGame } from "./use-spot-check-game";
+import { useSpotCheckSettings } from "./use-spot-check-settings";
 
 const MODE_INSTRUCTION_LABELS = {
   missing: "spotCheck.identifyMissing",
@@ -48,13 +37,13 @@ export const SpotCheck = () => {
   });
   const { stackKey, stackOrder, stackName } = useRequiredStack();
 
-  const [mode, setMode] = useLocalDb<SpotCheckMode>(
-    SPOT_CHECK_MODE_LSK,
-    "missing",
-    isSpotCheckMode,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
-  );
+  const {
+    mode,
+    timerSettings,
+    setTimerDuration,
+    handleModeChange,
+    handleTimerEnabledChange,
+  } = useSpotCheckSettings();
 
   const { limits, rangeSize } = useStackLimits(stackKey);
 
@@ -75,17 +64,6 @@ export const SpotCheck = () => {
     stackLimits: limits,
   });
 
-  const handleModeChange = useCallback(
-    (value: SpotCheckMode) => {
-      setMode(value);
-      eventBus.emit.SPOT_CHECK_MODE_CHANGED({ mode: value });
-    },
-    [setMode]
-  );
-
-  const { timerSettings, setTimerEnabled, setTimerDuration } =
-    useSpotCheckTimer();
-
   const {
     score,
     puzzleCards,
@@ -96,18 +74,6 @@ export const SpotCheck = () => {
   } = useSpotCheckGame(stackOrder, stackName, mode, timerSettings, limits, {
     onAnswer: handleAnswer,
   });
-
-  const handleTimerEnabledChange = useCallback(
-    (enabled: boolean) => {
-      analytics.trackEvent(
-        "Settings",
-        `Timer ${enabled ? "Enabled" : "Disabled"}`,
-        "SpotCheck"
-      );
-      setTimerEnabled(enabled);
-    },
-    [setTimerEnabled]
-  );
 
   const handleRevealAnswer = useCallback(() => {
     analytics.trackFeatureUsed("Reveal Answer - Spot Check");

--- a/src/pages/spot-check/use-spot-check-settings.test.ts
+++ b/src/pages/spot-check/use-spot-check-settings.test.ts
@@ -1,0 +1,172 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SPOT_CHECK_MODE_LSK } from "../../constants";
+import { createGatedSetterMock } from "../../test-utils/mock-local-db-setter";
+import { isSpotCheckMode, type SpotCheckMode } from "../../types/spot-check";
+
+let currentMode: SpotCheckMode = "missing";
+
+// `mockSetValueSucceeds` gates both setters together — flip to false before
+// a handler call to simulate a Mantine-swallowed quota-exceeded write.
+let mockSetValueSucceeds = true;
+const succeeds = () => mockSetValueSucceeds;
+
+const mockSetMode = createGatedSetterMock<SpotCheckMode>(succeeds, (v) => {
+  currentMode = v;
+});
+const mockSetTimerEnabled = createGatedSetterMock<boolean>(succeeds);
+const mockSetTimerDuration = vi.fn();
+const mockTrackEvent = vi.fn();
+const mockEmitSpotCheckModeChanged = vi.fn();
+
+vi.mock("../../utils/localstorage", () => ({
+  useLocalDb: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-spot-check-timer", () => ({
+  useSpotCheckTimer: vi.fn(() => ({
+    timerSettings: { enabled: false, duration: 15 },
+    setTimerEnabled: mockSetTimerEnabled,
+    setTimerDuration: mockSetTimerDuration,
+  })),
+}));
+
+vi.mock("../../services/analytics", () => ({
+  analytics: {
+    trackEvent: mockTrackEvent,
+  },
+}));
+
+vi.mock("../../services/event-bus", () => ({
+  eventBus: {
+    emit: {
+      SPOT_CHECK_MODE_CHANGED: mockEmitSpotCheckModeChanged,
+    },
+  },
+}));
+
+const { useLocalDb } = await import("../../utils/localstorage");
+const mockedUseLocalDb = vi.mocked(useLocalDb);
+const { useSpotCheckSettings } = await import("./use-spot-check-settings");
+
+describe("useSpotCheckSettings", () => {
+  let result: { current: ReturnType<typeof useSpotCheckSettings> };
+
+  beforeEach(() => {
+    currentMode = "missing";
+    mockSetValueSucceeds = true;
+
+    // Cast intentional: mockImplementation cannot satisfy generic useLocalDb<T> for multiple T.
+    (mockedUseLocalDb.mockImplementation as (fn: unknown) => unknown)(
+      (key: string) => {
+        if (key === SPOT_CHECK_MODE_LSK) {
+          return [currentMode, mockSetMode, vi.fn()];
+        }
+        throw new Error(`Unexpected useLocalDb key: ${key}`);
+      }
+    );
+
+    ({ result } = renderHook(() => useSpotCheckSettings()));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns default mode 'missing'", () => {
+    expect(result.current.mode).toBe("missing");
+  });
+
+  it("calls useLocalDb with SPOT_CHECK_MODE_LSK, default, validator, and write/corrupt callbacks", () => {
+    expect(mockedUseLocalDb).toHaveBeenCalledTimes(1);
+    expect(mockedUseLocalDb).toHaveBeenCalledWith(
+      SPOT_CHECK_MODE_LSK,
+      "missing",
+      isSpotCheckMode,
+      expect.any(Function),
+      expect.any(Function)
+    );
+  });
+
+  it("returns timer settings from useSpotCheckTimer", () => {
+    expect(result.current.timerSettings).toEqual({
+      enabled: false,
+      duration: 15,
+    });
+  });
+
+  it("delegates setTimerDuration to useSpotCheckTimer", () => {
+    act(() => {
+      result.current.setTimerDuration(30);
+    });
+    expect(mockSetTimerDuration).toHaveBeenCalledWith(30);
+  });
+
+  describe("handleModeChange", () => {
+    for (const value of ["missing", "swapped", "moved"] as const) {
+      it(`updates mode and emits event for '${value}'`, () => {
+        act(() => {
+          result.current.handleModeChange(value);
+        });
+        expect(mockSetMode).toHaveBeenCalledWith(
+          value,
+          expect.objectContaining({ onSuccess: expect.any(Function) })
+        );
+        expect(mockEmitSpotCheckModeChanged).toHaveBeenCalledWith({
+          mode: value,
+        });
+      });
+    }
+
+    it("does not emit SPOT_CHECK_MODE_CHANGED when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleModeChange("swapped");
+      });
+      expect(mockSetMode).toHaveBeenCalledTimes(1);
+      expect(mockEmitSpotCheckModeChanged).not.toHaveBeenCalled();
+      expect(currentMode).toBe("missing");
+    });
+  });
+
+  describe("handleTimerEnabledChange", () => {
+    it("tracks analytics and enables timer", () => {
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "Settings",
+        "Timer Enabled",
+        "SpotCheck"
+      );
+    });
+
+    it("tracks analytics and disables timer", () => {
+      act(() => {
+        result.current.handleTimerEnabledChange(false);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledWith(
+        false,
+        expect.objectContaining({ onSuccess: expect.any(Function) })
+      );
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        "Settings",
+        "Timer Disabled",
+        "SpotCheck"
+      );
+    });
+
+    it("does not track analytics when the wrapped setter's write fails", () => {
+      mockSetValueSucceeds = false;
+      act(() => {
+        result.current.handleTimerEnabledChange(true);
+      });
+      expect(mockSetTimerEnabled).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/pages/spot-check/use-spot-check-settings.ts
+++ b/src/pages/spot-check/use-spot-check-settings.ts
@@ -1,0 +1,67 @@
+import { useCallback } from "react";
+import { SPOT_CHECK_MODE_LSK } from "../../constants";
+import { useSpotCheckTimer } from "../../hooks/use-spot-check-timer";
+import { analytics } from "../../services/analytics";
+import { eventBus } from "../../services/event-bus";
+import { isSpotCheckMode, type SpotCheckMode } from "../../types/spot-check";
+import type { TimerDuration, TimerSettings } from "../../types/timer";
+import { useLocalDb } from "../../utils/localstorage";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../../utils/localstorage-telemetry";
+
+type UseSpotCheckSettingsResult = {
+  mode: SpotCheckMode;
+  timerSettings: TimerSettings;
+  setTimerDuration: (duration: TimerDuration) => void;
+  handleModeChange: (value: SpotCheckMode) => void;
+  handleTimerEnabledChange: (enabled: boolean) => void;
+};
+
+export const useSpotCheckSettings = (): UseSpotCheckSettingsResult => {
+  const [mode, setMode] = useLocalDb<SpotCheckMode>(
+    SPOT_CHECK_MODE_LSK,
+    "missing",
+    isSpotCheckMode,
+    reportLocalDbCorruption,
+    handleLocalDbWriteFailed
+  );
+
+  const { timerSettings, setTimerEnabled, setTimerDuration } =
+    useSpotCheckTimer();
+
+  const handleModeChange = useCallback(
+    (value: SpotCheckMode) => {
+      setMode(value, {
+        onSuccess: () => {
+          eventBus.emit.SPOT_CHECK_MODE_CHANGED({ mode: value });
+        },
+      });
+    },
+    [setMode]
+  );
+
+  const handleTimerEnabledChange = useCallback(
+    (enabled: boolean) => {
+      setTimerEnabled(enabled, {
+        onSuccess: () => {
+          analytics.trackEvent(
+            "Settings",
+            `Timer ${enabled ? "Enabled" : "Disabled"}`,
+            "SpotCheck"
+          );
+        },
+      });
+    },
+    [setTimerEnabled]
+  );
+
+  return {
+    mode,
+    timerSettings,
+    setTimerDuration,
+    handleModeChange,
+    handleTimerEnabledChange,
+  };
+};

--- a/src/test-utils/mock-local-db-setter.ts
+++ b/src/test-utils/mock-local-db-setter.ts
@@ -1,0 +1,23 @@
+import { vi } from "vitest";
+import type { UseLocalDbSetOptions } from "../utils/localstorage";
+
+/**
+ * Mantine-mirroring mock for a `useLocalDb` setter: invokes
+ * `options.onSuccess` only when `shouldSucceed()` returns true. State
+ * mutation (when provided) is also gated on success — production's
+ * `probedSetValue` returns early on `setItem` throw, so the mock must too.
+ *
+ * The success flag is a closure to keep a single shared `let` flag in scope
+ * across all setters within one test file (so a single `mockSetValueSucceeds
+ * = false` flips them all together for failure-path tests).
+ */
+export const createGatedSetterMock = <T>(
+  shouldSucceed: () => boolean,
+  onSuccessAssign?: (value: T) => void
+) =>
+  vi.fn((value: T, options?: UseLocalDbSetOptions) => {
+    if (shouldSucceed()) {
+      onSuccessAssign?.(value);
+      options?.onSuccess?.();
+    }
+  });

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -90,7 +90,7 @@ export const getStoredValue = <T>(
   return probe.status === "valid" ? probe.value : defaultValue;
 };
 
-type UseLocalDbSetOptions = { onSuccess?: () => void };
+export type UseLocalDbSetOptions = { onSuccess?: () => void };
 
 type UseLocalDbSetter<T> = (
   value: T | ((prevState: T) => T),


### PR DESCRIPTION
## Summary

Thread `onSuccess` through `useLocalDb` setters so analytics events and event-bus emits fire only after a successful write. Mirrors the silent-failure fix in #643 — previously, a Mantine-swallowed quota-exceeded write still emitted `*_MODE_CHANGED` events and tracked analytics as if persistence had succeeded.

- Add `UseLocalDbSetOptions` to `useLocalDb` and forward through `useTimerSettings.setTimerEnabled`.
- Update distance, flashcard, spot-check, and ACAAN handlers to gate emits/analytics inside `onSuccess`.
- Extract `useAcaanSettings` and `useSpotCheckSettings` to parallel the existing distance/flashcard pattern (also pulls some logic out of the page components).
- Add shared `createGatedSetterMock` test helper that mirrors `probedSetValue`'s success-only callback semantics.
- Cover both success and failure paths in tests for all four hooks.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test`
- [ ] Verify in browser: toggle the timer / change mode in each of distance, flashcard, spot-check, ACAAN, then check analytics + event-bus emissions only occur on a real persisted write (DevTools → Application → Local Storage shows the updated blob).