### PR TITLE
fix: drop vestigial safeListener latch that leaked on unload

### DIFF
--- a/src/services/analytics.test.ts
+++ b/src/services/analytics.test.ts
@@ -336,6 +336,63 @@ describe("analytics", () => {
         })
       );
     });
+
+    it("does not suppress subsequent listener errors when a microtask is never drained (page-unload regression)", () => {
+      // Capture queued callbacks instead of running them — simulates the
+      // page-unload scenario where the microtask queue never drains. Under
+      // the pre-fix latch, `isReportingListenerError` would stay true after
+      // the first throw and silently swallow every subsequent listener error
+      // for the document's lifetime; under the fix every throw must queue
+      // its own trackError microtask independently.
+      const captured: Array<() => void> = [];
+      const queueSpy = vi
+        .spyOn(globalThis, "queueMicrotask")
+        .mockImplementation((cb: () => void) => {
+          captured.push(cb);
+        });
+
+      try {
+        mockEvent.mockImplementationOnce(() => {
+          throw new Error("first-throw");
+        });
+        eventBus.emit.STACK_SELECTED({ stackName: "Mnemonica" });
+        expect(queueSpy).toHaveBeenCalledTimes(1);
+
+        mockEvent.mockImplementationOnce(() => {
+          throw new Error("second-throw");
+        });
+        eventBus.emit.STACK_SELECTED({ stackName: "Aronson" });
+        // Pre-fix this stays at 1 — the latch is still set. Post-fix it must
+        // be 2 because the latch reset is no longer gated on the microtask
+        // running.
+        expect(queueSpy).toHaveBeenCalledTimes(2);
+
+        // Drain the captured callbacks manually and verify each closed over
+        // the correct error — proves they aren't accidentally one queued
+        // callback fired twice with stale data.
+        captured[0]();
+        expect(mockEvent).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            category: "Error",
+            action: "Error",
+            label: "first-throw",
+          })
+        );
+        captured[1]();
+        expect(mockEvent).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            category: "Error",
+            action: "Error",
+            label: "second-throw",
+          })
+        );
+      } finally {
+        // The file's `afterEach` calls `vi.clearAllMocks()`, which clears
+        // call history but does NOT restore spies. Restoring explicitly
+        // keeps real `queueMicrotask` available for sibling tests.
+        queueSpy.mockRestore();
+      }
+    });
   });
 
   describe("initialize", () => {

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -35,33 +35,29 @@ const formatSessionLabel = (
     : `${mode} (open)`;
 
 // Wrap a subscriber so an exception inside it surfaces through trackError
-// without recursing back into the event bus (which would risk a loop, since
-// analytics is itself an emitter via SESSION_COMPLETED etc.). Reporting
-// happens in a microtask so the throwing listener has fully unwound before
-// the report runs, and a module-level latch short-circuits re-entry if the
-// report path itself throws.
-let isReportingListenerError = false;
+// without aborting iteration over the remaining listeners (eventBus already
+// isolates throws — see event-bus.ts:58 — so the wrap is purely about
+// routing the error to telemetry).
+//
+// Reporting is deferred to a microtask so the throwing listener's stack
+// has fully unwound before re-entering analytics machinery. No re-entry
+// guard is needed: analytics.trackError calls only ReactGA.event/send
+// (no bus emits), and listeners on a single channel are iterated as peers
+// — never nested — so the throwing-listener stack is the only reachable
+// source of recursion, and it is already unwound by the time the
+// microtask runs.
 const safeListener =
   <T>(channel: string, fn: (payload: T) => void): ((payload: T) => void) =>
   (payload: T) => {
     try {
       fn(payload);
     } catch (error) {
-      if (isReportingListenerError) {
-        return;
-      }
-      isReportingListenerError = true;
-      try {
-        queueMicrotask(() => {
-          isReportingListenerError = false;
-          analytics.trackError(
-            error instanceof Error ? error : new Error(String(error)),
-            `eventBus listener:${channel}`
-          );
-        });
-      } catch {
-        isReportingListenerError = false;
-      }
+      queueMicrotask(() =>
+        analytics.trackError(
+          error instanceof Error ? error : new Error(String(error)),
+          `eventBus listener:${channel}`
+        )
+      );
     }
   };
 


### PR DESCRIPTION
## Summary

The module-level `isReportingListenerError` latch in `safeListener` (`src/services/analytics.ts`) was reset *inside* the queued microtask, so any microtask dropped on page unload left the latch `true` for the rest of the document's lifetime — silently swallowing every subsequent listener exception with no telemetry signal.

Investigation established the latch never actually guarded what its comment claimed:

- `analytics.trackError` only calls `ReactGA.event` / `ReactGA.send` (no bus emits) — there is no path back into `safeListener`.
- `eventBus.emit` iterates listeners on a channel as peers in a single synchronous `for...of` loop with per-listener `try/catch` (`event-bus.ts:56-77`), never nested. No second `safeListener` invocation can observe the latch as `true` synchronously.

So the latch was vestigial recursion-guard scaffolding for a scenario that cannot happen in this codebase. The fix drops it entirely; the `catch` just defers `analytics.trackError` via `queueMicrotask`.

A regression test mocks `queueMicrotask` to capture-without-invoking (simulating the unload scenario) and asserts the second emit's throw still queues its own microtask. Pre-fix this stayed at 1 (latch suppressed); post-fix it must be 2.

## Test plan

- [x] `pnpm run typecheck` — passes
- [x] `pnpm run test` — 1750 passed (was 1749, +1 for the new regression test)
- [x] `pnpm run test:coverage` — `src/services` lines at 96.09% (≥ 90% threshold); `analytics.ts` at 95.32%
- [x] `npx ultracite check` on touched files — clean
- [x] Verified no `isReportingListenerError` references remain in code (only a descriptive mention in the new test's comment)
- [x] Independent multi-reviewer review (`/review`, error-handling + security dimensions) — zero findings

Closes #630