### PR TITLE
fix: preserve useLocalDb in-memory state on cross-tab corruption

### DIFF
--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Änderungen nicht gespeichert",
       "message": "Dein Browser-Speicher ist möglicherweise voll — letzte Änderungen bleiben nach einem Neuladen nicht erhalten."
+    },
+    "localDbCorrupt": {
+      "title": "Einstellungen nicht synchron",
+      "message": "Ein anderer Browser-Tab hat Daten gespeichert, die dieser Tab nicht lesen konnte. Deine Änderungen hier bleiben erhalten."
     }
   },
   "stats": {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -362,6 +362,10 @@
     "localDbWriteFailed": {
       "title": "Couldn't save",
       "message": "Your browser storage may be full — recent changes won't persist after a refresh."
+    },
+    "localDbCorrupt": {
+      "title": "Settings out of sync",
+      "message": "Another tab wrote data this tab couldn't read. Your changes here are safe."
     }
   },
   "stats": {

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Cambios no guardados",
       "message": "El almacenamiento del navegador puede estar lleno — los cambios recientes no se mantendrán tras recargar la página."
+    },
+    "localDbCorrupt": {
+      "title": "Ajustes desincronizados",
+      "message": "Otra pestaña escribió datos que esta pestaña no pudo leer. Tus cambios aquí están a salvo."
     }
   },
   "stats": {

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Modifications non enregistrées",
       "message": "Votre stockage navigateur est peut-être plein — les modifications récentes ne seront pas conservées après un rechargement."
+    },
+    "localDbCorrupt": {
+      "title": "Réglages désynchronisés",
+      "message": "Un autre onglet a écrit des données que celui-ci n'a pas pu lire. Vos modifications ici sont intactes."
     }
   },
   "stats": {

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Modifiche non salvate",
       "message": "Lo spazio di archiviazione del browser potrebbe essere pieno — le modifiche recenti non saranno mantenute dopo aver ricaricato la pagina."
+    },
+    "localDbCorrupt": {
+      "title": "Impostazioni non sincronizzate",
+      "message": "Un'altra scheda ha scritto dati che questa scheda non è riuscita a leggere. Le tue modifiche qui sono al sicuro."
     }
   },
   "stats": {

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Wijzigingen niet opgeslagen",
       "message": "Je browseropslag is misschien vol — recente wijzigingen gaan verloren na het herladen."
+    },
+    "localDbCorrupt": {
+      "title": "Instellingen niet meer synchroon",
+      "message": "Een ander tabblad schreef gegevens die dit tabblad niet kon lezen. Je wijzigingen hier zijn veilig."
     }
   },
   "stats": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -330,6 +330,10 @@
     "localDbWriteFailed": {
       "title": "Alterações não guardadas",
       "message": "O armazenamento do navegador pode estar cheio — as alterações recentes não serão mantidas após recarregar a página."
+    },
+    "localDbCorrupt": {
+      "title": "Definições dessincronizadas",
+      "message": "Outro separador escreveu dados que este separador não conseguiu ler. As tuas alterações aqui estão seguras."
     }
   },
   "stats": {

--- a/src/utils/localstorage-telemetry.test.ts
+++ b/src/utils/localstorage-telemetry.test.ts
@@ -6,6 +6,7 @@ import {
   handleLocalDbWriteFailed,
   notifyLocalDbWriteFailed,
   reportLocalDbCorruption,
+  reportLocalDbNotifyFailed,
   reportLocalDbWriteFailed,
 } from "./localstorage-telemetry";
 
@@ -182,6 +183,52 @@ describe("notifyLocalDbWriteFailed", () => {
 
     const ids = showSpy.mock.calls.map((args) => args[0].id);
     expect(ids).toEqual(["local-db-write-failed-a", "local-db-write-failed-b"]);
+  });
+});
+
+describe("reportLocalDbNotifyFailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renames the wrapper to LocalDbNotifyFailed and redacts an Error cause's message", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    const cause = new Error("notifications provider not mounted at /route");
+    reportLocalDbNotifyFailed("flashcard-mode", cause);
+
+    expect(trackErrorSpy).toHaveBeenCalledTimes(1);
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbNotifyFailed");
+    expect(errArg?.message).toBe("type=Error name=Error");
+    expect(errArg?.message).not.toContain("provider");
+    expect(errArg?.message).not.toContain("/route");
+    expect(contextArg).toBe("key=flashcard-mode");
+  });
+
+  it("wraps a string cause by length only", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportLocalDbNotifyFailed("k", "boom");
+
+    const [errArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg?.message).toBe("type=string length=4");
+  });
+
+  it("wraps a non-Error, non-string cause by typeof", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportLocalDbNotifyFailed("k", { unexpected: "shape" });
+
+    const [errArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg?.message).toBe("type=object");
   });
 });
 

--- a/src/utils/localstorage-telemetry.ts
+++ b/src/utils/localstorage-telemetry.ts
@@ -64,6 +64,24 @@ export const notifyLocalDbWriteFailed = (key: string): void => {
 };
 
 /**
+ * Surfaces a Mantine notification when `useLocalDb` detects a post-mount
+ * valid→corrupt transition — typically a cross-tab corrupt write. Mount-time
+ * corruption is intentionally not toasted here: consumers like
+ * `useStackLimits` show their own dedicated mount toast, and reset-on-write
+ * recovery for low-stakes single-value consumers stays silent. The actual
+ * dedup lives in `useLocalDb`'s `wasValidRef`; the id is belt-and-suspenders
+ * for racing shows on the same key.
+ */
+export const notifyLocalDbCorruption = (key: string): void => {
+  notifications.show({
+    id: `local-db-corrupt-${key}`,
+    color: "yellow",
+    title: i18next.t("errors.localDbCorrupt.title"),
+    message: i18next.t("errors.localDbCorrupt.message"),
+  });
+};
+
+/**
  * Combined `onWriteFailed` callback for `useLocalDb` — the canonical handler
  * consumers should pass. Reports the failure to analytics and surfaces a
  * Mantine notification so the user knows their change won't persist.
@@ -71,4 +89,27 @@ export const notifyLocalDbWriteFailed = (key: string): void => {
 export const handleLocalDbWriteFailed = (key: string, cause: unknown): void => {
   reportLocalDbWriteFailed(key, cause);
   notifyLocalDbWriteFailed(key);
+};
+
+/**
+ * Reports a `notifyLocalDbCorruption` failure (toast pipeline broken) to
+ * analytics. Without this breadcrumb, a regressed Mantine provider mount or a
+ * pre-i18n init throw would silently disable cross-tab corruption toasts in
+ * production with no signal — the data path keeps working, but the user never
+ * learns another tab wrote unreadable data.
+ */
+export const reportLocalDbNotifyFailed = (
+  key: string,
+  cause: unknown
+): void => {
+  let wrapped: Error;
+  if (cause instanceof Error) {
+    wrapped = new Error(`type=Error name=${cause.name}`);
+  } else if (typeof cause === "string") {
+    wrapped = new Error(`type=string length=${cause.length}`);
+  } else {
+    wrapped = new Error(`type=${typeof cause}`);
+  }
+  wrapped.name = "LocalDbNotifyFailed";
+  analytics.trackError(wrapped, `key=${key}`);
 };

--- a/src/utils/localstorage.test.ts
+++ b/src/utils/localstorage.test.ts
@@ -3,10 +3,23 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockReadLocalStorageValue = vi.fn();
 const mockUseLocalStorage = vi.fn();
+const mockNotifyLocalDbCorruption = vi.fn<(key: string) => void>();
+const mockReportLocalDbNotifyFailed =
+  vi.fn<(key: string, cause: unknown) => void>();
 
 vi.mock("@mantine/hooks", () => ({
   readLocalStorageValue: (args: unknown) => mockReadLocalStorageValue(args),
   useLocalStorage: (args: unknown) => mockUseLocalStorage(args),
+}));
+
+// Mock the telemetry module so cross-tab corruption tests can assert the
+// wrapper's notification + analytics calls without exercising real Mantine
+// `notifications`, i18next lookups, or GA. `localstorage.ts` only imports
+// `notifyLocalDbCorruption` and `reportLocalDbNotifyFailed` from this module,
+// so a full replacement is safe.
+vi.mock("./localstorage-telemetry", () => ({
+  notifyLocalDbCorruption: mockNotifyLocalDbCorruption,
+  reportLocalDbNotifyFailed: mockReportLocalDbNotifyFailed,
 }));
 
 const { getStoredValue, probeStoredValue, useLocalDb } = await import(
@@ -1018,6 +1031,598 @@ describe("useLocalDb", () => {
       });
 
       expect(result.current[0]).toBe("default");
+    });
+  });
+
+  // Issue #628 regression: when a cross-tab `storage` event delivers a value
+  // that fails JSON.parse / validate, the wrapper used to roll the rendered
+  // `value` (and the setter's `prev`) back to `defaultValue`, silently
+  // discarding the user's in-flight edits. The fix tracks the last-known-
+  // valid value in a ref and prefers it on corrupt/read-error probes.
+  describe("cross-tab corruption preserves in-memory state (issue #628)", () => {
+    type Rec = { a: number; b: number };
+    const isRec = (value: unknown): value is Rec =>
+      typeof value === "object" &&
+      value !== null &&
+      "a" in value &&
+      "b" in value &&
+      typeof value.a === "number" &&
+      typeof value.b === "number";
+
+    const fireCrossTabRaw = (key: string, bytes: string): void => {
+      window.localStorage.setItem(key, bytes);
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key,
+          newValue: bytes,
+          storageArea: window.localStorage,
+        })
+      );
+    };
+
+    beforeEach(() => {
+      mockNotifyLocalDbCorruption.mockClear();
+      mockReportLocalDbNotifyFailed.mockClear();
+    });
+
+    it("preserves the in-memory value across a cross-tab corrupt write (read side)", () => {
+      window.localStorage.setItem("k", JSON.stringify("user-edit"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("user-edit");
+
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+
+      // Without the rollback fix this would be "default"; with it the user's
+      // last-known-valid in-memory state survives.
+      expect(result.current[0]).toBe("user-edit");
+    });
+
+    it("preserves in-memory state for a functional setter's `prev` after cross-tab corruption (write side)", () => {
+      const initial: Rec = { a: 1, b: 2 };
+      window.localStorage.setItem("rec", JSON.stringify(initial));
+
+      const { result } = renderHook(() =>
+        useLocalDb<Rec>("rec", { a: 0, b: 0 }, isRec)
+      );
+
+      act(() => {
+        fireCrossTabRaw("rec", "{not valid json");
+      });
+
+      act(() => {
+        result.current[1]((prev) => ({ ...prev, a: 99 }));
+      });
+
+      // Without the write-side fix `prev` would be the defaultValue
+      // { a: 0, b: 0 } and the persisted blob would be { a: 99, b: 0 } —
+      // silently dropping the user's `b: 2`. The fix uses the last valid
+      // in-memory state as `prev`, so `b: 2` survives.
+      const persisted: unknown = JSON.parse(
+        window.localStorage.getItem("rec") ?? "null"
+      );
+      expect(persisted).toEqual({ a: 99, b: 2 });
+    });
+
+    it("does not toast on a mount-time corrupt blob", () => {
+      window.localStorage.setItem("k", "{not valid json");
+
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("toasts once on a valid→corrupt cross-tab transition", () => {
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledWith("k");
+    });
+
+    it("does not re-toast on consecutive corrupt events without an intervening valid", () => {
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad-1");
+      });
+      act(() => {
+        fireCrossTabRaw("k", "{bad-2");
+      });
+      act(() => {
+        fireCrossTabRaw("k", "{bad-3");
+      });
+
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-toasts after a corrupt→valid→corrupt sequence", () => {
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad-1");
+      });
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        fireCrossTabRaw("k", JSON.stringify("recovered"));
+      });
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad-2");
+      });
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not toast on an absent→corrupt sequence (cross-tab clear() then cross-tab corrupt write)", () => {
+      // After an `absent` probe (cross-tab clear), `wasValidRef` is reset to
+      // false, so the subsequent corrupt probe is treated as mount-like
+      // rather than a valid→corrupt transition. Pins the invariant: a
+      // future refactor that flipped `wasValidRef` to true on `absent`
+      // would start firing phantom toasts on clear-then-corrupt sequences.
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      renderHook(() => useLocalDb("k", "default", isString));
+
+      act(() => {
+        window.localStorage.removeItem("k");
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: null,
+            newValue: null,
+            storageArea: window.localStorage,
+          })
+        );
+      });
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("does not toast on a cross-tab `clear()` (absent), and falls back to defaultValue", () => {
+      window.localStorage.setItem("k", JSON.stringify("user-edit"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("user-edit");
+
+      act(() => {
+        window.localStorage.removeItem("k");
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: null,
+            newValue: null,
+            storageArea: window.localStorage,
+          })
+        );
+      });
+
+      // `absent` keeps current semantics: a deliberate cross-tab clear is
+      // not corruption, so the value falls back to defaultValue and no
+      // toast fires.
+      expect(result.current[0]).toBe("default");
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("still invokes `onCorrupt` on the valid→corrupt transition (telemetry semantics preserved)", () => {
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      const onCorrupt = vi.fn();
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      expect(onCorrupt).not.toHaveBeenCalled();
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad");
+      });
+
+      expect(onCorrupt).toHaveBeenCalledTimes(1);
+      expect(onCorrupt).toHaveBeenCalledWith("k", "{bad");
+    });
+
+    it("does not surface the previous key's last-known-valid value when `key` changes to a corrupt blob (read side)", () => {
+      window.localStorage.setItem("key-a", JSON.stringify("from-a"));
+      window.localStorage.setItem("key-b", "{not valid json");
+
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", isString),
+        { initialProps: { k: "key-a" } }
+      );
+      expect(result.current[0]).toBe("from-a");
+
+      rerender({ k: "key-b" });
+
+      // Without the per-key guard, latestValidRef would still carry
+      // "from-a" and the corrupt key-b would surface it as if it were a
+      // valid key-b value. With the guard, the consumer sees `defaultValue`.
+      expect(result.current[0]).toBe("default");
+    });
+
+    it("does not fire the toast when `key` changes from a valid blob to a key whose blob is corrupt", () => {
+      window.localStorage.setItem("key-a", JSON.stringify("from-a"));
+      window.localStorage.setItem("key-b", "{not valid json");
+
+      const { rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", isString),
+        { initialProps: { k: "key-a" } }
+      );
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+
+      rerender({ k: "key-b" });
+
+      // A `key` swap is not a valid→corrupt transition for the new key —
+      // the new key's first probe is mount-time corruption from its
+      // perspective, which is documented to stay silent.
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("does not feed the previous key's last-known-valid value to a functional setter when the new key's blob is corrupt", () => {
+      const initial: Rec = { a: 1, b: 2 };
+      window.localStorage.setItem("key-a", JSON.stringify(initial));
+      window.localStorage.setItem("key-b", "{not valid json");
+
+      const { result, rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb<Rec>(k, { a: 0, b: 0 }, isRec),
+        { initialProps: { k: "key-a" } }
+      );
+
+      rerender({ k: "key-b" });
+
+      act(() => {
+        result.current[1]((prev) => ({ ...prev, a: 99 }));
+      });
+
+      const persisted: unknown = JSON.parse(
+        window.localStorage.getItem("key-b") ?? "null"
+      );
+      // Without the per-key guard, `prev` would be { a: 1, b: 2 } from
+      // key-a and the persisted record would mix keys. With the guard,
+      // `prev` falls back to the consumer's `defaultValue`.
+      expect(persisted).toEqual({ a: 99, b: 0 });
+    });
+
+    it("preserves the in-memory value across a cross-tab read-error event (validator throws)", () => {
+      window.localStorage.setItem("k", JSON.stringify("user-edit"));
+      const validatorError = new TypeError("validator boom");
+      let throwOnNext = false;
+      // Validator throws ONLY on the cross-tab post-image so the initial
+      // mount produces a valid probe (otherwise latestValidRef never
+      // populates and the test only exercises the mount-time-corrupt path).
+      const validateMaybeThrows = (value: unknown): value is string => {
+        if (throwOnNext) {
+          throw validatorError;
+        }
+        return typeof value === "string";
+      };
+
+      const { result } = renderHook(() =>
+        useLocalDb("k", "default", validateMaybeThrows)
+      );
+      expect(result.current[0]).toBe("user-edit");
+
+      throwOnNext = true;
+      act(() => {
+        fireCrossTabRaw("k", JSON.stringify("post-image"));
+      });
+
+      // Read-error branch must preserve in-memory state, not roll back to
+      // `defaultValue`.
+      expect(result.current[0]).toBe("user-edit");
+    });
+
+    it("toasts on a valid→read-error cross-tab transition (validator throws)", () => {
+      window.localStorage.setItem("k", JSON.stringify("user-edit"));
+      let throwOnNext = false;
+      const validateMaybeThrows = (value: unknown): value is string => {
+        if (throwOnNext) {
+          throw new TypeError("validator boom");
+        }
+        return typeof value === "string";
+      };
+
+      renderHook(() => useLocalDb("k", "default", validateMaybeThrows));
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+
+      throwOnNext = true;
+      act(() => {
+        fireCrossTabRaw("k", JSON.stringify("post-image"));
+      });
+
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledWith("k");
+    });
+
+    it("uses the latest in-memory value as `prev` for a functional setter when the setter's own re-read hits read-error", () => {
+      const initial: Rec = { a: 1, b: 2 };
+      window.localStorage.setItem("rec", JSON.stringify(initial));
+      let throwOnNext = false;
+      const validateMaybeThrows = (value: unknown): value is Rec => {
+        if (throwOnNext) {
+          throw new TypeError("validator boom");
+        }
+        return isRec(value);
+      };
+
+      const { result } = renderHook(() =>
+        useLocalDb<Rec>("rec", { a: 0, b: 0 }, validateMaybeThrows)
+      );
+
+      throwOnNext = true;
+      act(() => {
+        fireCrossTabRaw("rec", JSON.stringify({ a: "tampered" }));
+      });
+
+      // Keep `throwOnNext = true` through the setter so the setter's own
+      // `parseRawValue(readRawValue(key), validate)` re-read hits the
+      // read-error branch (validate throws) — NOT the corrupt branch
+      // (validate returns false). Without this discipline, a regression
+      // that dropped `read-error` from the setter's else-if would survive
+      // the suite. The read-error throw is caught inside `parseRawValue`
+      // and surfaces as `currentProbe.status === "read-error"`.
+      act(() => {
+        result.current[1]((prev) => ({ ...prev, a: 99 }));
+      });
+
+      const persisted: unknown = JSON.parse(
+        window.localStorage.getItem("rec") ?? "null"
+      );
+      expect(persisted).toEqual({ a: 99, b: 2 });
+    });
+
+    it("re-fires the toast on corrupt→valid→corrupt while `onCorrupt` stays once (asymmetry pin)", () => {
+      window.localStorage.setItem("k", JSON.stringify("ok"));
+      const onCorrupt = vi.fn();
+      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad-1");
+      });
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+      expect(onCorrupt).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        fireCrossTabRaw("k", JSON.stringify("recovered"));
+      });
+
+      act(() => {
+        fireCrossTabRaw("k", "{bad-2");
+      });
+
+      // Toast fires every fresh transition (UI signal must track each
+      // drift). `onCorrupt` is once-per-mount-key by design — telemetry
+      // intentionally does not repeat for the same session.
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(2);
+      expect(onCorrupt).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not pollute `latestValidRef` with corrupt-probe data (valid → corrupt → valid')", () => {
+      // Cache-purity invariant: only `valid` probes may update
+      // `latestValidRef`. A regression where a corrupt probe overwrote the
+      // cache (e.g. with `{ has: true, value: probe.raw }`) would not be
+      // caught by the existing valid→corrupt tests because they assert the
+      // pre-corruption value. This test pins the invariant by interposing a
+      // valid' (different) value AFTER the corrupt event and asserting the
+      // in-memory state reflects valid', not the corrupt blob's parsed-but-
+      // invalid form.
+      window.localStorage.setItem("k", JSON.stringify("first-valid"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("first-valid");
+
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+      // Corrupt probe must not have overwritten the cache.
+      expect(result.current[0]).toBe("first-valid");
+
+      act(() => {
+        fireCrossTabRaw("k", JSON.stringify("second-valid"));
+      });
+      // After a fresh valid probe, the cache must update — and any
+      // subsequent corrupt event must fall back to `second-valid`, not
+      // `first-valid` (which would indicate the corrupt probe had silently
+      // pinned the cache to the wrong slot).
+      expect(result.current[0]).toBe("second-valid");
+
+      act(() => {
+        fireCrossTabRaw("k", "{another corrupt blob");
+      });
+      expect(result.current[0]).toBe("second-valid");
+    });
+
+    it("uses the most recent setter-written value (not the mount-time value) as `latestValid` after multiple writes", () => {
+      const initial: Rec = { a: 1, b: 2 };
+      window.localStorage.setItem("rec", JSON.stringify(initial));
+
+      const { result } = renderHook(() =>
+        useLocalDb<Rec>("rec", { a: 0, b: 0 }, isRec)
+      );
+
+      // Several user-driven valid writes after mount — `latestValidRef`
+      // must track the most recent, not the mount-time blob.
+      act(() => {
+        result.current[1]({ a: 10, b: 20 });
+      });
+      act(() => {
+        result.current[1]({ a: 100, b: 200 });
+      });
+
+      act(() => {
+        fireCrossTabRaw("rec", "{not valid json");
+      });
+
+      act(() => {
+        result.current[1]((prev) => ({ ...prev, a: 999 }));
+      });
+
+      const persisted: unknown = JSON.parse(
+        window.localStorage.getItem("rec") ?? "null"
+      );
+      // `prev` must be the LAST setter-written record, not the mount-time
+      // one — otherwise post-mount edits silently disappear under
+      // cross-tab corruption.
+      expect(persisted).toEqual({ a: 999, b: 200 });
+    });
+
+    it("preserves both peer subscribers' in-memory values when a cross-tab corrupt event fires", () => {
+      window.localStorage.setItem("k", JSON.stringify("seed"));
+
+      const { result } = renderHook(() => ({
+        a: useLocalDb("k", "default", isString),
+        b: useLocalDb("k", "default", isString),
+      }));
+      expect(result.current.a[0]).toBe("seed");
+      expect(result.current.b[0]).toBe("seed");
+
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+
+      // Each instance has its own `latestValidRef` — both should
+      // independently keep the last-known-valid value.
+      expect(result.current.a[0]).toBe("seed");
+      expect(result.current.b[0]).toBe("seed");
+      // Each instance fires its own toast call; Mantine's `id` field on
+      // the notification is what dedups at the UI layer (out of scope
+      // here). Pin the per-instance call-count contract.
+      expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not toast on a cross-tab targeted removal (`event.key === "k"`, `newValue === null`)', () => {
+      window.localStorage.setItem("k", JSON.stringify("user-edit"));
+      const { result } = renderHook(() => useLocalDb("k", "default", isString));
+      expect(result.current[0]).toBe("user-edit");
+
+      act(() => {
+        window.localStorage.removeItem("k");
+        // Cross-tab targeted removal arrives with the specific key and a
+        // null newValue — distinct from `event.key === null` which fires
+        // on `localStorage.clear()`. Both must collapse to `absent` and
+        // stay silent on the toast surface.
+        window.dispatchEvent(
+          new StorageEvent("storage", {
+            key: "k",
+            newValue: null,
+            storageArea: window.localStorage,
+          })
+        );
+      });
+
+      expect(result.current[0]).toBe("default");
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("clears `wasValid` BEFORE invoking `notifyLocalDbCorruption` so a throw doesn't pin re-toast on every subsequent probe", () => {
+      // Pins the ordering invariant in the toast effect: the ref must be
+      // assigned before the call, otherwise a throw inside
+      // `notifyLocalDbCorruption` (e.g. notifications provider not mounted
+      // during prerender or pre-i18n init) leaves `wasValidRef` true and
+      // causes every subsequent probe to re-attempt the toast.
+      // Suppress the catch block's DEV-only console.warn so the test output
+      // stays quiet — match the suppression pattern used elsewhere in this
+      // file for intentional throw paths.
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {
+          // Intentionally swallow the dev-only warn from the wrapper's catch.
+        });
+      try {
+        mockNotifyLocalDbCorruption.mockImplementationOnce(() => {
+          throw new Error("notifications provider not mounted");
+        });
+        window.localStorage.setItem("k", JSON.stringify("ok"));
+        renderHook(() => useLocalDb("k", "default", isString));
+
+        act(() => {
+          fireCrossTabRaw("k", "{bad-1");
+        });
+        // First fire: throws inside the call. With the ordering fix,
+        // `wasValidRef` was already cleared to `{ wasValid: false }` before
+        // the throw. Without the fix, it would still be true.
+        expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+
+        act(() => {
+          fireCrossTabRaw("k", "{bad-2");
+        });
+        // Second fire (different bytes → fresh probe → effect re-runs).
+        // With the ordering fix: wasValid=false → no toast call (count stays 1).
+        // Without the fix: wasValid still true (mock no longer throws this
+        // time) → toast call → count would be 2.
+        expect(mockNotifyLocalDbCorruption).toHaveBeenCalledTimes(1);
+        // Telemetry breadcrumb pinned: the catch block must report the
+        // toast-pipeline failure to analytics so a regressed Mantine
+        // provider doesn't silently disable corruption toasts in production.
+        expect(mockReportLocalDbNotifyFailed).toHaveBeenCalledTimes(1);
+        expect(mockReportLocalDbNotifyFailed).toHaveBeenCalledWith(
+          "k",
+          expect.any(Error)
+        );
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
+    });
+
+    it("does not fire the toast when `key` changes to a key whose blob triggers a read-error (validator throws)", () => {
+      // Symmetric to the corrupt-branch key-swap test above. Pins the
+      // per-key guard's read-error variant.
+      let throwForKey: string | null = null;
+      const validateMaybeThrows = (value: unknown): value is string => {
+        if (throwForKey !== null) {
+          throw new TypeError("validator boom");
+        }
+        return typeof value === "string";
+      };
+
+      window.localStorage.setItem("key-a", JSON.stringify("from-a"));
+      window.localStorage.setItem("key-b", JSON.stringify("from-b"));
+
+      const { rerender } = renderHook(
+        ({ k }: { k: string }) => useLocalDb(k, "default", validateMaybeThrows),
+        { initialProps: { k: "key-a" } }
+      );
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+
+      throwForKey = "key-b";
+      rerender({ k: "key-b" });
+
+      // First probe of key-b is read-error (validator throws). The per-key
+      // guard rejects the stale `wasValidRef.current.key === "key-a"`, so
+      // this looks like mount-time corruption for key-b, not a transition.
+      expect(mockNotifyLocalDbCorruption).not.toHaveBeenCalled();
+    });
+
+    it("preserves each peer subscriber's last-known-valid value independently when one peer wrote fresh state before a cross-tab corrupt event", () => {
+      window.localStorage.setItem("k", JSON.stringify("seed"));
+
+      const { result } = renderHook(() => ({
+        a: useLocalDb("k", "default", isString),
+        b: useLocalDb("k", "default", isString),
+      }));
+
+      // Peer A writes a fresh value via the setter; the same-tab custom
+      // event propagates to peer B, so both update their own
+      // `latestValidRef` to "fresh-from-a".
+      act(() => {
+        result.current.a[1]("fresh-from-a");
+      });
+      expect(result.current.a[0]).toBe("fresh-from-a");
+      expect(result.current.b[0]).toBe("fresh-from-a");
+
+      // Cross-tab corrupt event arrives — both peers' in-memory state
+      // must hold the post-write value, not the seed and not the default.
+      act(() => {
+        fireCrossTabRaw("k", "{not valid json");
+      });
+
+      expect(result.current.a[0]).toBe("fresh-from-a");
+      expect(result.current.b[0]).toBe("fresh-from-a");
     });
   });
 

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -6,6 +6,10 @@ import {
   useRef,
   useSyncExternalStore,
 } from "react";
+import {
+  notifyLocalDbCorruption,
+  reportLocalDbNotifyFailed,
+} from "./localstorage-telemetry";
 
 /**
  * Result of probing a localStorage key: distinguishes "key absent" from "key
@@ -215,6 +219,20 @@ const dispatchKeyChange = (key: string): void => {
 // real value once `window` is present.
 const getServerSnapshot = (): null => null;
 
+// Latest-valid cache slot. `has: false` is the bootstrap sentinel before any
+// valid probe has been observed; once a valid probe arrives, the slot flips
+// to `has: true` carrying the value AND the key it belongs to. The key is
+// embedded so a `key` prop change clears the cache implicitly — readers
+// match against the current `key` and fall back to `defaultValue` when the
+// cached entry is stale (mirrors the per-key discipline of `reportedKeyRef`).
+type LatestValidSlot<T> = { has: false } | { has: true; key: string; value: T };
+
+// Previous-probe-validity cache. Same per-key embedding rationale as
+// `LatestValidSlot`: a `key` prop change must NOT make the new key's first
+// corrupt probe look like a valid→corrupt transition (which would fire the
+// post-mount Mantine toast for what is actually mount-time corruption).
+type WasValidSlot = { wasValid: false } | { wasValid: true; key: string };
+
 /**
  * A reactive wrapper around `localStorage` for JSON-serializable values.
  *
@@ -253,6 +271,16 @@ const getServerSnapshot = (): null => null;
  * tabs. Same-tab sync (multiple `useLocalDb` instances on the same key)
  * goes through a project-internal `memdeck-localstorage` `CustomEvent`
  * dispatched on every write.
+ *
+ * **Cross-tab corruption:** when a cross-tab `storage` event delivers a
+ * value that fails JSON.parse / validate, the consumer-facing `value` and
+ * the setter's `prev` (for functional updates) both fall back to the most
+ * recently-observed valid value rather than `defaultValue`. The on-disk
+ * blob is corrupt until the next write, but the user's in-memory state is
+ * preserved. A Mantine notification (`notifyLocalDbCorruption`) fires once
+ * per valid→corrupt transition so the user knows another tab wrote
+ * unreadable data — mount-time corruption stays silent here (consumers
+ * that care, e.g. `useStackLimits`, surface their own toast).
  */
 export const useLocalDb = <T>(
   key: string,
@@ -297,6 +325,20 @@ export const useLocalDb = <T>(
   // new-failure case still surfaces.
   const reportedWriteKeyRef = useRef<string | null>(null);
 
+  // Latest-valid cache for the rollback fix (issue #628). Updated in the
+  // value `useMemo` below; consulted by both the value computation and the
+  // setter when the on-disk probe is corrupt.
+  const latestValidRef = useRef<LatestValidSlot<T>>({ has: false });
+
+  // Tracks whether the previous probe was valid, so the transition-toast
+  // effect can fire a notification on the valid→corrupt edge specifically
+  // (and not on mount-time corruption, repeated corrupt events, or
+  // cross-tab `clear()` which surfaces as `absent`). The slot embeds the
+  // `key` it belongs to — without it, a `key` prop change would leave the
+  // boolean `true` from the previous key and the new key's first corrupt
+  // probe would falsely fire as a valid→corrupt transition.
+  const wasValidRef = useRef<WasValidSlot>({ wasValid: false });
+
   // Capture latest callbacks in refs so the setter / effect closures stay
   // stable regardless of whether the caller passes inline arrows.
   const onCorruptRef = useRef(onCorrupt);
@@ -331,10 +373,74 @@ export const useLocalDb = <T>(
     }
   }, [key, probe]);
 
-  const value = useMemo(
-    (): T => (probe.status === "valid" ? probe.value : defaultValue),
-    [probe, defaultValue]
-  );
+  // Cross-tab corruption surface: fires a Mantine toast on the valid→corrupt
+  // transition only. `wasValidRef` starts `{ wasValid: false }` so a
+  // mount-time corrupt probe stays silent; `absent` (cross-tab `clear()`)
+  // is excluded so a deliberate reset doesn't masquerade as corruption.
+  // After the toast fires, `wasValidRef` is `{ wasValid: false }` until the
+  // next valid probe — a streak of corrupt events doesn't re-toast, but a
+  // corrupt→valid→corrupt sequence does (correctly — that's a fresh
+  // transition). The `wasValid && key === ...` check rejects stale state
+  // from a previous `key` prop value (otherwise a key swap would falsely
+  // fire as a transition for the new key's mount-time probe).
+  //
+  // Asymmetry with `onCorrupt`: this toast effect re-fires on every
+  // valid→corrupt transition, but `onCorrupt` is once-per-mount-key (its
+  // `reportedKeyRef` latches and never resets on a valid probe). The
+  // asymmetry is intentional — telemetry shouldn't repeat for the same
+  // session, but UI feedback should track every fresh drift event.
+  useEffect(() => {
+    const wasValid =
+      wasValidRef.current.wasValid && wasValidRef.current.key === key;
+    const isValid = probe.status === "valid";
+    // Update the ref BEFORE invoking the toast so a throw inside
+    // `notifyLocalDbCorruption` (e.g. notifications provider not mounted
+    // during prerender or pre-i18n init) doesn't pin `wasValid` true and
+    // cause every subsequent probe to re-attempt the toast.
+    wasValidRef.current = isValid
+      ? { wasValid: true, key }
+      : { wasValid: false };
+    if (
+      wasValid &&
+      (probe.status === "corrupt" || probe.status === "read-error")
+    ) {
+      try {
+        notifyLocalDbCorruption(key);
+      } catch (notifyError) {
+        // Surface the toast-pipeline failure to analytics so a regressed
+        // Mantine provider mount or pre-i18n init throw doesn't silently
+        // disable corruption toasts in production. The data path keeps
+        // working (last-known-valid fallback runs above), but without this
+        // breadcrumb the UI signal would vanish with no telemetry trace.
+        reportLocalDbNotifyFailed(key, notifyError);
+        if (import.meta.env.DEV) {
+          console.warn(
+            `[localStorage] notifyLocalDbCorruption threw for key "${key}":`,
+            notifyError
+          );
+        }
+      }
+    }
+  }, [key, probe]);
+
+  const value = useMemo((): T => {
+    if (probe.status === "valid") {
+      latestValidRef.current = { has: true, key, value: probe.value };
+      return probe.value;
+    }
+    if (probe.status === "absent") {
+      return defaultValue;
+    }
+    // corrupt | read-error: prefer last-known-valid in-memory state so a
+    // cross-tab corrupt write doesn't roll back the user's in-flight edits
+    // to `defaultValue`. The cached entry must belong to the current `key`
+    // — otherwise a key swap would silently surface the previous key's
+    // value when the new key's stored blob is corrupt or invalid.
+    if (latestValidRef.current.has && latestValidRef.current.key === key) {
+      return latestValidRef.current.value;
+    }
+    return defaultValue;
+  }, [probe, defaultValue, key]);
 
   const handleWriteSuccess = useCallback(
     (onSuccess: (() => void) | undefined): void => {
@@ -387,9 +493,30 @@ export const useLocalDb = <T>(
       // wrapper-level corrupt-lock here: it would silently break recovery
       // for the single-value consumers without buying any new protection
       // for the multi-record ones.
+      //
+      // Cross-tab corruption rollback (issue #628): when the on-disk probe
+      // is corrupt/read-error, prefer `latestValidRef.current.value` as
+      // `prev` for functional updates so multi-field record consumers like
+      // `useTimerSettings` ({ enabled, duration }) don't drop the user's
+      // last-saved fields. `absent` keeps `defaultValue` semantics — a
+      // cross-tab `clear()` is a deliberate reset, not a corruption event.
+      // The cached entry must belong to the current `key`; otherwise a key
+      // swap would feed the previous key's value into a functional updater
+      // and persist a record that mixes both keys' state.
       const currentProbe = parseRawValue(readRawValue(key), validate);
-      const prev =
-        currentProbe.status === "valid" ? currentProbe.value : defaultValue;
+      let prev: T;
+      if (currentProbe.status === "valid") {
+        prev = currentProbe.value;
+      } else if (currentProbe.status === "absent") {
+        prev = defaultValue;
+      } else if (
+        latestValidRef.current.has &&
+        latestValidRef.current.key === key
+      ) {
+        prev = latestValidRef.current.value;
+      } else {
+        prev = defaultValue;
+      }
       const resolved =
         typeof next === "function"
           ? // `as` justified: typeof check cannot narrow `T | ((prev: T) => T)`


### PR DESCRIPTION
## Summary

A cross-tab `storage` event delivering an unparseable or invalid blob previously rolled the consumer's `value` (and the setter's `prev`) back to `defaultValue`, silently dropping in-flight edits. The fix:

- Caches the last-known-valid value per key in `latestValidRef` (key-embedded so a `key` prop swap clears the cache implicitly).
- Prefers the cached value on `corrupt` / `read-error` probes — both for the rendered value and the functional setter's `prev` argument.
- Surfaces the valid→corrupt transition via a Mantine toast (`notifyLocalDbCorruption`) so users learn another tab wrote unreadable data. Mount-time corruption stays silent — consumers like `useStackLimits` already surface their own dedicated mount toast.
- `wasValidRef` is updated **before** the toast call so a throw inside `notifyLocalDbCorruption` (e.g. notifications provider not mounted during prerender or pre-i18n init) does not pin the transition state and re-fire the toast on every subsequent probe.
- `reportLocalDbNotifyFailed` forwards toast-pipeline failures to analytics with the same redaction discipline as the existing `reportLocalDb*` helpers.

Asymmetry pin: `onCorrupt` telemetry remains once-per-mount-key, but the toast re-fires on every fresh valid→corrupt transition — telemetry shouldn't repeat for the same session, but UI feedback should track every drift event.

## Test plan

- [x] New `useLocalDb` tests cover the read-side rollback, the write-side functional-setter `prev` rollback, mount-time silence, valid→corrupt toast, no re-toast on consecutive corrupt events, corrupt→valid→corrupt re-fires (asymmetry vs. `onCorrupt`), `read-error` (validator throws) parity, key-swap per-key guard for both `corrupt` and `read-error` branches, ref-write-before-toast ordering, multi-instance peer independence, and cache-purity invariant.
- [x] `reportLocalDbNotifyFailed` unit tests cover Error / string / unknown causes (matching the existing `reportLocalDbWriteFailed` redaction pattern).
- [x] Locale additions for the new `errors.localDbCorrupt.title` / `.message` keys across all 7 supported languages.

Closes #628