### PR TITLE
refactor: thread timerSettings into useAcaanGame

### DIFF
--- a/src/pages/acaan/acaan.tsx
+++ b/src/pages/acaan/acaan.tsx
@@ -63,18 +63,19 @@ export const Acaan = () => {
     dismissSummary,
   } = useSession({ mode: "acaan", stackKey, autoStart: true });
 
+  const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
+    useAcaanSettings();
+
   const {
     scenario,
     score,
     timeRemaining,
-    timerEnabled,
     timerDuration,
     submitAnswer,
     revealAnswer,
-  } = useAcaanGame(stackOrder, stackName, { onAnswer: handleAnswer });
-
-  const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
-    useAcaanSettings();
+  } = useAcaanGame(stackOrder, stackName, timerSettings, {
+    onAnswer: handleAnswer,
+  });
 
   const handleRevealAnswer = useCallback(() => {
     analytics.trackFeatureUsed("Reveal Answer - ACAAN");
@@ -129,7 +130,7 @@ export const Acaan = () => {
         </Grid.Col>
         <Grid.Col span={12}>
           <Space h="xl" />
-          {timerEnabled && (
+          {timerSettings.enabled && (
             <TimerDisplay
               timeRemaining={timeRemaining}
               timerDuration={timerDuration}

--- a/src/pages/acaan/use-acaan-game.test.ts
+++ b/src/pages/acaan/use-acaan-game.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeckPosition, type Stack } from "../../types/stacks";
 import { aronson } from "../../types/stacks/aronson";
 import { mnemonica } from "../../types/stacks/mnemonica";
+import type { TimerSettings } from "../../types/timer";
 import type { AcaanScenario } from "../../utils/acaan-scenario";
 import { calculateCutDepth } from "../../utils/acaan-scenario";
 import {
@@ -17,13 +18,6 @@ import { useAcaanGame } from "./use-acaan-game";
 
 vi.mock("@mantine/notifications", () => ({
   notifications: { show: vi.fn() },
-}));
-
-vi.mock("../../hooks/use-acaan-timer", () => ({
-  useAcaanTimer: () => ({
-    timerSettings: { enabled: false, duration: 15 },
-    setTimerSettings: vi.fn(),
-  }),
 }));
 
 vi.mock("../../hooks/use-game-timer", () => {
@@ -55,6 +49,8 @@ vi.mock("../../services/event-bus", () => ({
     emit: { ACAAN_ANSWER: vi.fn() },
   },
 }));
+
+const mockTimerSettings: TimerSettings = { enabled: false, duration: 15 };
 
 // Helper to create a test scenario
 const createTestScenario = (
@@ -536,7 +532,7 @@ describe("useAcaanGame hook", () => {
         await import("@mantine/notifications")
       );
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       const { cardPosition, targetPosition } = result.current.scenario;
@@ -559,7 +555,7 @@ describe("useAcaanGame hook", () => {
 
     it("increments fails count", () => {
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       expect(result.current.score.fails).toBe(0);
@@ -573,7 +569,7 @@ describe("useAcaanGame hook", () => {
 
     it("advances to a new scenario", () => {
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       const originalScenario = result.current.scenario;
@@ -588,7 +584,9 @@ describe("useAcaanGame hook", () => {
     it("calls onAnswer callback with correct: false and questionAdvanced: true", () => {
       const onAnswer = vi.fn();
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica", { onAnswer })
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings, {
+          onAnswer,
+        })
       );
 
       act(() => {
@@ -604,7 +602,7 @@ describe("useAcaanGame hook", () => {
     it("emits ACAAN_ANSWER event with correct: false", async () => {
       const { eventBus } = await import("../../services/event-bus");
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       act(() => {
@@ -622,7 +620,7 @@ describe("useAcaanGame hook", () => {
     it("emits ACAAN_ANSWER event with correct: true on correct answer", async () => {
       const { eventBus } = await import("../../services/event-bus");
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       const { cardPosition, targetPosition } = result.current.scenario;
@@ -641,7 +639,7 @@ describe("useAcaanGame hook", () => {
     it("emits ACAAN_ANSWER event with correct: false on wrong answer", async () => {
       const { eventBus } = await import("../../services/event-bus");
       const { result } = renderHook(() =>
-        useAcaanGame(mnemonica.order, "Mnemonica")
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
       );
 
       const { cardPosition, targetPosition } = result.current.scenario;
@@ -668,7 +666,9 @@ describe("useAcaanGame hook", () => {
         __getCapturedOnTimeout: () => (() => void) | undefined;
       };
 
-      renderHook(() => useAcaanGame(mnemonica.order, "Mnemonica"));
+      renderHook(() =>
+        useAcaanGame(mnemonica.order, "Mnemonica", mockTimerSettings)
+      );
 
       const onTimeout = gameTimerMock.__getCapturedOnTimeout();
       expect(onTimeout).toBeDefined();
@@ -696,7 +696,8 @@ describe("useAcaanGame hook", () => {
         name: "Mnemonica",
       };
       const { result, rerender } = renderHook(
-        ({ stack, name }: Props) => useAcaanGame(stack, name),
+        ({ stack, name }: Props) =>
+          useAcaanGame(stack, name, mockTimerSettings),
         { initialProps }
       );
 

--- a/src/pages/acaan/use-acaan-game.ts
+++ b/src/pages/acaan/use-acaan-game.ts
@@ -2,12 +2,12 @@ import { notifications } from "@mantine/notifications";
 import { useCallback, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { NOTIFICATION_CLOSE_TIMEOUT } from "../../constants";
-import { useAcaanTimer } from "../../hooks/use-acaan-timer";
 import { useGameTimer } from "../../hooks/use-game-timer";
 import { eventBus } from "../../services/event-bus";
 import type { GameScore } from "../../types/game";
 import type { AnswerOutcome } from "../../types/session";
 import type { Stack, StackValue } from "../../types/stacks";
+import type { TimerSettings } from "../../types/timer";
 import type { AcaanScenario } from "../../utils/acaan-scenario";
 import { generateAcaanScenario } from "../../utils/acaan-scenario";
 import {
@@ -27,7 +27,6 @@ type UseAcaanGameResult = {
   scenario: AcaanScenario;
   score: GameScore;
   timeRemaining: number;
-  timerEnabled: boolean;
   timerDuration: number;
   submitAnswer: (userAnswer: number) => void;
   revealAnswer: () => void;
@@ -36,10 +35,10 @@ type UseAcaanGameResult = {
 export const useAcaanGame = (
   stackOrder: Stack,
   stackName: StackValue["name"],
+  timerSettings: TimerSettings,
   options?: UseAcaanGameOptions
 ): UseAcaanGameResult => {
   const { t } = useTranslation();
-  const { timerSettings } = useAcaanTimer();
 
   // Refs let callbacks below read the latest stackOrder/stackName without
   // being re-created when those props change.
@@ -175,7 +174,6 @@ export const useAcaanGame = (
     scenario: state.scenario,
     score: { successes: state.successes, fails: state.fails },
     timeRemaining: state.timeRemaining,
-    timerEnabled: timerSettings.enabled,
     timerDuration: state.timerDuration,
     submitAnswer,
     revealAnswer,


### PR DESCRIPTION
## Summary
- Move `useAcaanTimer()` out of `useAcaanGame` and accept `timerSettings: TimerSettings` as a parameter, matching the Flashcard / Distance / SpotCheck pattern.
- Drop `timerEnabled` from `UseAcaanGameResult`; the page reads `timerSettings.enabled` from `useAcaanSettings` directly.
- Update the test file: remove the `useAcaanTimer` mock, add a typed `mockTimerSettings` fixture, thread it into all `useAcaanGame(...)` call sites.

Result: one `useLocalDb` subscription to `ACAAN_TRAINER_TIMER_LSK` instead of two, eliminating the first-paint timing inconsistency described in the issue.

Closes #627

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint` (Ultracite, via rtk proxy — full-repo OOM is a pre-existing RTK buffering issue, not Biome)
- [x] `pnpm run knip`
- [x] `pnpm run fta` (no acaan files flagged)
- [x] `pnpm run test:coverage` (1776/1776 passing)
- [ ] Manual smoke: open `/acaan/`, toggle timer enable + change duration, confirm UI reacts synchronously