### PR TITLE
docs: route lint through rtk proxy in Claude sessions

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -5,7 +5,7 @@ description: Run the Definition of Done for memdeck.org
 Run the verification protocol from CLAUDE.md, in order, stopping at the first failure:
 
 1. `pnpm run typecheck`
-2. `pnpm run lint`
+2. `rtk proxy pnpm run lint` (NOT `pnpm run lint` — the plain form OOMs in Claude sessions due to RTK output buffering; see CLAUDE.md "Lint invocation")
 3. `pnpm run knip`
 4. `pnpm run fta`
 5. `pnpm run test:coverage`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,14 @@ Never sacrifice readability or testability for performance unless profiling prov
 - **Verify before declaring done.** After changes to `src/**` or `scripts/**`, run the Definition of Done below. A passing type-check alone is not sufficient once UI, routing, or tests are involved.
 - **If you can't actually run it, say so.** For UI changes you can't exercise in a browser, state that explicitly instead of claiming success. Type-checks and unit tests verify code correctness, not feature correctness.
 
+### Lint invocation
+
+When running the linter in this repo, ALWAYS invoke it as `rtk proxy pnpm run lint`, never `pnpm run lint`. The plain form is silently rewritten to `rtk lint` by the user-level RTK PreToolUse hook, which buffers Biome's full output for filtering and OOMs on full-repo runs in Claude sessions. `rtk proxy` keeps RTK's command tracking but skips the output filter and does not OOM. This applies to `/verify`, plan execution, and any ad-hoc invocation. The per-file `ultracite fix <path>` PostToolUse hook is unaffected and stays as-is.
+
 ### Definition of Done (run in order; stop at first failure)
 
 1. `pnpm run typecheck`
-2. `pnpm run lint`
+2. `rtk proxy pnpm run lint` (see "Lint invocation")
 3. `pnpm run knip` — catches unused exports, dependencies, and files. Runs in seconds.
 4. `pnpm run fta` — file-complexity check; CI fails on regressions.
 5. `pnpm run test:coverage` — runs the full unit suite **and** enforces the per-directory coverage ratchets in `vitest.config.ts`. Use this in place of `pnpm run test` for DoD.


### PR DESCRIPTION
## Summary

Plain `pnpm run lint` is silently rewritten to `rtk lint` by the user-level RTK PreToolUse Bash hook, which buffers Biome's full output for filtering. On full-repo runs in Claude sessions, the buffer pushes the wrapper process over the OOM threshold. Standalone shell runs are unaffected — the issue is the wrapper, not Biome.

This routes Claude's lint invocations through `rtk proxy pnpm run lint`, which keeps RTK's command tracking but skips the in-memory output filter.

- `CLAUDE.md` — adds a **Lint invocation** subsection under the Verification Protocol explaining the rule and the OOM mechanism; updates Definition of Done step 2 to use `rtk proxy pnpm run lint`.
- `.claude/commands/verify.md` — updates step 2 with an inline cross-reference to the rule.

## Test plan

- [x] `git diff --stat` confirms only the two doc files changed.
- [ ] After merge, future Claude sessions running `/verify` use `rtk proxy pnpm run lint` and stop OOMing.
- [ ] Standalone `pnpm run lint` in the user's own shell continues to work as before — no shell-level rewrite changed.