### PR TITLE
chore: bump tsconfig.app.json to ES2022

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ All memorized decks are centralized in `src/types/stacks.ts`:
 - **Use `const` by default**, `let` only when reassignment is needed, never `var`.
 - **Use `for...of`** over `.forEach()` and indexed `for` loops.
 - **Use optional chaining (`?.`) and nullish coalescing (`??`)** for safer property access.
+- **Prefer ES2022 built-ins.** Both `tsconfig.app.json` and `tsconfig.node.json` target ES2022. Use `Object.hasOwn(obj, key)` over `Object.prototype.hasOwnProperty.call(...)`, `arr.at(-1)` over `arr[arr.length - 1]`, `findLast` / `findLastIndex` over manual reverse-loops, and `new Error(msg, { cause })` for error chaining. Exception: `src/utils/localstorage-telemetry.ts` deliberately drops `cause` to keep V8's `JSON.parse` SyntaxError snippet out of analytics — see the file's lines 16–19 comment before refactoring it.
 
 ## Formatting & Linting
 

--- a/src/hooks/use-session.test.ts
+++ b/src/hooks/use-session.test.ts
@@ -806,8 +806,7 @@ describe("useSession hook", () => {
     expect(updated.status.phase).toBe("summary");
     // The persisted record should reflect the new limits, not the old ones.
     const calls = mockBuildSessionRecord.mock.calls;
-    // biome-ignore lint/style/useAtIndex: tsconfig.app lib is ES2020 — Array.prototype.at type is not available on mock.calls' inferred type
-    const finalizedSession = calls[calls.length - 1]?.[0];
+    const finalizedSession = calls.at(-1)?.[0];
     expect(finalizedSession?.stackLimits).toEqual(limitsB);
   });
 

--- a/src/pages/toolbox/spell-card.ts
+++ b/src/pages/toolbox/spell-card.ts
@@ -10,7 +10,7 @@ export type SpellingEntry = {
 };
 
 export const getLetterCount = (name: string): number =>
-  name.split(" ").join("").length;
+  name.replaceAll(" ", "").length;
 
 export const getSpellingData = (
   stackOrder: Stack,

--- a/src/utils/session-typeguards.ts
+++ b/src/utils/session-typeguards.ts
@@ -155,10 +155,7 @@ const FOREIGN_MODE_FIELDS = {
 // entirely OR explicitly `undefined`. An explicit `null` (or any other value)
 // is corrupt — a record carrying `"flashcardMode": null` on an acaan session
 // would otherwise pass this guard and reach reducers that don't expect it.
-const hasOwn = (obj: object, key: string): boolean => {
-  // biome-ignore lint/suspicious/noPrototypeBuiltins: project tsconfig targets ES2020 lib; Object.hasOwn requires ES2022.
-  return Object.prototype.hasOwnProperty.call(obj, key);
-};
+const hasOwn = (obj: object, key: string): boolean => Object.hasOwn(obj, key);
 
 const hasNoForeignModeFields = (
   value: Record<string, unknown>,

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary

- Bumps `tsconfig.app.json` `target` and `lib` from ES2020 → ES2022 to align with `tsconfig.node.json`.
- Removes two fragile `biome-ignore` comments that were workarounds for the ES2020 lib limitation:
  - `src/utils/session-typeguards.ts:158` — switches to `Object.hasOwn`.
  - `src/hooks/use-session.test.ts:809` — switches to `calls.at(-1)`.
- Modernizes `src/pages/toolbox/spell-card.ts` from `name.split(' ').join('')` to `name.replaceAll(' ', '')`.
- Adds a `CLAUDE.md` bullet documenting ES2022 idiom preferences (`Object.hasOwn`, `arr.at`, `findLast`/`findLastIndex`, `new Error(msg, { cause })`) with the explicit `localstorage-telemetry.ts` V8 SyntaxError redaction exception so future code generation does not re-introduce the leak.

The shipped delta is exactly one ES2022 runtime API call in production code (`Object.hasOwn`), so the practical browser-cutoff exposure is "Safari 16.3+ for that one call site," not a wholesale ES2022 cutoff. `browserslist.production` is permissive (`>0.2%, not dead, not op_mini all`) and Safari 16.3 shipped Jan 2023.

## Out of scope (deliberate non-changes)

- `src/utils/localstorage-telemetry.ts` is unchanged. Adopting `{ cause }` there would re-introduce the V8 `JSON.parse` SyntaxError snippet leak the file is engineered to prevent (see lines 16-19 of that file).
- No new tests — all changes are semantically identical refactors with existing implicit/explicit coverage.

## Test plan

- [x] `pnpm run typecheck`
- [x] `rtk proxy pnpm run lint`
- [x] `pnpm run knip`
- [x] `pnpm run fta`
- [x] `pnpm run test:coverage`
- [x] Confirmed no class components affected by the `useDefineForClassFields` + ES2022 native class-field semantics change

Closes #633