### PR TITLE
fix(telemetry): consolidate localStorage write-error paths so GA sees one exception taxonomy

### DIFF
--- a/src/hooks/use-session-auto-save.test.ts
+++ b/src/hooks/use-session-auto-save.test.ts
@@ -536,7 +536,11 @@ describe("useSessionAutoSave", () => {
       expect(analytics.trackError).toHaveBeenCalledOnce();
       const [error, context] = vi.mocked(analytics.trackError).mock.calls[0];
       expect(error).toBeInstanceOf(Error);
-      expect(error.message).toContain("write-failed");
+      // `name` IS GA's `action` dimension — the discriminator the consolidation
+      // exists to set. write-failed shares the LocalDbWriteFailed bucket with
+      // useLocalDb's write path.
+      expect(error.name).toBe("LocalDbWriteFailed");
+      expect(error.message).toBe("reason=write-failed");
       // Cleanup path on internal-navigation unmount uses the :cleanup context
       // so triage can split it from real beforeunload (page-close) failures.
       expect(context).toBe("useSessionAutoSave:cleanup");
@@ -561,7 +565,10 @@ describe("useSessionAutoSave", () => {
 
       expect(analytics.trackError).toHaveBeenCalledOnce();
       const [error] = vi.mocked(analytics.trackError).mock.calls[0];
-      expect(error.message).toContain("corrupt");
+      // corrupt = two failed writes (stats write + history rollback), so it
+      // also lands in the LocalDbWriteFailed bucket.
+      expect(error.name).toBe("LocalDbWriteFailed");
+      expect(error.message).toBe("reason=corrupt");
     });
 
     it("does NOT emit analytics.trackError when tryFinalizeSession returns duplicate", () => {
@@ -597,7 +604,7 @@ describe("useSessionAutoSave", () => {
       expect(analytics.trackError).not.toHaveBeenCalled();
     });
 
-    it("writes the last-save-failed breadcrumb on beforeunload when finalize returns write-failed", () => {
+    it("writes the breadcrumb and reports to GA on beforeunload when finalize returns write-failed", () => {
       // Real beforeunload (page closing) cannot show a notification — the
       // hook persists a breadcrumb so the next session start surfaces the
       // failure to the user.
@@ -623,6 +630,15 @@ describe("useSessionAutoSave", () => {
       expect(writeLastSaveFailedBreadcrumb).toHaveBeenCalledWith(
         "write-failed"
       );
+      // The :beforeUnload context string is the load-bearing GA discriminator
+      // that splits page-close failures from the :cleanup path. Assert it here
+      // so a regression that swaps/drops it on this branch fails a test — the
+      // :cleanup path asserts the symmetric thing in the observability suite.
+      expect(analytics.trackError).toHaveBeenCalledOnce();
+      const [error, context] = vi.mocked(analytics.trackError).mock.calls[0];
+      expect(error.name).toBe("LocalDbWriteFailed");
+      expect(error.message).toBe("reason=write-failed");
+      expect(context).toBe("useSessionAutoSave:beforeUnload");
     });
 
     it("does NOT write the last-save-failed breadcrumb on the React-cleanup path even on write-failed", () => {

--- a/src/hooks/use-session-auto-save.ts
+++ b/src/hooks/use-session-auto-save.ts
@@ -7,9 +7,9 @@ import {
   useRef,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { analytics } from "../services/analytics";
 import type { ActiveSession, SessionPhase } from "../types/session";
 import type { StackKey } from "../types/stacks";
+import { reportSessionPersistenceFailed } from "../utils/localstorage-telemetry";
 import { writeLastSaveFailedBreadcrumb } from "../utils/session-breadcrumbs";
 import { meetsMinimumSaveThreshold } from "../utils/session-phase";
 import type { TryFinalizeSessionResult } from "./use-session";
@@ -86,8 +86,10 @@ export const useSessionAutoSave = ({
       const result = tryFinalizeSession(current.session);
       if (result.status === "write-failed") {
         writeLastSaveFailedBreadcrumb(result.reason);
-        analytics.trackError(
-          new Error(`Session save failed on unload (${result.reason})`),
+        // The :beforeUnload context distinguishes this from the :cleanup and
+        // useSession:flush call sites in GA — see reportSessionPersistenceFailed.
+        reportSessionPersistenceFailed(
+          result.reason,
           "useSessionAutoSave:beforeUnload"
         );
         if (import.meta.env.DEV) {
@@ -111,8 +113,8 @@ export const useSessionAutoSave = ({
       }
       const result = tryFinalizeSession(current.session);
       if (result.status === "write-failed") {
-        analytics.trackError(
-          new Error(`Session save failed on cleanup (${result.reason})`),
+        reportSessionPersistenceFailed(
+          result.reason,
           "useSessionAutoSave:cleanup"
         );
         const isUnrecoverable =

--- a/src/hooks/use-session.test.ts
+++ b/src/hooks/use-session.test.ts
@@ -851,8 +851,14 @@ describe("useSession hook", () => {
       // Every finalize failure reports to analytics — the auto-save cleanup
       // path reports unconditionally and asymmetry here was undercounting
       // user-Stop quota failures in GA.
+      // write-failed shares the LocalDbWriteFailed GA bucket with useLocalDb's
+      // write path — see reportSessionPersistenceFailed. `name` IS the GA
+      // `action` dimension, so it's the discriminator the fix exists to set.
       expect(mockTrackError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "Session finalize: write-failed" }),
+        expect.objectContaining({
+          name: "LocalDbWriteFailed",
+          message: "reason=write-failed",
+        }),
         "useSession:flush"
       );
     });
@@ -873,8 +879,13 @@ describe("useSession hook", () => {
           message: "errors.sessionStorageCorrupt.message",
         })
       );
+      // corrupt = two failed writes (stats write + history rollback), so it
+      // also lands in the LocalDbWriteFailed bucket.
       expect(mockTrackError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: "Session finalize: corrupt" }),
+        expect.objectContaining({
+          name: "LocalDbWriteFailed",
+          message: "reason=corrupt",
+        }),
         "useSession:flush"
       );
       // Phase stays active but the session id was added to finalizedIds so
@@ -898,9 +909,13 @@ describe("useSession hook", () => {
           title: "errors.sessionStorageCorrupt.title",
         })
       );
+      // corrupt-prior-state involved no failed write (we refused to overwrite),
+      // so it gets the distinct LocalDbPersistenceFailed name rather than
+      // inflating the write-failure bucket.
       expect(mockTrackError).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: "Session finalize: corrupt-prior-state",
+          name: "LocalDbPersistenceFailed",
+          message: "reason=corrupt-prior-state",
         }),
         "useSession:flush"
       );
@@ -920,9 +935,12 @@ describe("useSession hook", () => {
           title: "errors.sessionSaveFailed.title",
         })
       );
+      // serialize-failed is a JSON.stringify failure — no write was attempted,
+      // so it shares the LocalDbPersistenceFailed name, not LocalDbWriteFailed.
       expect(mockTrackError).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: "Session finalize: serialize-failed",
+          name: "LocalDbPersistenceFailed",
+          message: "reason=serialize-failed",
         }),
         "useSession:flush"
       );

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -1,7 +1,6 @@
 import { notifications } from "@mantine/notifications";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { analytics } from "../services/analytics";
 import { eventBus } from "../services/event-bus";
 import type { DistanceConvention, DistanceMode } from "../types/distance";
 import type { FlashcardMode } from "../types/flashcard";
@@ -16,6 +15,7 @@ import type {
 import type { SpotCheckMode } from "../types/spot-check";
 import type { StackLimits } from "../types/stack-limits";
 import type { StackKey } from "../types/stacks";
+import { reportSessionPersistenceFailed } from "../utils/localstorage-telemetry";
 import {
   clearLastSaveFailedBreadcrumb,
   hasLastSaveFailedNotificationBeenShown,
@@ -23,7 +23,7 @@ import {
   readLastSaveFailedBreadcrumb,
 } from "../utils/session-breadcrumbs";
 import {
-  type FinalizeSessionResult,
+  type FinalizeFailureReason,
   finalizeSession,
 } from "../utils/session-persistence";
 import {
@@ -76,17 +76,15 @@ type UseSessionResult = {
  * (`write-failed`) so they can decide whether to surface the failure to
  * analytics or the user. `finalized` carries the computed summary on success.
  *
- * The `reason` on `write-failed` mirrors `FinalizeSessionResult.reason` so
- * callers can differentiate quota/serialization failures from a corrupt
- * on-disk state where the rollback also failed.
+ * The `reason` on `write-failed` is `FinalizeFailureReason` — the same union
+ * as `FinalizeSessionResult.reason` — so callers can differentiate
+ * quota/serialization failures from a corrupt on-disk state where the
+ * rollback also failed.
  */
 export type TryFinalizeSessionResult =
   | { status: "finalized"; summary: SessionSummary }
   | { status: "duplicate" }
-  | {
-      status: "write-failed";
-      reason: Extract<FinalizeSessionResult, { ok: false }>["reason"];
-    };
+  | { status: "write-failed"; reason: FinalizeFailureReason };
 
 export const useSession = (options: UseSessionOptions): UseSessionResult => {
   const { t } = useTranslation();
@@ -269,16 +267,15 @@ export const useSession = (options: UseSessionOptions): UseSessionResult => {
     // Report every finalize failure to analytics so quota/serialize/corrupt
     // buckets are all observable in GA — the auto-save cleanup path reports
     // unconditionally, and asymmetry here was undercounting user-Stop quota
-    // failures. Distinct copy per reason still drives the user-facing message:
+    // failures. `reportSessionPersistenceFailed` names the GA exception so
+    // write failures aggregate with `useLocalDb`'s. Distinct copy per reason
+    // still drives the user-facing message:
     //  - corrupt / corrupt-prior-state: retry won't help; tell user to clear
     //    storage. Mark the session id as finalized so we don't re-show the
     //    notification on every Stop click.
     //  - serialize-failed / write-failed: keep phase: "active" so the user
     //    can retry Stop after clearing space.
-    analytics.trackError(
-      new Error(`Session finalize: ${result.reason}`),
-      "useSession:flush"
-    );
+    reportSessionPersistenceFailed(result.reason, "useSession:flush");
     const isUnrecoverable =
       result.reason === "corrupt" || result.reason === "corrupt-prior-state";
     if (isUnrecoverable) {

--- a/src/utils/localstorage-telemetry.test.ts
+++ b/src/utils/localstorage-telemetry.test.ts
@@ -8,6 +8,7 @@ import {
   reportLocalDbCorruption,
   reportLocalDbNotifyFailed,
   reportLocalDbWriteFailed,
+  reportSessionPersistenceFailed,
 } from "./localstorage-telemetry";
 
 // `as` justified: i18next.t has overloaded TFunction signatures; vi.fn's
@@ -147,6 +148,77 @@ describe("reportLocalDbWriteFailed", () => {
 
     const [errArg] = trackErrorSpy.mock.calls[0] ?? [];
     expect(errArg?.message).toBe("type=number");
+  });
+});
+
+describe("reportSessionPersistenceFailed", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // write-failed / corrupt are genuine localStorage.setItem failures — they
+  // share the LocalDbWriteFailed GA `action` bucket with `useLocalDb`'s write
+  // path so "how often does a write fail" is a single, trustworthy query.
+  it("names write-failed under the shared LocalDbWriteFailed bucket", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportSessionPersistenceFailed("write-failed", "useSession:flush");
+
+    expect(trackErrorSpy).toHaveBeenCalledTimes(1);
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbWriteFailed");
+    expect(errArg?.message).toBe("reason=write-failed");
+    expect(contextArg).toBe("useSession:flush");
+  });
+
+  it("names corrupt under the shared LocalDbWriteFailed bucket", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportSessionPersistenceFailed("corrupt", "useSessionAutoSave:cleanup");
+
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbWriteFailed");
+    expect(errArg?.message).toBe("reason=corrupt");
+    expect(contextArg).toBe("useSessionAutoSave:cleanup");
+  });
+
+  // serialize-failed / corrupt-prior-state involved no failed write, so they
+  // get a distinct name rather than inflating the write-failure aggregate.
+  it("names serialize-failed under the distinct LocalDbPersistenceFailed bucket", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportSessionPersistenceFailed("serialize-failed", "useSession:flush");
+
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbPersistenceFailed");
+    expect(errArg?.message).toBe("reason=serialize-failed");
+    expect(contextArg).toBe("useSession:flush");
+  });
+
+  it("names corrupt-prior-state under the distinct LocalDbPersistenceFailed bucket", () => {
+    const trackErrorSpy = vi
+      .spyOn(analytics, "trackError")
+      .mockImplementation(() => undefined);
+
+    reportSessionPersistenceFailed(
+      "corrupt-prior-state",
+      "useSessionAutoSave:beforeUnload"
+    );
+
+    const [errArg, contextArg] = trackErrorSpy.mock.calls[0] ?? [];
+    expect(errArg).toBeInstanceOf(Error);
+    expect(errArg?.name).toBe("LocalDbPersistenceFailed");
+    expect(errArg?.message).toBe("reason=corrupt-prior-state");
+    expect(contextArg).toBe("useSessionAutoSave:beforeUnload");
   });
 });
 

--- a/src/utils/localstorage-telemetry.ts
+++ b/src/utils/localstorage-telemetry.ts
@@ -1,6 +1,7 @@
 import { notifications } from "@mantine/notifications";
 import i18next from "i18next";
 import { analytics } from "../services/analytics";
+import type { FinalizeFailureReason } from "./session-persistence";
 
 /**
  * Default `onCorrupt` callback for `useLocalDb`. Wraps the underlying
@@ -45,6 +46,44 @@ export const reportLocalDbWriteFailed = (key: string, cause: unknown): void => {
   }
   wrapped.name = "LocalDbWriteFailed";
   analytics.trackError(wrapped, `key=${key}`);
+};
+
+/**
+ * Reports a `finalizeSession` failure (session history + all-time stats
+ * persistence) to analytics under the SAME exception-name taxonomy as
+ * `reportLocalDbWriteFailed`, so GA's `action` dimension aggregates every
+ * localStorage write failure with a single query instead of needing a
+ * `label`-substring filter over the generic `"Error"` bucket.
+ *
+ * Name mapping:
+ * - `write-failed` / `corrupt` → `LocalDbWriteFailed`. Both are genuine
+ *   `localStorage.setItem` throws (`corrupt` is two: the stats write failed
+ *   AND the history rollback write failed). They share the bucket with
+ *   `useLocalDb`'s write path — that bucket IS "how often does a write fail".
+ *   Note: `corrupt` reports two underlying failed writes as one event, so the
+ *   bucket slightly under-counts raw `setItem` throws — pre-existing, not
+ *   changed here.
+ * - `serialize-failed` / `corrupt-prior-state` → `LocalDbPersistenceFailed`.
+ *   Neither involved a failed write (`JSON.stringify` threw, or we refused to
+ *   overwrite a corrupt prior blob), so folding them into `LocalDbWriteFailed`
+ *   would inflate the write-failure aggregate with non-write failures.
+ *
+ * `reason` is a string enum — no user data — so unlike the read/write probes
+ * there is nothing to scrub; we still construct a fresh Error and name it
+ * explicitly rather than relying on the default `name === "Error"`. Operational
+ * context (the failing call site) flows through the `context` argument, which
+ * `analytics.trackError` appends to the GA exception description.
+ */
+export const reportSessionPersistenceFailed = (
+  reason: FinalizeFailureReason,
+  context: string
+): void => {
+  const wrapped = new Error(`reason=${reason}`);
+  wrapped.name =
+    reason === "write-failed" || reason === "corrupt"
+      ? "LocalDbWriteFailed"
+      : "LocalDbPersistenceFailed";
+  analytics.trackError(wrapped, context);
 };
 
 /**

--- a/src/utils/session-persistence.ts
+++ b/src/utils/session-persistence.ts
@@ -217,16 +217,21 @@ export const computeSessionSummary = (
  *   Callers should tell the user storage is corrupt and stop the auto-retry
  *   loop.
  */
+/**
+ * Why a `finalizeSession` call failed. Exported so the telemetry reporter
+ * (`reportSessionPersistenceFailed`) and `use-session.ts`'s
+ * `TryFinalizeSessionResult` share one definition instead of each re-deriving
+ * the reason union.
+ */
+export type FinalizeFailureReason =
+  | "write-failed"
+  | "serialize-failed"
+  | "corrupt"
+  | "corrupt-prior-state";
+
 export type FinalizeSessionResult =
   | { ok: true; summary: SessionSummary }
-  | {
-      ok: false;
-      reason:
-        | "write-failed"
-        | "serialize-failed"
-        | "corrupt"
-        | "corrupt-prior-state";
-    };
+  | { ok: false; reason: FinalizeFailureReason };
 
 /**
  * Finalizes an active session: persists it atomically and returns a summary.


### PR DESCRIPTION
## Summary

Two localStorage write-failure paths fed Google Analytics with inconsistent exception names, making it impossible to aggregate "how often does a write fail" without manually filtering label substrings:

- **`useLocalDb` path** → `reportLocalDbWriteFailed` → `error.name = "LocalDbWriteFailed"` (GA `action` is queryable)
- **Session-persistence path** (3 call sites) → `new Error("Session finalize: ...")` → `error.name = "Error"` (collides with every other error)

**Fix**: new `reportSessionPersistenceFailed(reason, context)` in `localstorage-telemetry.ts` with a 2-name scheme that keeps the `LocalDbWriteFailed` bucket honest:

| session `reason` | `error.name` (GA `action`) |
|---|---|
| `write-failed` / `corrupt` | `LocalDbWriteFailed` (genuine `setItem` throws — unified with `useLocalDb` path) |
| `serialize-failed` / `corrupt-prior-state` | `LocalDbPersistenceFailed` (no write was attempted — kept out so the aggregate isn't inflated) |

`error.message = "reason=<reason>"` for drill-down; call-site preserved via the existing `context` arg to `analytics.trackError`.

Also exports `FinalizeFailureReason` from `session-persistence.ts` and reuses it in `FinalizeSessionResult` + `TryFinalizeSessionResult`, replacing the inline `Extract<>` expression.

## Test plan

- [ ] `reportSessionPersistenceFailed`: all 4 reasons + context passthrough covered in `localstorage-telemetry.test.ts`
- [ ] `use-session.test.ts`: 4 assertions updated to assert `error.name` explicitly (the GA `action` discriminator)
- [ ] `use-session-auto-save.test.ts`: 2 assertions strengthened + `beforeUnload` GA assertion added (was previously exercising the branch but not asserting the GA effect)
- [ ] CI: typecheck, lint, 1780+ unit tests

Closes #637