### PR TITLE
chore(deps): bump knip to 6.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fta-cli": "3.0.0",
     "globals": "17.6.0",
     "happy-dom": "20.9.0",
-    "knip": "6.13.1",
+    "knip": "6.14.1",
     "lefthook": "2.1.6",
     "postcss": "8.5.14",
     "postcss-preset-mantine": "1.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 20.9.0
         version: 20.9.0
       knip:
-        specifier: 6.13.1
-        version: 6.13.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: 6.14.1
+        version: 6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
@@ -2826,8 +2826,8 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  knip@6.13.1:
-    resolution: {integrity: sha512-hvSnb+YDpDWW1LXub4U0JFfkQhscwgInWuQOv99WTutPZavf1cEP3GwxzEzO2JJpGI9yATk6l0jPLY1V3fp1sQ==}
+  knip@6.14.1:
+    resolution: {integrity: sha512-SN3Ly0ixzj5CQkY/rc4OPHpWrCC0XRIIjgdP76G9Cni5k72ur5jBYOyvJuF5oPTM14v8eHcMUgPbElHa+lnR0g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7094,7 +7094,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  knip@6.13.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  knip@6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0


### PR DESCRIPTION
## Summary

- Bumps `knip` from 6.13.1 → 6.14.1.
- Updates `pnpm-lock.yaml` accordingly.

## Test plan

- [ ] CI passes (typecheck, lint, unit tests, knip itself).