### PR TITLE
test(e2e): add stack-limits corrupt-lock + STACK_LIMITS_CHANGED emit coverage

### DIFF
--- a/e2e/stack-limits.e2e.ts
+++ b/e2e/stack-limits.e2e.ts
@@ -1,5 +1,18 @@
 import { expect } from "@playwright/test";
+import type { eventBus } from "../src/services/event-bus";
 import { test } from "./fixtures/test-setup";
+
+declare global {
+  interface Window {
+    __capturedStackLimitsChanges?: Array<{
+      start: number;
+      end: number;
+      rangeSize: number;
+      stackName: string;
+    }>;
+    __memdeckEventBus?: typeof eventBus;
+  }
+}
 
 const STACK_RANGE_BADGE_PATTERN = /Stack range/;
 
@@ -188,5 +201,118 @@ test.describe("Stack Limits", () => {
       localStorage.getItem("memdeck-app-stack-limits")
     );
     expect(onDisk).toBe(corrupt);
+  });
+});
+
+// These tests opt out of the parent describe's `beforeEach` because they
+// need to control the initial navigation themselves: test 1 must plant the
+// corrupt blob before useStackLimits mounts, and both tests load with
+// `?memdeck-e2e=1` so `window.__memdeckEventBus` is exposed (the
+// production gate lives in `src/main.tsx`).
+test.describe("Stack Limits — emit and corrupt-lock", () => {
+  test("should refuse to overwrite a corrupt stack-limits blob when a preset is clicked", async ({
+    page,
+  }) => {
+    const corrupt = JSON.stringify("garbage-not-a-record");
+
+    await page.addInitScript((value) => {
+      localStorage.setItem("memdeck-app-stack-limits", value);
+    }, corrupt);
+
+    await page.goto("/?memdeck-e2e=1");
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .locator("[data-testid='stack-picker']")
+      .first()
+      .selectOption("mnemonica");
+    await page.waitForLoadState("networkidle");
+
+    await page.waitForFunction(() => window.__memdeckEventBus !== undefined);
+    await page.evaluate(() => {
+      const bus = window.__memdeckEventBus;
+      if (!bus) {
+        throw new Error("__memdeckEventBus not exposed");
+      }
+      window.__capturedStackLimitsChanges = [];
+      bus.subscribe.STACK_LIMITS_CHANGED((payload) => {
+        window.__capturedStackLimitsChanges?.push(payload);
+      });
+    });
+
+    await page
+      .getByRole("button", { name: "Stack range: 52 cards. Tap to adjust." })
+      .click();
+    const limitsControl = page.locator("[data-testid='stack-limits-control']");
+    await limitsControl
+      .getByRole("button", { name: "Set range to first 13 cards" })
+      .click();
+    await page.keyboard.press("Escape");
+
+    const onDisk = await page.evaluate(() =>
+      localStorage.getItem("memdeck-app-stack-limits")
+    );
+    expect(onDisk).toBe(corrupt);
+
+    // The emit chain is synchronous today (setRecord → setItem → onSuccess);
+    // a brief settle catches a delayed emit if onSuccess ever wraps in a
+    // microtask, so the empty-captured assertion stays meaningful.
+    await page.waitForTimeout(100);
+    const captured = await page.evaluate(
+      () => window.__capturedStackLimitsChanges
+    );
+    expect(captured).toEqual([]);
+
+    const badge = page.getByRole("button", {
+      name: "Stack range: 52 cards. Tap to adjust.",
+    });
+    await expect(badge).toBeVisible();
+  });
+
+  test("should emit STACK_LIMITS_CHANGED with the correct payload when a preset succeeds", async ({
+    page,
+  }) => {
+    await page.goto("/?memdeck-e2e=1");
+    await page.waitForLoadState("networkidle");
+
+    await page
+      .locator("[data-testid='stack-picker']")
+      .first()
+      .selectOption("mnemonica");
+    await page.waitForLoadState("networkidle");
+
+    await page.waitForFunction(() => window.__memdeckEventBus !== undefined);
+    await page.evaluate(() => {
+      const bus = window.__memdeckEventBus;
+      if (!bus) {
+        throw new Error("__memdeckEventBus not exposed");
+      }
+      window.__capturedStackLimitsChanges = [];
+      bus.subscribe.STACK_LIMITS_CHANGED((payload) => {
+        window.__capturedStackLimitsChanges?.push(payload);
+      });
+    });
+
+    await page
+      .getByRole("button", { name: "Stack range: 52 cards. Tap to adjust." })
+      .click();
+    await page
+      .locator("[data-testid='stack-limits-control']")
+      .getByRole("button", { name: "Set range to first 13 cards" })
+      .click();
+
+    // Poll so the assertion retries if onSuccess ever becomes async — the
+    // emit chain is synchronous today, but `expect.poll` removes the latent
+    // race without changing semantics on the happy path.
+    await expect
+      .poll(() => page.evaluate(() => window.__capturedStackLimitsChanges))
+      .toEqual([
+        {
+          start: 1,
+          end: 13,
+          rangeSize: 13,
+          stackName: "Tamariz",
+        },
+      ]);
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,17 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { languageReady } from "./i18n";
 import { Provider } from "./provider";
+import { eventBus } from "./services/event-bus";
+
+declare global {
+  interface Window {
+    __memdeckEventBus?: typeof eventBus;
+  }
+}
+
+if (new URLSearchParams(window.location.search).has("memdeck-e2e")) {
+  window.__memdeckEventBus = eventBus;
+}
 
 const rootElement = document.getElementById("root");
 


### PR DESCRIPTION
## Summary

- Adds a `?memdeck-e2e=1` query-param gate in `src/main.tsx` that exposes the `eventBus` singleton on `window.__memdeckEventBus`. This lets Playwright subscribe to internal events from page context in both dev mode and the built bundle (CI uses `pnpm run preview`).
- Adds two new e2e tests in a sibling `describe` block in `e2e/stack-limits.e2e.ts` covering behaviors added by PR #625 that were previously unit-test only:
  1. **Corrupt-lock blocks writes**: planting a corrupt blob in `memdeck-app-stack-limits`, clicking preset 13, and asserting the blob is unchanged on disk and `STACK_LIMITS_CHANGED` was never emitted.
  2. **Happy-path emit**: asserting `STACK_LIMITS_CHANGED` fires with the correct payload `{ start: 1, end: 13, rangeSize: 13, stackName: "Tamariz" }` when preset 13 is clicked successfully.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — clean
- [x] `pnpm run knip` — clean
- [x] `pnpm run test:coverage` — all unit tests pass, coverage ratchets hold
- [x] `pnpm run test:e2e` — 175 passed (8/8 stack-limits, 167/167 rest)
- [x] `CI=1 pnpm exec playwright test e2e/stack-limits.e2e.ts` — 8/8 in built bundle (the load-bearing CI path)
- [x] `pnpm run build` — clean

Closes #638