### PR TITLE
test(e2e): add write-failure coverage and extract COLOR_SCHEME_LSK

### DIFF
--- a/e2e/persistence.e2e.ts
+++ b/e2e/persistence.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import { COLOR_SCHEME_LSK } from "../src/constants";
 import { test } from "./fixtures/test-setup";
 
 test.describe("localStorage Persistence", () => {
@@ -90,8 +91,9 @@ test.describe("localStorage Persistence", () => {
     }
 
     // Verify localStorage (color scheme is stored as plain string, not JSON stringified)
-    const savedScheme = await page.evaluate(() =>
-      localStorage.getItem("memdeck-app-color-scheme")
+    const savedScheme = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      COLOR_SCHEME_LSK
     );
     expect(savedScheme).toBe("dark");
 
@@ -162,8 +164,9 @@ test.describe("localStorage Persistence", () => {
     expect(mode).toBe('"numberonly"');
 
     // Check theme (color scheme is stored as plain string)
-    const scheme = await page.evaluate(() =>
-      localStorage.getItem("memdeck-app-color-scheme")
+    const scheme = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      COLOR_SCHEME_LSK
     );
     expect(scheme).toBe("dark");
   });

--- a/e2e/theme.e2e.ts
+++ b/e2e/theme.e2e.ts
@@ -1,5 +1,12 @@
 import { expect } from "@playwright/test";
+import { COLOR_SCHEME_LSK } from "../src/constants";
 import { test } from "./fixtures/test-setup";
+
+declare global {
+  interface Window {
+    __failColorSchemeWrites?: boolean;
+  }
+}
 
 test.describe("Theme & Color Scheme", () => {
   test.beforeEach(async ({ page }) => {
@@ -49,8 +56,9 @@ test.describe("Theme & Color Scheme", () => {
     await expect(themeSwitch).not.toBeChecked();
 
     // Check localStorage
-    const colorScheme = await page.evaluate(() =>
-      localStorage.getItem("memdeck-app-color-scheme")
+    const colorScheme = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      COLOR_SCHEME_LSK
     );
 
     expect(colorScheme).toBe("dark");
@@ -191,5 +199,65 @@ test.describe("Theme & Color Scheme", () => {
     await expect(
       page.getByRole("heading", { name: "Master your memorized deck" })
     ).toBeVisible();
+  });
+});
+
+// Top-level describe (sibling, not nested) so the parent's `goto("/")`
+// beforeEach doesn't fire — the `setItem` shim must be installed via
+// `addInitScript` before any app code runs.
+test.describe("Theme & Color Scheme — write failure", () => {
+  test("should surface the localDbWriteFailed toast when the color-scheme write throws", async ({
+    page,
+  }) => {
+    await page.addInitScript((key) => {
+      // Pre-seed with the default value so the post-test assertion proves
+      // the failed write did NOT overwrite localStorage — without this,
+      // `getItem` would return null whether the shim threw or the write
+      // never happened at all.
+      window.localStorage.setItem(key, "light");
+      const originalSetItem = window.localStorage.setItem.bind(
+        window.localStorage
+      );
+      window.localStorage.setItem = function patchedSetItem(
+        k: string,
+        v: string
+      ) {
+        if (k === key && window.__failColorSchemeWrites === true) {
+          throw new DOMException("Quota exceeded", "QuotaExceededError");
+        }
+        originalSetItem(k, v);
+      };
+    }, COLOR_SCHEME_LSK);
+
+    await page.goto("/");
+    // Waiting on the switch to render proves React has committed, not just
+    // that the network is idle — `networkidle` would resolve before Mantine
+    // mounts and could let the shim arm during the render window.
+    const themeSwitchTrack = page.locator(".mantine-Switch-track").first();
+    await expect(themeSwitchTrack).toBeVisible();
+
+    // Arm the shim after mount so any mount-time Mantine writes can't trip
+    // the toast before the user-triggered toggle — keeps the assertion
+    // attributable to the click below.
+    await page.evaluate(() => {
+      window.__failColorSchemeWrites = true;
+    });
+
+    await themeSwitchTrack.click();
+
+    // Match the message body, which is unique to `errors.localDbWriteFailed`
+    // — using the title ("Couldn't save") as substring would also match the
+    // unrelated `errors.sessionSaveFailed` toast whose message starts with
+    // "Couldn't save your session…".
+    const notification = page
+      .getByRole("alert")
+      .filter({ hasText: "recent changes won't persist" });
+    await expect(notification).toBeVisible({ timeout: 2000 });
+
+    const stored = await page.evaluate(
+      (key) => window.localStorage.getItem(key),
+      COLOR_SCHEME_LSK
+    );
+    expect(stored).toBe("light");
   });
 });

--- a/e2e/user-journeys.e2e.ts
+++ b/e2e/user-journeys.e2e.ts
@@ -1,4 +1,5 @@
 import { expect } from "@playwright/test";
+import { COLOR_SCHEME_LSK } from "../src/constants";
 import { test } from "./fixtures/test-setup";
 
 // URL patterns
@@ -213,8 +214,9 @@ test.describe("User Journeys", () => {
     }
 
     // Final state should be persisted (color scheme is stored as plain string)
-    const scheme = await page.evaluate(() =>
-      localStorage.getItem("memdeck-app-color-scheme")
+    const scheme = await page.evaluate(
+      (key) => localStorage.getItem(key),
+      COLOR_SCHEME_LSK
     );
 
     const expectedScheme = isLight ? "light" : "dark";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const SELECTED_STACK_LSK = "memdeck-app-stack";
 export const FLASHCARD_OPTION_LSK = "memdeck-app-flashcard-option";
 export const FLASHCARD_TIMER_LSK = "memdeck-app-flashcard-timer";
 export const ACAAN_TRAINER_TIMER_LSK = "memdeck-app-acaan-trainer-timer";
+export const COLOR_SCHEME_LSK = "memdeck-app-color-scheme";
 export const BLANK_CARD_IMAGE = "/cards/blank_card.svg";
 export const NOTIFICATION_CLOSE_TIMEOUT = 2000;
 

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -15,6 +15,7 @@ import { App } from "./app";
 import { FocusOnNavigate } from "./components/focus-on-navigate";
 import { LanguageLoadNotifier } from "./components/language-load-notifier";
 import { PwaUpdateNotifier } from "./components/pwa-update-notifier";
+import { COLOR_SCHEME_LSK } from "./constants";
 import { analytics } from "./services/analytics";
 import { createColorSchemeManager } from "./utils/color-scheme-manager";
 
@@ -30,7 +31,7 @@ const getSystemColorScheme = (): "light" | "dark" => {
 
 const systemColorScheme = getSystemColorScheme();
 
-const colorSchemeManager = createColorSchemeManager("memdeck-app-color-scheme");
+const colorSchemeManager = createColorSchemeManager(COLOR_SCHEME_LSK);
 
 const theme = createTheme({
   primaryColor: "blue",

--- a/src/utils/color-scheme-manager.test.ts
+++ b/src/utils/color-scheme-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { COLOR_SCHEME_LSK } from "../constants";
 
 const mockHandleLocalDbWriteFailed =
   vi.fn<(key: string, cause: unknown) => void>();
@@ -9,7 +10,7 @@ vi.mock("./localstorage-telemetry", () => ({
 
 const { createColorSchemeManager } = await import("./color-scheme-manager");
 
-const KEY = "memdeck-app-color-scheme";
+const KEY = COLOR_SCHEME_LSK;
 
 const quotaError = (): DOMException =>
   new DOMException("quota", "QuotaExceededError");


### PR DESCRIPTION
## Summary

- Extract `COLOR_SCHEME_LSK = "memdeck-app-color-scheme"` to `src/constants.ts`, eliminating the magic string across `provider.tsx`, `color-scheme-manager.test.ts`, and all three e2e suites
- Add a new Playwright test verifying the `localDbWriteFailed` toast surfaces when `localStorage.setItem` throws — confirms the error path introduced in #672 fires end-to-end

Closes #635

## Test plan

- [x] New e2e test: `Theme & Color Scheme — write failure` (installs a `localStorage.setItem` shim scoped to the instance, not `Storage.prototype`, then clicks the theme toggle and asserts the toast appears and the stored value is unchanged)
- [x] Existing unit suite passes (`pnpm run test:coverage`)
- [x] Typecheck and lint clean