### PR TITLE
refactor(localstorage): migrate useLocalDb callbacks to options object

### DIFF
--- a/src/hooks/use-all-time-stats-corruption.test.ts
+++ b/src/hooks/use-all-time-stats-corruption.test.ts
@@ -25,14 +25,15 @@ describe("useAllTimeStats statsStatus", () => {
   it("starts in 'ready' and flips to 'corrupt' while reporting telemetry when useLocalDb invokes onCorrupt", () => {
     let captured: OnCorrupt | undefined;
     mockedUseLocalDb.mockImplementation(
-      (_key, defaultValue, _validate, onCorrupt) => {
-        captured = onCorrupt;
+      (_key, defaultValue, _validate, options) => {
+        captured = options?.onCorrupt;
         return [defaultValue, vi.fn(), vi.fn()];
       }
     );
 
     const { result } = renderHook(() => useAllTimeStats());
 
+    expect(captured).toBeTypeOf("function");
     expect(result.current.statsStatus).toBe("ready");
     expect(mockedReport).not.toHaveBeenCalled();
 

--- a/src/hooks/use-all-time-stats.ts
+++ b/src/hooks/use-all-time-stats.ts
@@ -35,9 +35,11 @@ export const useAllTimeStats = (): UseAllTimeStatsResult => {
     ALL_TIME_STATS_LSK,
     {},
     isAllTimeStats,
-    (key, error) => {
-      reportLocalDbCorruption(key, error);
-      setStatsStatus("corrupt");
+    {
+      onCorrupt: (key, error) => {
+        reportLocalDbCorruption(key, error);
+        setStatsStatus("corrupt");
+      },
     }
   );
 

--- a/src/hooks/use-selected-stack.test.ts
+++ b/src/hooks/use-selected-stack.test.ts
@@ -2,6 +2,10 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { SELECTED_STACK_LSK } from "../constants";
 import { stacks } from "../types/stacks";
 import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
+import {
   isStackKey,
   useRequiredStack,
   useSelectedStack,
@@ -105,8 +109,10 @@ describe("useSelectedStack", () => {
       SELECTED_STACK_LSK,
       "",
       expect.any(Function),
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/hooks/use-selected-stack.ts
+++ b/src/hooks/use-selected-stack.ts
@@ -39,8 +39,10 @@ export const useSelectedStack = (): SelectedStackResult => {
     SELECTED_STACK_LSK,
     "",
     isStackKeyOrEmpty,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   const setStackKey = (key: StackKey | ""): void => {

--- a/src/hooks/use-session-history-corruption.test.ts
+++ b/src/hooks/use-session-history-corruption.test.ts
@@ -25,14 +25,15 @@ describe("useSessionHistory historyStatus", () => {
   it("starts in 'ready' and flips to 'corrupt' while reporting telemetry when useLocalDb invokes onCorrupt", () => {
     let captured: OnCorrupt | undefined;
     mockedUseLocalDb.mockImplementation(
-      (_key, defaultValue, _validate, onCorrupt) => {
-        captured = onCorrupt;
+      (_key, defaultValue, _validate, options) => {
+        captured = options?.onCorrupt;
         return [defaultValue, vi.fn(), vi.fn()];
       }
     );
 
     const { result } = renderHook(() => useSessionHistory());
 
+    expect(captured).toBeTypeOf("function");
     expect(result.current.historyStatus).toBe("ready");
     expect(mockedReport).not.toHaveBeenCalled();
 

--- a/src/hooks/use-session-history.ts
+++ b/src/hooks/use-session-history.ts
@@ -24,9 +24,11 @@ export const useSessionHistory = (): UseSessionHistoryResult => {
     SESSION_HISTORY_LSK,
     [],
     isSessionRecordArray,
-    (key, error) => {
-      reportLocalDbCorruption(key, error);
-      setHistoryStatus("corrupt");
+    {
+      onCorrupt: (key, error) => {
+        reportLocalDbCorruption(key, error);
+        setHistoryStatus("corrupt");
+      },
     }
   );
 

--- a/src/hooks/use-stack-limits.test.ts
+++ b/src/hooks/use-stack-limits.test.ts
@@ -6,6 +6,10 @@ import {
   isStackLimitsRecord,
 } from "../types/stack-limits";
 import { createDeckPosition, stacks } from "../types/stacks";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
 import { useStackLimits } from "./use-stack-limits";
 
 // Mantine-mirroring setter: invoke `options.onSuccess` so the emit gating
@@ -138,8 +142,10 @@ describe("useStackLimits", () => {
       STACK_LIMITS_LSK,
       expect.anything(),
       isStackLimitsRecord,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/hooks/use-stack-limits.ts
+++ b/src/hooks/use-stack-limits.ts
@@ -41,8 +41,10 @@ export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
     STACK_LIMITS_LSK,
     {},
     isStackLimitsRecord,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   // Probe once on mount; if the stored blob is corrupt, lock writes for the

--- a/src/hooks/use-timer-settings.test.ts
+++ b/src/hooks/use-timer-settings.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { FLASHCARD_TIMER_LSK } from "../constants";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
 import { isTimerSettings, useTimerSettings } from "./use-timer-settings";
 
 const mockSetSettings = vi.fn();
@@ -83,8 +87,10 @@ describe("useTimerSettings", () => {
       FLASHCARD_TIMER_LSK,
       expect.any(Object),
       expect.any(Function),
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/hooks/use-timer-settings.ts
+++ b/src/hooks/use-timer-settings.ts
@@ -68,8 +68,10 @@ export const useTimerSettings = (
     storageKey,
     DEFAULT_TIMER_SETTINGS,
     isTimerSettings,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   const setTimerEnabled = useCallback(

--- a/src/pages/distance/use-distance-settings.test.ts
+++ b/src/pages/distance/use-distance-settings.test.ts
@@ -65,6 +65,9 @@ vi.mock("../../services/event-bus", () => ({
 
 const { useLocalDb } = await import("../../utils/localstorage");
 const mockedUseLocalDb = vi.mocked(useLocalDb);
+const { handleLocalDbWriteFailed, reportLocalDbCorruption } = await import(
+  "../../utils/localstorage-telemetry"
+);
 const { useTimerSettings } = await import("../../hooks/use-timer-settings");
 const mockedUseTimerSettings = vi.mocked(useTimerSettings);
 const { useDistanceSettings } = await import("./use-distance-settings");
@@ -111,15 +114,19 @@ describe("useDistanceSettings", () => {
       DISTANCE_OPTION_LSK,
       "compute",
       isDistanceMode,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       DISTANCE_CONVENTION_LSK,
       "cyclic",
       isDistanceConvention,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/pages/distance/use-distance-settings.ts
+++ b/src/pages/distance/use-distance-settings.ts
@@ -35,15 +35,19 @@ export const useDistanceSettings = (): UseDistanceSettingsResult => {
     DISTANCE_OPTION_LSK,
     "compute",
     isDistanceMode,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
   const [convention, setConvention] = useLocalDb<DistanceConvention>(
     DISTANCE_CONVENTION_LSK,
     "cyclic",
     isDistanceConvention,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   const { timerSettings, setTimerEnabled, setTimerDuration } =

--- a/src/pages/flashcard/use-flashcard-settings.test.ts
+++ b/src/pages/flashcard/use-flashcard-settings.test.ts
@@ -61,6 +61,9 @@ vi.mock("../../services/event-bus", () => ({
 
 const { useLocalDb } = await import("../../utils/localstorage");
 const mockedUseLocalDb = vi.mocked(useLocalDb);
+const { handleLocalDbWriteFailed, reportLocalDbCorruption } = await import(
+  "../../utils/localstorage-telemetry"
+);
 const { useFlashcardSettings } = await import("./use-flashcard-settings");
 
 describe("useFlashcardSettings", () => {
@@ -106,15 +109,19 @@ describe("useFlashcardSettings", () => {
       FLASHCARD_OPTION_LSK,
       "bothmodes",
       isFlashcardMode,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
     expect(mockedUseLocalDb).toHaveBeenCalledWith(
       NEIGHBOR_DIRECTION_LSK,
       "random",
       isNeighborDirection,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/pages/flashcard/use-flashcard-settings.ts
+++ b/src/pages/flashcard/use-flashcard-settings.ts
@@ -31,16 +31,20 @@ export const useFlashcardSettings = (): UseFlashcardSettingsResult => {
     FLASHCARD_OPTION_LSK,
     "bothmodes",
     isFlashcardMode,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
   const [neighborDirection, setNeighborDirection] =
     useLocalDb<NeighborDirection>(
       NEIGHBOR_DIRECTION_LSK,
       "random",
       isNeighborDirection,
-      reportLocalDbCorruption,
-      handleLocalDbWriteFailed
+      {
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      }
     );
 
   const { timerSettings, setTimerEnabled, setTimerDuration } =

--- a/src/pages/spot-check/use-spot-check-settings.test.ts
+++ b/src/pages/spot-check/use-spot-check-settings.test.ts
@@ -47,6 +47,9 @@ vi.mock("../../services/event-bus", () => ({
 
 const { useLocalDb } = await import("../../utils/localstorage");
 const mockedUseLocalDb = vi.mocked(useLocalDb);
+const { handleLocalDbWriteFailed, reportLocalDbCorruption } = await import(
+  "../../utils/localstorage-telemetry"
+);
 const { useSpotCheckSettings } = await import("./use-spot-check-settings");
 
 describe("useSpotCheckSettings", () => {
@@ -83,8 +86,10 @@ describe("useSpotCheckSettings", () => {
       SPOT_CHECK_MODE_LSK,
       "missing",
       isSpotCheckMode,
-      expect.any(Function),
-      expect.any(Function)
+      expect.objectContaining({
+        onCorrupt: reportLocalDbCorruption,
+        onWriteFailed: handleLocalDbWriteFailed,
+      })
     );
   });
 

--- a/src/pages/spot-check/use-spot-check-settings.ts
+++ b/src/pages/spot-check/use-spot-check-settings.ts
@@ -24,8 +24,10 @@ export const useSpotCheckSettings = (): UseSpotCheckSettingsResult => {
     SPOT_CHECK_MODE_LSK,
     "missing",
     isSpotCheckMode,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   const { timerSettings, setTimerEnabled, setTimerDuration } =

--- a/src/pages/toolbox/toolbox.tsx
+++ b/src/pages/toolbox/toolbox.tsx
@@ -42,8 +42,10 @@ export const Toolbox = () => {
     TOOLBOX_SECTIONS_LSK,
     [],
     isStringArray,
-    reportLocalDbCorruption,
-    handleLocalDbWriteFailed
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
   );
 
   const openSectionsRef = useRef(openSections);

--- a/src/utils/localstorage.test.ts
+++ b/src/utils/localstorage.test.ts
@@ -518,7 +518,7 @@ describe("useLocalDb", () => {
       const onCorrupt = vi.fn();
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, onCorrupt)
+        useLocalDb("k", "default", isString, { onCorrupt })
       );
 
       expect(result.current[0]).toBe("default");
@@ -609,7 +609,7 @@ describe("useLocalDb", () => {
       window.localStorage.setItem("k", JSON.stringify("ok"));
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
 
       expect(onCorrupt).not.toHaveBeenCalled();
     });
@@ -617,7 +617,7 @@ describe("useLocalDb", () => {
     it("does not invoke onCorrupt when the stored value is absent", () => {
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
 
       expect(onCorrupt).not.toHaveBeenCalled();
     });
@@ -626,7 +626,7 @@ describe("useLocalDb", () => {
       window.localStorage.setItem("k", JSON.stringify(123));
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
       expect(onCorrupt).toHaveBeenCalledWith("k", 123);
@@ -637,7 +637,7 @@ describe("useLocalDb", () => {
       window.localStorage.setItem("k", garbage);
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
       expect(onCorrupt).toHaveBeenCalledWith("k", garbage);
@@ -656,7 +656,7 @@ describe("useLocalDb", () => {
       const onCorrupt = vi.fn();
 
       const { rerender } = renderHook(() =>
-        useLocalDb("k", "default", isString, onCorrupt)
+        useLocalDb("k", "default", isString, { onCorrupt })
       );
       for (let i = 0; i < 20; i++) {
         rerender();
@@ -672,7 +672,8 @@ describe("useLocalDb", () => {
       const onCorrupt = vi.fn();
 
       const { rerender } = renderHook(
-        ({ k }: { k: string }) => useLocalDb(k, "default", isString, onCorrupt),
+        ({ k }: { k: string }) =>
+          useLocalDb(k, "default", isString, { onCorrupt }),
         { initialProps: { k: "key-a" } }
       );
 
@@ -694,7 +695,9 @@ describe("useLocalDb", () => {
       };
       const onCorrupt = vi.fn();
 
-      renderHook(() => useLocalDb("k", "default", validateThrows, onCorrupt));
+      renderHook(() =>
+        useLocalDb("k", "default", validateThrows, { onCorrupt })
+      );
 
       expect(onCorrupt).toHaveBeenCalledTimes(1);
       expect(onCorrupt).toHaveBeenCalledWith("k", validatorError);
@@ -794,7 +797,7 @@ describe("useLocalDb", () => {
       window.addEventListener("memdeck-localstorage", throwingListener);
       try {
         const { result } = renderHook(() =>
-          useLocalDb("k", "default", isString, undefined, onWriteFailed)
+          useLocalDb("k", "default", isString, { onWriteFailed })
         );
 
         expect(() =>
@@ -1217,7 +1220,7 @@ describe("useLocalDb", () => {
     it("still invokes `onCorrupt` on the valid→corrupt transition (telemetry semantics preserved)", () => {
       window.localStorage.setItem("k", JSON.stringify("ok"));
       const onCorrupt = vi.fn();
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
       expect(onCorrupt).not.toHaveBeenCalled();
 
       act(() => {
@@ -1380,7 +1383,7 @@ describe("useLocalDb", () => {
     it("re-fires the toast on corrupt→valid→corrupt while `onCorrupt` stays once (asymmetry pin)", () => {
       window.localStorage.setItem("k", JSON.stringify("ok"));
       const onCorrupt = vi.fn();
-      renderHook(() => useLocalDb("k", "default", isString, onCorrupt));
+      renderHook(() => useLocalDb("k", "default", isString, { onCorrupt }));
 
       act(() => {
         fireCrossTabRaw("k", "{bad-1");
@@ -1640,7 +1643,7 @@ describe("useLocalDb", () => {
       });
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       result.current[1]("next");
@@ -1656,7 +1659,7 @@ describe("useLocalDb", () => {
       });
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       result.current[1]("a");
@@ -1681,7 +1684,7 @@ describe("useLocalDb", () => {
         });
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       result.current[1]("a");
@@ -1699,7 +1702,7 @@ describe("useLocalDb", () => {
 
       const { result, rerender } = renderHook(
         ({ k }: { k: string }) =>
-          useLocalDb(k, "default", isString, undefined, onWriteFailed),
+          useLocalDb(k, "default", isString, { onWriteFailed }),
         { initialProps: { k: "key-a" } }
       );
 
@@ -1745,7 +1748,7 @@ describe("useLocalDb", () => {
       });
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       expect(() => result.current[1]("next")).not.toThrow();
@@ -1762,7 +1765,7 @@ describe("useLocalDb", () => {
       });
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       result.current[1]("next", { onSuccess });
@@ -1778,7 +1781,7 @@ describe("useLocalDb", () => {
       const onWriteFailed = vi.fn();
 
       const { result } = renderHook(() =>
-        useLocalDb("k", "default", isString, undefined, onWriteFailed)
+        useLocalDb("k", "default", isString, { onWriteFailed })
       );
 
       expect(() => result.current[1]("next", { onSuccess })).not.toThrow();

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -96,6 +96,11 @@ export const getStoredValue = <T>(
 
 export type UseLocalDbSetOptions = { onSuccess?: () => void };
 
+export type UseLocalDbOptions = {
+  onCorrupt?: (key: string, error: unknown) => void;
+  onWriteFailed?: (key: string, error: unknown) => void;
+};
+
 type UseLocalDbSetter<T> = (
   value: T | ((prevState: T) => T),
   options?: UseLocalDbSetOptions
@@ -251,16 +256,16 @@ type WasValidSlot = { wasValid: false } | { wasValid: true; key: string };
  * consumers that cannot tolerate that (`useStackLimits`) gate the setter
  * at the consumer level (see `use-stack-limits.ts:50-58, 95`).
  *
- * Pass `onCorrupt` to be notified when the stored value exists but cannot
- * be validated (the type guard returned `false`, or the type guard itself
- * threw). Storage-layer read errors (Safari ITP, private mode) collapse
- * to "absent" — `onCorrupt` is NOT fired for those. Consumers that need
- * to distinguish "absent" from "read errored" call `probeStoredValue`
- * directly. Without `onCorrupt`, the hook silently falls back to
- * `defaultValue`.
+ * Pass `options.onCorrupt` to be notified when the stored value exists but
+ * cannot be validated (the type guard returned `false`, or the type guard
+ * itself threw). Storage-layer read errors (Safari ITP, private mode)
+ * collapse to "absent" — `onCorrupt` is NOT fired for those. Consumers
+ * that need to distinguish "absent" from "read errored" call
+ * `probeStoredValue` directly. Without `onCorrupt`, the hook silently
+ * falls back to `defaultValue`.
  *
- * Pass `onWriteFailed` to be notified when a write throws (quota exceeded,
- * Safari private mode, ITP eviction).
+ * Pass `options.onWriteFailed` to be notified when a write throws (quota
+ * exceeded, Safari private mode, ITP eviction).
  *
  * The returned setter accepts an optional `{ onSuccess }` so callers can
  * gate side effects (analytics emits, navigation) on a real persisted
@@ -286,8 +291,7 @@ export const useLocalDb = <T>(
   key: string,
   defaultValue: T,
   validate: (value: unknown) => value is T,
-  onCorrupt?: (key: string, error: unknown) => void,
-  onWriteFailed?: (key: string, error: unknown) => void
+  { onCorrupt, onWriteFailed }: UseLocalDbOptions = {}
 ): [T, UseLocalDbSetter<T>, () => void] => {
   // Subscribe + snapshot for `useSyncExternalStore`. `subscribe` re-attaches
   // listeners when `key` changes; `getSnapshot` returns the raw string so


### PR DESCRIPTION
## Summary

- Replace the two positional callback parameters (`onCorrupt`, `onWriteFailed`) in `useLocalDb` with a single `UseLocalDbOptions` object
- Export the new `UseLocalDbOptions` type from `localstorage.ts`
- Update all 9 consumer call sites across hooks and page-settings hooks
- Update JSDoc to reference `options.onCorrupt` / `options.onWriteFailed`

This removes the awkward `undefined` placeholder pattern (`useLocalDb(..., undefined, onWriteFailed)`) and makes it easy to pass only the callbacks you need.

Closes #636

## Test plan

- [ ] 876 unit tests pass (`pnpm vitest run src/utils src/hooks src/pages`)
- [ ] Typecheck clean (`pnpm run typecheck`)
- [ ] Test assertions strengthened: `expect.any(Function)` → `expect.objectContaining({ onCorrupt: reportLocalDbCorruption, onWriteFailed: handleLocalDbWriteFailed })`, verifying exact callback identity