### PR TITLE
feat(nav): add llms.txt footer link

### DIFF
--- a/e2e/pages.e2e.ts
+++ b/e2e/pages.e2e.ts
@@ -100,6 +100,25 @@ test.describe("Pages & Features", () => {
     }
   });
 
+  test("should have working llms.txt link in footer", async ({ page }) => {
+    const llmsLink = page.locator('a[href="/llms.txt"]').first();
+    await expect(llmsLink).toBeVisible();
+
+    const href = await llmsLink.getAttribute("href");
+    expect(href).toBe("/llms.txt");
+  });
+
+  test("should have working llms.txt link with noopener attribute", async ({
+    page,
+  }) => {
+    const llmsLink = page.locator('a[href="/llms.txt"]').first();
+
+    const rel = await llmsLink.getAttribute("rel");
+    if (rel) {
+      expect(rel).toContain("noopener");
+    }
+  });
+
   test("should navigate back to home when clicking logo", async ({ page }) => {
     // Navigate to a different page
     await page.locator("a:has-text('Resources')").first().click();

--- a/src/components/nav-footer.tsx
+++ b/src/components/nav-footer.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Divider, Group, Text, VisuallyHidden } from "@mantine/core";
 import { IconBrandGithub } from "@tabler/icons-react";
 import { useTranslation } from "react-i18next";
-import { GITHUB_URL } from "../constants";
+import { GITHUB_URL, LLMS_TXT_PATH } from "../constants";
 import { useSelectedStack } from "../hooks/use-selected-stack";
 import { LanguagePicker } from "./language-picker";
 import { ResetButton } from "./reset-button";
@@ -51,6 +51,17 @@ export const NavFooter = () => {
           underline="hover"
         >
           <IconBrandGithub aria-hidden="true" size={16} />
+        </Anchor>
+        <Anchor
+          c="dimmed"
+          href={LLMS_TXT_PATH}
+          rel="noopener"
+          size="xs"
+          target="_blank"
+          underline="hover"
+        >
+          llms.txt
+          <VisuallyHidden> {t("navFooter.llmsTxtDescription")}</VisuallyHidden>
         </Anchor>
         <ShareButton />
         <Text c="dimmed" size="xs">

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const GITHUB_URL = "https://github.com/julienroussel/memdeck.org";
+export const LLMS_TXT_PATH = "/llms.txt";
 export const LINKTREE_URL = "https://linktr.ee/julien.roussel";
 export const MAGIC_LAB_URL = "https://themagiclab.app";
 export const SELECTED_STACK_LSK = "memdeck-app-stack";

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Farbschema wechseln",
     "languageAriaLabel": "Sprache"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Website-Zusammenfassung für LLMs (öffnet in neuem Tab)"
+  },
   "home": {
     "pageTitle": "MemDeck — Meistere dein memoriertes Kartendeck",
     "pageDescription": "Kostenloses Online-Tool zum Meistern von memorierten Kartensystemen wie Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant und Infinity.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Toggle color scheme",
     "languageAriaLabel": "Language"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— LLM-friendly site summary (opens in new tab)"
+  },
   "home": {
     "pageTitle": "MemDeck — Master your memorized deck",
     "pageDescription": "Free online tool for mastering memorized deck systems like Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant, and Infinity.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Alternar esquema de colores",
     "languageAriaLabel": "Idioma"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Resumen del sitio para los LLM (se abre en una nueva pestaña)"
+  },
   "home": {
     "pageTitle": "MemDeck — Domina tu baraja memorizada",
     "pageDescription": "Herramienta online gratuita para dominar sistemas de barajas memorizadas como Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant e Infinity.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Changer le thème de couleur",
     "languageAriaLabel": "Langue"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Résumé du site pour les LLM (s'ouvre dans un nouvel onglet)"
+  },
   "home": {
     "pageTitle": "MemDeck — Maîtrisez votre jeu mémorisé",
     "pageDescription": "Outil en ligne gratuit pour maîtriser les systèmes de jeu mémorisé comme Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant et Infinity.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Cambia il tema colore",
     "languageAriaLabel": "Lingua"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Riepilogo del sito per gli LLM (si apre in una nuova scheda)"
+  },
   "home": {
     "pageTitle": "MemDeck — Padroneggia il mazzo memorizzato",
     "pageDescription": "Strumento online gratuito per padroneggiare sistemi di mazzi memorizzati come Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant e Infinity.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Kleurthema wisselen",
     "languageAriaLabel": "Taal"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Sitesamenvatting voor LLM's (opent in een nieuw tabblad)"
+  },
   "home": {
     "pageTitle": "MemDeck — Beheers je gememoriseerde kaartspel",
     "pageDescription": "Gratis online tool voor het beheersen van gememoriseerde kaartsystemen zoals Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant en Infinity.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -61,6 +61,9 @@
     "toggleColorScheme": "Alternar esquema de cores",
     "languageAriaLabel": "Idioma"
   },
+  "navFooter": {
+    "llmsTxtDescription": "— Resumo do site para LLMs (abre em nova guia)"
+  },
   "home": {
     "pageTitle": "MemDeck — Domine o baralho memorizado",
     "pageDescription": "Ferramenta online gratuita para dominar sistemas de baralho memorizado como Mnemonica, Aronson, Memorandum, Redford, Particle, Elephant e Infinity.",


### PR DESCRIPTION
## Summary

- Adds a dimmed footer `Anchor` pointing to `/llms.txt` — memdeck's existing LLM-readable site summary — making it discoverable to developers and AI power-users without cluttering the training UI.
- Extracts `/llms.txt` to `LLMS_TXT_PATH` constant in `src/constants.ts` (consistent with `GITHUB_URL`).
- Uses `<VisuallyHidden>` composition rather than `aria-label` so the accessible name contains the visible text "llms.txt" (WCAG 2.5.3 Label in Name, Level A) and announces "opens in new tab" (`target="_blank"` + `rel="noopener"`).
- Adds `navFooter.llmsTxtDescription` i18n section across all 7 locales (en, fr, es, de, it, nl, pt). Translations validated by native-speaker expert review — es/de/nl/pt received corrections; fr/it were clean.
- Adds 2 e2e assertions in `pages.e2e.ts` mirroring the existing GitHub link tests (visibility + `noopener`).

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — clean
- [x] `pnpm run knip` — no unused exports
- [x] `pnpm run test:coverage` — 105 files / 1805 tests pass
- [x] `npx playwright test e2e/pages.e2e.ts` — 10/10 pass including new llms.txt tests
- [x] Manual browser check — link visible in footer, click opens `/llms.txt` in new tab, accessible name verified: `"llms.txt — LLM-friendly site summary (opens in new tab)"`