### PR TITLE
chore: bump knip from 6.14.1 to 6.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "fta-cli": "3.0.0",
     "globals": "17.6.0",
     "happy-dom": "20.9.0",
-    "knip": "6.14.1",
+    "knip": "6.14.2",
     "lefthook": "2.1.8",
     "postcss": "8.5.15",
     "postcss-preset-mantine": "1.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 20.9.0
         version: 20.9.0
       knip:
-        specifier: 6.14.1
-        version: 6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: 6.14.2
+        version: 6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       lefthook:
         specifier: 2.1.8
         version: 2.1.8
@@ -2829,8 +2829,8 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  knip@6.14.1:
-    resolution: {integrity: sha512-SN3Ly0ixzj5CQkY/rc4OPHpWrCC0XRIIjgdP76G9Cni5k72ur5jBYOyvJuF5oPTM14v8eHcMUgPbElHa+lnR0g==}
+  knip@6.14.2:
+    resolution: {integrity: sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7099,7 +7099,7 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  knip@6.14.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+  knip@6.14.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0


### PR DESCRIPTION
## Summary

- Bumps `knip` from `6.14.1` to `6.14.2`.

## Test plan

- [ ] CI passes (typecheck, lint, knip, fta, tests).