### PR TITLE
chore: extract PWA shortcuts to typed constant and add e2e lint rule

### DIFF
--- a/.claude/commands/verify.md
+++ b/.claude/commands/verify.md
@@ -9,6 +9,7 @@ Run the verification protocol from CLAUDE.md, in order, stopping at the first fa
 3. `pnpm run knip`
 4. `pnpm run fta`
 5. `pnpm run test:coverage`
+6. `pnpm run lint:e2e-no-wait` — bans `waitForTimeout(` in `e2e/`; runs in milliseconds.
 
 Report pass/fail per step. On failure, show the relevant output (not the full log) and stop.
 

--- a/.claude/rules/localstorage-persistence.md
+++ b/.claude/rules/localstorage-persistence.md
@@ -1,0 +1,46 @@
+---
+paths:
+  - "src/hooks/use-all-time-stats*.ts"
+  - "src/hooks/use-pwa-install.ts"
+  - "src/hooks/use-selected-stack.ts"
+  - "src/hooks/use-session*.ts"
+  - "src/hooks/use-stack-limits.ts"
+  - "src/hooks/use-timer-settings.ts"
+  - "src/pages/**/use-*-settings.ts"
+  - "src/utils/localstorage*.ts"
+  - "src/utils/session-*.ts"
+  - "src/utils/color-scheme-manager.ts"
+  - "src/services/analytics.ts"
+---
+
+# localStorage Persistence
+
+localStorage writes are not guaranteed — Safari ITP eviction, quota exhausted, private-browsing limits, and cross-tab races all cause silent failures. Every persisted-state hook in this codebase encodes assumptions earned from real incidents (#639, #643, #644, #647, #651, #652, #654, #669, #672, #673, #674). Follow the patterns below when extending or adding one.
+
+## Don't call `localStorage.setItem` directly
+
+Go through `useLocalDb` (`src/utils/localstorage.ts`). The hook reads via `useSyncExternalStore` so no mount-time writes can overwrite corrupt-but-recoverable state (#647), writes only when the consumer's setter runs, reports failures via `onWriteFailed`, and parses JSON with a prototype-stripping reviver. Storage keys live in `src/constants.ts` with the `_LSK` suffix — never inline a string literal (pattern locked in by #673's `COLOR_SCHEME_LSK` extraction). For non-localStorage persistence (color scheme), `src/utils/color-scheme-manager.ts` mirrors the same write-failure telemetry path.
+
+## Wire telemetry through the canonical helpers
+
+Pass `handleLocalDbWriteFailed` and `reportLocalDbCorruption` from `src/utils/localstorage-telemetry.ts` to every `useLocalDb` consumer. They scrub error messages — V8 leaks `JSON.parse` SyntaxError snippets into the GA exception description otherwise (see the comment inside `reportLocalDbCorruption` in `src/utils/localstorage-telemetry.ts` before refactoring it) — and route all write failures into a single GA exception taxonomy (`LocalDbWriteFailed` / `LocalDbPersistenceFailed`) so aggregations don't need substring filters (#669).
+
+## Gate side-effects on `{ onSuccess }`
+
+When the change being persisted is also analytics-tracked or event-bus-emitted, pass `{ onSuccess }` to the setter and run the emit inside it (#651, #674). Otherwise a swallowed quota-exceeded looks like a successful change to analytics. The pattern is already applied in `use-timer-settings.ts`, `use-acaan-settings.ts`, `use-spot-check-settings.ts`, and the distance/flashcard/spot-check page handlers — mirror it in any new persisted setting.
+
+## Use `probeStoredValue` for recoverable state
+
+`probeStoredValue` (`src/utils/localstorage.ts:42`) returns a discriminated `absent | valid | corrupt | read-error` result. Use it instead of `getStoredValue` when overwriting would destroy user-recoverable data (session history, all-time stats) so consumers refuse to silently overwrite a corrupt-but-readable blob (#647). `getStoredValue` is fine for low-stakes single values where reset-on-write is acceptable.
+
+## sessionStorage sentinels for non-clearable breadcrumbs; last-known-valid cache for cross-tab corruption
+
+When `removeItem` itself fails (quota exhausted), a breadcrumb can't be cleared and the notification loops on every mount. Use a sessionStorage sentinel — separate quota bucket — to suppress within-tab repeats (#652; see `LAST_SAVE_FAILED_SHOWN_SSK` for the canonical example). Separately, a cross-tab `storage` event delivering an unparseable blob must not roll the consumer's value back to default; cache the last-known-valid per key and prefer it on corrupt/read-error probes (#654).
+
+## Test the write-failure path
+
+When adding a new persisted-state hook, write at least one unit test that triggers the `onWriteFailed` path. Use `createGatedSetterMock` (the shared test helper added in #651) — it mirrors `probedSetValue`'s success-only callback semantics. The vitest coverage ratchets in `vitest.config.ts` only catch missing branch coverage in aggregate; the write-failure path is easy to leave unexercised. For E2E coverage of quota-exceeded, see `e2e/theme.e2e.ts` (added in `c00203c`) — it shims `window.localStorage.setItem` to throw `QuotaExceededError` and asserts the toast appears.
+
+## Note on rule activation
+
+Per the Claude Code docs, path-scoped rules trigger when Claude *reads* a matching file. If you're asking Claude to create a brand-new `src/hooks/use-foo.ts` from scratch (no prior read), this rule won't auto-attach — mention it explicitly or have Claude read an existing persisted-state hook (e.g., `use-stack-limits.ts`) first.

--- a/.claude/rules/pwa-and-lazy-loading.md
+++ b/.claude/rules/pwa-and-lazy-loading.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "vite.config.ts"
+  - "src/routes.tsx"
+  - "src/utils/lazy-with-reload.ts"
+  - "src/utils/stale-chunk.ts"
+  - "src/i18n/language.ts"
+  - "src/i18n/index.ts"
+---
+
+# PWA & Lazy Loading
+
+The PWA + SPA + locale-chunk combination has several easy-to-break, hard-to-test edges. The patterns below have prevented or recovered from real incidents (#412, #413, #500, #513, #519, #521, #527, #537, #582, #646).
+
+## Use `lazyWithReload`, never bare `React.lazy()`
+
+Route-level code splitting goes through `lazyWithReload` (`src/utils/lazy-with-reload.ts`), not React's bare `lazy()`. The wrapper catches stale-chunk 404s — old PWA shells fetching chunk hashes that no longer exist after deploy — guards against reload loops with a sessionStorage sentinel (falling back to a `chunk-reloaded` URL param if sessionStorage is unavailable), and calls `window.location.reload()` (#527, #537). It does NOT update the service worker — the route path relies on `registerType: "autoUpdate"` having the new SW ready. Without `lazyWithReload`, post-deploy navigation produces blank pages and 500s. The shared 404 detector is `isStaleChunkError` in `src/utils/stale-chunk.ts`.
+
+## Locale switching uses `changeLanguage()`, not raw `import()`
+
+`changeLanguage()` in `src/i18n/language.ts` is the only safe entry point for switching languages — its `reloadOnStaleChunk` helper reuses `isStaleChunkError` to recover from cross-tab locale-chunk 404s after deploy AND calls `updateServiceWorker()` (uses `navigator.serviceWorker.getRegistration()` + Workbox's `SKIP_WAITING` message convention) before reloading, because a stale locale chunk usually means the active SW is also stale (#527). Never call `i18next.changeLanguage()` directly or dynamic-import a locale JSON ad-hoc; both bypass the recovery and break for users with old PWA shells in a fresh tab.
+
+## PWA manifest shortcuts must reference `ROUTES`
+
+The router 301-redirects no-trailing-slash → trailing-slash, and a PWA launch that hits the 301 breaks the install context (#582 was a 51-file fix from this exact mismatch). `ROUTES` in `src/constants.ts` is type-enforced to end with `/` via `satisfies Record<string, RoutePath>`. The manifest shortcuts in `vite.config.ts` are kept in sync via `PWA_SHORTCUTS` (also in `src/constants.ts`); `src/pwa-shortcuts.test.ts` fails if a shortcut URL drifts from `ROUTES`. Add new shortcuts to `PWA_SHORTCUTS`, not inline in `vite.config.ts`.
+
+## When touching the vite PWA block, rebuild
+
+If you change `manifest`, `globIgnores`, `registerType`, `manualChunks`, or `runtimeCaching`, add `pnpm run build` to your Definition of Done and visually verify:
+
+- `dist/sw.js` exists and is non-empty
+- `dist/assets/locale-<code>-<hash>.js` chunks exist for every locale
+- The PWA manifest is referenced from `dist/index.html`
+- New locale chunks are listed under `globIgnores` (otherwise precache bloats with 7 locales × N KB)
+
+This is the only end-to-end check; the build is the source of truth, not source-level reasoning.
+
+## `manualChunks` is load-bearing for caching
+
+The vendor chunks (`react-vendor`, `mantine-vendor`, `icons-vendor`, `analytics-vendor`, `i18n-vendor`) give predictable HTTP cache survival across deploys. Locale chunks are named `locale-<code>` so `globIgnores: ["assets/locale-*.js", "splash/*.png"]` works as a single pattern. Don't rename, flatten, or merge — every refactor here should preserve the cache surfaces.
+
+## `registerType: "autoUpdate"` is intentional
+
+Updates are silent with a subtle toast (#513). The previous "prompt user to update" flow was annoying for a single-dev SPA. Don't flip back without strong justification.
+
+## Lighthouse CI is the perf budget
+
+`lighthouserc.json` enforces 0.9 (warn) for performance, 0.9 (error) for accessibility / best-practices / SEO. Run `pnpm run lighthouse` locally before merging if you're about to lazy-load heavy work in a route. The audit set was trimmed from 27 URLs → 3 representative ones in #521 — don't restore the bloated set; static SPAs have negligible variance.
+
+## New lazy-loaded heavy modules
+
+Wrap in `lazyWithReload`, give them a `<Suspense>` boundary with `PageLoader` (or an inline fallback), and verify the chunk appears under `dist/assets/`. There is no per-route bundle-size budget — Lighthouse CI is the only enforced check, so plan ahead before lazy-loading anything heavy.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
         run: pnpm run knip
       - name: Lint
         run: pnpm run lint
+      - name: Check no waitForTimeout in e2e
+        run: pnpm run lint:e2e-no-wait
       - name: Typecheck
         run: pnpm run typecheck
       - name: Check file complexity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,10 +31,11 @@ When running the linter in this repo, ALWAYS invoke it as `rtk proxy pnpm run li
 3. `pnpm run knip` — catches unused exports, dependencies, and files. Runs in seconds.
 4. `pnpm run fta` — file-complexity check; CI fails on regressions.
 5. `pnpm run test:coverage` — runs the full unit suite **and** enforces the per-directory coverage ratchets in `vitest.config.ts`. Use this in place of `pnpm run test` for DoD.
-6. `pnpm run test:e2e` — when you changed routing, page chrome, or a user-facing flow. Otherwise skip; it's slow.
-7. `pnpm run build` — when you changed `vite.config.ts`, `scripts/**`, `index.html`, or anything under `public/`.
+6. `pnpm run lint:e2e-no-wait` — fails if any `waitForTimeout(` is reintroduced in `e2e/`. See `.claude/rules/pwa-and-lazy-loading.md` for the rationale.
+7. `pnpm run test:e2e` — when you changed routing, page chrome, or a user-facing flow. Otherwise skip; it's slow.
+8. `pnpm run build` — when you changed `vite.config.ts`, `scripts/**`, `index.html`, or anything under `public/`.
 
-A `/verify` slash command exists (`.claude/commands/verify.md`) that runs steps 1–5.
+A `/verify` slash command exists (`.claude/commands/verify.md`) that runs steps 1–6.
 
 ## Development Commands
 
@@ -190,6 +191,15 @@ This project uses **Ultracite** (a Biome preset) for formatting and linting.
 - **playwright.config.ts**: E2E test configuration
 - **.claude/review-baseline.json** and **.claude/audit-\*.json**: Snapshots from prior audit/review runs. Treat timestamps as authoritative — if older than ~2 weeks, re-run the relevant review or audit before citing their findings. Don't edit by hand.
 - **.claude/settings.json**: Claude Code hook config. The PostToolUse hook pipes tool-use JSON through `jq` to scope Ultracite formatting to the edited file. `jq` must be on `PATH` (install via `brew install jq` on macOS) — without it the hook fails silently and format-on-save stops working.
+
+## Path-Scoped Rules
+
+Topic-specific guidance lives in `.claude/rules/` and auto-attaches via `paths:` frontmatter when Claude opens matching files:
+
+- `localstorage-persistence.md` — patterns for any hook/util that persists to localStorage (`useLocalDb`, write-failure telemetry, corruption recovery).
+- `pwa-and-lazy-loading.md` — `lazyWithReload` discipline, stale-chunk recovery, locale switching, vite PWA build verification, manifest-shortcut/ROUTES parity.
+
+Each rule documents its trigger globs at the top.
 
 ## Memory for This Project
 

--- a/e2e/stack-limits.e2e.ts
+++ b/e2e/stack-limits.e2e.ts
@@ -254,19 +254,19 @@ test.describe("Stack Limits — emit and corrupt-lock", () => {
     );
     expect(onDisk).toBe(corrupt);
 
-    // The emit chain is synchronous today (setRecord → setItem → onSuccess);
-    // a brief settle catches a delayed emit if onSuccess ever wraps in a
-    // microtask, so the empty-captured assertion stays meaningful.
-    await page.waitForTimeout(100);
-    const captured = await page.evaluate(
-      () => window.__capturedStackLimitsChanges
-    );
-    expect(captured).toEqual([]);
-
+    // Wait for the badge before checking the captured-emits array: the
+    // visibility assertion is a positive UI settle signal that lets
+    // Playwright drain any microtask the emit chain might use, replacing
+    // an arbitrary timeout-based wait with a deterministic one.
     const badge = page.getByRole("button", {
       name: "Stack range: 52 cards. Tap to adjust.",
     });
     await expect(badge).toBeVisible();
+
+    const captured = await page.evaluate(
+      () => window.__capturedStackLimitsChanges
+    );
+    expect(captured).toEqual([]);
   });
 
   test("should emit STACK_LIMITS_CHANGED with the correct payload when a preset succeeds", async ({

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "scripts": {
     "knip": "knip",
     "lint": "ultracite check",
+    "lint:e2e-no-wait": "if grep -rnE \"\\.\\s*waitForTimeout\\s*\\(\" --include='*.ts' --include='*.tsx' e2e/ ; then echo 'E2E tests must use semantic waits, not waitForTimeout. See .claude/rules/pwa-and-lazy-loading.md.' >&2; exit 1; fi",
     "fix": "ultracite fix",
     "dev": "vite",
     "build": "vite build && node scripts/generate-sitemap.ts && node scripts/prerender.ts",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -111,3 +111,42 @@ export const ROUTES = {
   stats: "/stats/",
   about: "/about/",
 } as const satisfies Record<string, RoutePath>;
+
+/**
+ * PWA manifest shortcuts. URLs are constrained to `RoutePath` so they always
+ * end with `/` and avoid the 301-redirect that breaks the PWA install context
+ * (#582). `vite.config.ts` spreads this into `manifest.shortcuts`, and
+ * `src/pwa-shortcuts.test.ts` asserts every URL exists in `ROUTES`.
+ */
+export const PWA_SHORTCUTS = [
+  {
+    name: "Flashcard",
+    short_name: "Flashcard",
+    url: ROUTES.flashcard,
+    description: "Practice memorized deck with flashcard drills",
+  },
+  {
+    name: "ACAAN",
+    short_name: "ACAAN",
+    url: ROUTES.acaan,
+    description: "Any Card At Any Number calculator",
+  },
+  {
+    name: "Distance",
+    short_name: "Distance",
+    url: ROUTES.distance,
+    description:
+      "Practice distance numbers between cards in your memorized stack",
+  },
+  {
+    name: "Toolbox",
+    short_name: "Toolbox",
+    url: ROUTES.toolbox,
+    description: "Memorized deck utilities",
+  },
+] as const satisfies readonly {
+  name: string;
+  short_name: string;
+  url: RoutePath;
+  description: string;
+}[];

--- a/src/pwa-shortcuts.test.ts
+++ b/src/pwa-shortcuts.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { PWA_SHORTCUTS, ROUTES } from "./constants";
+
+describe("PWA manifest shortcuts", () => {
+  it("contains at least one shortcut", () => {
+    expect(PWA_SHORTCUTS.length).toBeGreaterThan(0);
+  });
+
+  it("every shortcut URL matches a value in ROUTES", () => {
+    const routeValues = new Set<string>(Object.values(ROUTES));
+
+    for (const shortcut of PWA_SHORTCUTS) {
+      expect(routeValues.has(shortcut.url)).toBe(true);
+    }
+  });
+
+  it("has no duplicate URLs", () => {
+    const urls = PWA_SHORTCUTS.map((shortcut) => shortcut.url);
+    expect(new Set(urls).size).toBe(urls.length);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import { VitePWA } from "vite-plugin-pwa";
 
+const { PWA_SHORTCUTS } = await import("./src/constants.ts");
+
 const commitHash = execSync("git rev-parse --short HEAD").toString().trim();
 
 const LOCALE_CHUNK_RE = /i18n\/locales\/(?!en)(\w+)\.json$/;
@@ -95,33 +97,7 @@ export default defineConfig({
           "Free online tool for mastering memorized deck systems like Mnemonica, Aronson, Memorandum, Redford, and Particle.",
         theme_color: "#228be6",
         background_color: "#ffffff",
-        shortcuts: [
-          {
-            name: "Flashcard",
-            short_name: "Flashcard",
-            url: "/flashcard/",
-            description: "Practice memorized deck with flashcard drills",
-          },
-          {
-            name: "ACAAN",
-            short_name: "ACAAN",
-            url: "/acaan/",
-            description: "Any Card At Any Number calculator",
-          },
-          {
-            name: "Distance",
-            short_name: "Distance",
-            url: "/distance/",
-            description:
-              "Practice distance numbers between cards in your memorized stack",
-          },
-          {
-            name: "Toolbox",
-            short_name: "Toolbox",
-            url: "/toolbox/",
-            description: "Memorized deck utilities",
-          },
-        ],
+        shortcuts: [...PWA_SHORTCUTS],
         screenshots: [
           {
             src: "/screenshots/home-mobile.png",


### PR DESCRIPTION
## Summary

- **PWA shortcuts centralized**: `PWA_SHORTCUTS` const in `src/constants.ts` uses `satisfies readonly { url: RoutePath; … }[]` to enforce trailing-slash URLs at compile time — prevents the #582 class of bug where a shortcut URL triggers a 301 that breaks the PWA install context
- **Test coverage**: `src/pwa-shortcuts.test.ts` asserts every shortcut URL exists in `ROUTES` and there are no duplicate URLs — drift is caught at CI
- **`lint:e2e-no-wait` guard**: new `package.json` script + CI step bans `waitForTimeout(` in `e2e/`; replaces the last instance in `stack-limits.e2e.ts` with a deterministic `toBeVisible` wait
- **Path-scoped rules**: `.claude/rules/` directory with `pwa-and-lazy-loading.md` and `localstorage-persistence.md` — auto-attach to relevant files and document the incident history driving each pattern; registered in `CLAUDE.md`

## Test plan

- [ ] `pnpm run typecheck` — PWA_SHORTCUTS type enforced
- [ ] `pnpm run test:coverage` — pwa-shortcuts.test.ts (3 tests) pass
- [ ] `pnpm run lint:e2e-no-wait` — exits 0 (no waitForTimeout in e2e/)
- [ ] `pnpm run build` — manifest.webmanifest contains four shortcuts with trailing-slash URLs