### PR TITLE
chore: bump ultracite 7.8.0→7.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "postcss-simple-vars": "7.0.1",
     "sharp": "0.34.5",
     "typescript": "6.0.3",
-    "ultracite": "7.8.0",
+    "ultracite": "7.8.1",
     "vite": "8.0.14",
     "vite-plugin-pwa": "1.3.0",
     "vitest": "4.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       ultracite:
-        specifier: 7.8.0
-        version: 7.8.0(oxlint@1.38.0)
+        specifier: 7.8.1
+        version: 7.8.1(oxlint@1.38.0)
       vite:
         specifier: 8.0.14
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)(yaml@2.9.0)
@@ -3952,8 +3952,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ultracite@7.8.0:
-    resolution: {integrity: sha512-wAIdn7YTBjygSdpz3ubMCAqja0odk2SCn/YqrM6k17D7ASouo0qaODJa76Xo3tp13yPWnNnLvcduNlmLBAtzYg==}
+  ultracite@7.8.1:
+    resolution: {integrity: sha512-yVkUHR9gMvqt7uEzC45tkSgJNUfAYztJPqZLSK6Z/PkWksoQOWjSVAcff7pEQarQKUJF/KR2S41UJ7wVAlo44Q==}
     hasBin: true
     peerDependencies:
       oxfmt: '>=0.1.0'
@@ -8350,7 +8350,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ultracite@7.8.0(oxlint@1.38.0):
+  ultracite@7.8.1(oxlint@1.38.0):
     dependencies:
       '@clack/prompts': 1.4.0
       commander: 14.0.3


### PR DESCRIPTION
## Summary

- Bump `ultracite` from 7.8.0 to 7.8.1.
- Update `pnpm-lock.yaml` to match.

## Test plan

- [ ] CI passes.