### PR TITLE
feat: record whether a session was timed

### DIFF
--- a/src/hooks/use-session.test.ts
+++ b/src/hooks/use-session.test.ts
@@ -233,6 +233,34 @@ describe("useSession hook", () => {
     });
   });
 
+  it("captures timed=true from options onto the active session", () => {
+    const { result } = renderHook(() =>
+      useSession({ mode: "flashcard", stackKey: "mnemonica", timed: true })
+    );
+
+    act(() => {
+      result.current.startSession({ type: "open" });
+    });
+
+    const { status } = result.current;
+    assertPhase(status, "active");
+    expect(status.session.timed).toBe(true);
+  });
+
+  it("defaults timed to false when the option is omitted", () => {
+    const { result } = renderHook(() =>
+      useSession({ mode: "flashcard", stackKey: "mnemonica" })
+    );
+
+    act(() => {
+      result.current.startSession({ type: "open" });
+    });
+
+    const { status } = result.current;
+    assertPhase(status, "active");
+    expect(status.session.timed).toBe(false);
+  });
+
   it("increments successes and streak on a correct answer", () => {
     const { result } = renderHook(() =>
       useSession({ mode: "flashcard", stackKey: "mnemonica" })

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -41,6 +41,7 @@ type UseSessionOptionsBase = {
   stackKey: StackKey;
   autoStart?: boolean;
   stackLimits?: StackLimits;
+  timed?: boolean;
 };
 
 type UseSessionOptions =
@@ -97,7 +98,7 @@ export const useSession = (options: UseSessionOptions): UseSessionResult => {
   // list mount-only). Mirrors the pattern in use-session-auto-save.ts.
   const tRef = useRef(t);
   tRef.current = t;
-  const { mode, stackKey, autoStart = false } = options;
+  const { mode, stackKey, autoStart = false, timed = false } = options;
   const stackLimits = options.stackLimits;
   const stackLimitsRef = useRef(stackLimits);
   stackLimitsRef.current = stackLimits;
@@ -360,6 +361,7 @@ export const useSession = (options: UseSessionOptions): UseSessionResult => {
         currentStreak: 0,
         bestStreak: 0,
         stackLimits: stackLimitsRef.current,
+        timed,
       };
 
       let session: ActiveSession;
@@ -395,6 +397,7 @@ export const useSession = (options: UseSessionOptions): UseSessionResult => {
       spotCheckMode,
       distanceMode,
       distanceConvention,
+      timed,
       tryFinalizeSession,
     ] // stackLimits removed, accessed via ref
   );

--- a/src/pages/acaan/acaan.tsx
+++ b/src/pages/acaan/acaan.tsx
@@ -37,6 +37,9 @@ export const Acaan = () => {
   });
   useCardImagePreload();
   const { stackKey, stackOrder, stackName } = useRequiredStack();
+  const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
+    useAcaanSettings();
+
   const {
     status,
     startSession,
@@ -46,10 +49,12 @@ export const Acaan = () => {
     activeSession,
     stopSession,
     dismissSummary,
-  } = useSession({ mode: "acaan", stackKey, autoStart: true });
-
-  const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
-    useAcaanSettings();
+  } = useSession({
+    mode: "acaan",
+    stackKey,
+    autoStart: true,
+    timed: timerSettings.enabled,
+  });
 
   const {
     scenario,

--- a/src/pages/distance/distance.tsx
+++ b/src/pages/distance/distance.tsx
@@ -64,6 +64,7 @@ export const Distance = () => {
     distanceConvention: convention,
     autoStart: true,
     stackLimits: limits,
+    timed: timerSettings.enabled,
   });
 
   const rangeTooSmall = rangeSize < MIN_DISTANCE_RANGE;

--- a/src/pages/flashcard/flashcard.tsx
+++ b/src/pages/flashcard/flashcard.tsx
@@ -56,6 +56,7 @@ export const Flashcard = () => {
     flashcardMode: mode,
     autoStart: true,
     stackLimits: limits,
+    timed: timerSettings.enabled,
   });
 
   const {

--- a/src/pages/spot-check/spot-check.tsx
+++ b/src/pages/spot-check/spot-check.tsx
@@ -63,6 +63,7 @@ export const SpotCheck = () => {
     spotCheckMode: mode,
     autoStart: true,
     stackLimits: limits,
+    timed: timerSettings.enabled,
   });
 
   const {

--- a/src/test-utils/session-factories.ts
+++ b/src/test-utils/session-factories.ts
@@ -42,6 +42,7 @@ export const makeActiveSession = (
     questionsCompleted: 0,
     currentStreak: 0,
     bestStreak: 0,
+    timed: false,
     ...overrides,
   }) as ActiveSession;
 

--- a/src/types/session.ts
+++ b/src/types/session.ts
@@ -34,6 +34,7 @@ export type ActiveSessionBase = {
   currentStreak: number;
   bestStreak: number;
   stackLimits?: StackLimits;
+  timed: boolean;
 };
 
 /** Runtime state of an active session */
@@ -65,6 +66,7 @@ type SessionRecordBase = {
   // Spelled out explicitly so adding a field to the runtime StackLimits type doesn't
   // silently widen the persisted shape.
   stackLimits?: { start: number; end: number };
+  timed?: boolean;
 };
 
 /** Persisted session record (immutable snapshot) */

--- a/src/utils/session-persistence.test.ts
+++ b/src/utils/session-persistence.test.ts
@@ -118,6 +118,18 @@ describe("buildSessionRecord", () => {
     expect(record.stackLimits).toBeUndefined();
   });
 
+  it("propagates timed=true from the active session", () => {
+    const session = makeSession({ timed: true });
+    const record = buildSessionRecord(session);
+    expect(record.timed).toBe(true);
+  });
+
+  it("propagates timed=false from the active session", () => {
+    const session = makeSession({ timed: false });
+    const record = buildSessionRecord(session);
+    expect(record.timed).toBe(false);
+  });
+
   it("returns a spotcheck record with the selected spot check mode", () => {
     const session = makeSession({
       mode: "spotcheck",

--- a/src/utils/session-persistence.ts
+++ b/src/utils/session-persistence.ts
@@ -37,6 +37,7 @@ export const buildSessionRecord = (session: ActiveSession): SessionRecord => {
     accuracy: calculateAccuracy(session.successes, session.fails),
     bestStreak: session.bestStreak,
     stackLimits: session.stackLimits,
+    timed: session.timed,
   };
 
   switch (session.mode) {

--- a/src/utils/session-typeguards.test.ts
+++ b/src/utils/session-typeguards.test.ts
@@ -201,6 +201,30 @@ describe("isSessionRecord", () => {
     };
     expect(isSessionRecord(record)).toBe(false);
   });
+
+  it("returns true when timed is true", () => {
+    expect(isSessionRecord(makeRecord({ timed: true }))).toBe(true);
+  });
+
+  it("returns true when timed is false", () => {
+    expect(isSessionRecord(makeRecord({ timed: false }))).toBe(true);
+  });
+
+  it("returns true when timed is absent (legacy record)", () => {
+    const record = makeRecord();
+    expect("timed" in record).toBe(false);
+    expect(isSessionRecord(record)).toBe(true);
+  });
+
+  it("returns true when timed is explicitly undefined", () => {
+    const record = { ...makeRecord(), timed: undefined };
+    expect(isSessionRecord(record)).toBe(true);
+  });
+
+  it("returns false when timed is not a boolean", () => {
+    const record = { ...makeRecord(), timed: "yes" };
+    expect(isSessionRecord(record)).toBe(false);
+  });
 });
 
 describe("isSessionRecordArray", () => {

--- a/src/utils/session-typeguards.ts
+++ b/src/utils/session-typeguards.ts
@@ -57,6 +57,13 @@ const isOptionalStackLimits = (value: object): boolean => {
   );
 };
 
+/** Validates that `value.timed` is either absent/undefined or a boolean.
+ * Returns boolean (not a type guard) because the outer `isSessionRecord` handles full narrowing. */
+const isOptionalTimed = (value: object): boolean =>
+  !("timed" in value) ||
+  value.timed === undefined ||
+  typeof value.timed === "boolean";
+
 const isSessionConfig = (value: unknown): value is SessionConfig => {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -120,6 +127,9 @@ export const isSessionRecord = (value: unknown): value is SessionRecord => {
     return false;
   }
   if (!isOptionalStackLimits(value)) {
+    return false;
+  }
+  if (!isOptionalTimed(value)) {
     return false;
   }
   // System boundary: value has been validated structurally above (all required


### PR DESCRIPTION
## Summary

- Adds `timed: boolean` to `ActiveSessionBase` (required) and `timed?: boolean` to `SessionRecordBase` (optional — old records without the field still validate, reading as "not timed")
- Threads `timed?` (default `false`) through `UseSessionOptionsBase` → `startSession` → `buildSessionRecord`, so every completed session record now captures the timer state at session start
- All 4 training pages (`flashcard`, `spot-check`, `distance`, `acaan`) pass `timed: timerSettings.enabled` into `useSession` (ACAAN needed a hook reorder to bring `timerSettings` into scope first)
- New `isOptionalTimed` guard helper in `session-typeguards.ts`, mirroring `isOptionalStackLimits`, wired into `isSessionRecord` for backward-compatible validation

**No UI changes. No new reads of the flag.** Data capture only — ship early so history starts accruing the `timed` field before the Feature Discovery issues (#697) consume it.

Part of #693.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — no issues  
- [x] `pnpm run knip` — no unused exports
- [x] `pnpm run fta` — no regressions
- [x] `pnpm run test:coverage` — 1869 tests pass, all per-directory ratchets met
- [x] `pnpm run lint:e2e-no-wait` — clean
- New tests cover `isOptionalTimed` all branches (absent / undefined / true / false / non-boolean), `buildSessionRecord` timed propagation, `useSession` start-path with `timed: true` and default `false`

Closes #694