### PR TITLE
feat: guided discovery — personalised "New challenge" card on home

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ All memorized decks are centralized in `src/types/stacks.ts`:
 - **Distance Number** (`src/pages/distance/`): Drill the offset between two cards in the stack — the math behind Pit Hartling's Quartets routines (*In Order to Amaze*). Two sub-modes (compute, apply) and two conventions (cyclic 1..N-1, signed shortest). Respects stack range; needs at least 6 cards in range
 - **Toolbox** (`src/pages/toolbox/`): Collection of memorized deck utilities
 - **Stats** (`src/pages/stats/`): Session history, accuracy statistics, and best streak tracking
+- **Guided Discovery** (`src/hooks/use-feature-discovery.ts`, `src/components/next-challenge-card.tsx`): Nudges users toward untried modes and sub-variants, deduced from their own session history (`deriveFeatureUsage`). Surfaces one dismissible "New challenge" card at a time on the home page — earned after ≥3 sessions, personalized to the most-used mode, retire-on-accept, retire-and-snooze-the-surface-on-dismiss, and silent while the share nudge is pending. Engine lives in `src/utils/{feature-usage,suggestion-catalog,discovery-typeguards}.ts`; the catalog covers untried whole modes and sub-variants (timed suggestions and the post-session/Stats surfaces are tracked in epic #693)
 - **Guide** (`src/pages/guide/`): Getting started and training instructions. Includes `HowTo` and `BreadcrumbList` JSON-LD schemas
 - **FAQ** (`src/pages/faq.tsx`): Frequently asked questions about memorized decks, targeting LLM search discoverability. Includes `FAQPage` and `BreadcrumbList` JSON-LD schemas
 - **Resources** (`src/pages/resources.tsx`): Curated reading list of memorized deck books and PDFs. Includes `ItemList`/`Book` and `BreadcrumbList` JSON-LD schemas
@@ -219,7 +220,7 @@ The user-level auto-memory system handles most of the work. For memdeck.org spec
 
 ## Constants
 
-Application constants are defined in `src/constants.ts`, including localStorage keys (suffixed `_LSK`), card dimensions, and site metadata.
+Application constants are defined in `src/constants.ts`, including localStorage keys (suffixed `_LSK`), card dimensions, and site metadata. The Feature Discovery system persists its dismissed-suggestion ids and snooze gate under `FEATURE_DISCOVERY_LSK`.
 
 ## Copy & Tone Guidelines
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Browse any stack with a draggable, touch-friendly spread. Supports mouse, touch 
 
 Track your training history with accuracy stats, best streaks, and per-mode breakdowns.
 
+### Guided Discovery
+
+Once you've logged a few sessions, MemDeck surfaces a "New challenge" card on the home page — pointing you to a mode or variant you haven't tried yet, picked from your own training history. One calm suggestion at a time, personalized to what you train most, and easy to dismiss.
+
 ### Resources
 
 Curated reading list of memorized deck books and PDFs to deepen your knowledge.

--- a/e2e/feature-discovery.e2e.ts
+++ b/e2e/feature-discovery.e2e.ts
@@ -1,0 +1,146 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/test-setup";
+
+const NEW_CHALLENGE_PATTERN = /new challenge/i;
+const NUMBERONLY_DEEP_LINK = /\/flashcard\/\?try=numberonly$/;
+const NEIGHBOR_DEEP_LINK = /\/flashcard\/\?try=neighbor$/;
+
+type Seed = {
+  sessions: Record<string, unknown>[];
+  totalSessions: number;
+};
+
+function session(
+  id: string,
+  extra: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    id,
+    stackKey: "mnemonica",
+    config: { type: "structured", totalQuestions: 10 },
+    startedAt: "2026-02-10T10:00:00.000Z",
+    endedAt: "2026-02-10T10:05:00.000Z",
+    durationSeconds: 300,
+    successes: 8,
+    fails: 2,
+    questionsCompleted: 10,
+    accuracy: 0.8,
+    bestStreak: 5,
+    ...extra,
+  };
+}
+
+// One session of every whole mode (4 total): ≥ DISCOVERY_MIN_SESSIONS (3) but
+// < SHARE_NUDGE_MIN_SESSIONS (5). All whole modes are tried, so a sub-variant
+// surfaces; the 1-each tie resolves most-used to flashcard (first in
+// TRAINING_MODES), making flashcard-numberonly the top suggestion and
+// flashcard-neighbor the next one.
+const ALL_WHOLE_MODES_SEED: Seed = {
+  sessions: [
+    session("s0", { mode: "flashcard", flashcardMode: "cardonly" }),
+    session("s1", { mode: "spotcheck", spotCheckMode: "missing" }),
+    session("s2", { mode: "distance" }),
+    session("s3", { mode: "acaan" }),
+  ],
+  totalSessions: 4,
+};
+
+// Seed a selected stack + session history + an all-time-stats total before the
+// app mounts, then open home. The app reads these via useSyncExternalStore on
+// mount, so the seeded stack flips home to the with-stack view. The init script
+// re-runs on every full navigation/reload but leaves the discovery state
+// (FEATURE_DISCOVERY_LSK) untouched, so accept/dismiss writes survive a reload.
+async function seedAndOpenHome(page: Page, seed: Seed) {
+  await page.addInitScript((data: Seed) => {
+    localStorage.setItem("memdeck-app-stack", JSON.stringify("mnemonica"));
+    localStorage.setItem(
+      "memdeck-app-session-history",
+      JSON.stringify(data.sessions)
+    );
+    localStorage.setItem(
+      "memdeck-app-all-time-stats",
+      JSON.stringify({
+        "flashcard:mnemonica": {
+          totalSessions: data.totalSessions,
+          totalQuestions: data.totalSessions * 10,
+          totalSuccesses: data.totalSessions * 8,
+          totalFails: data.totalSessions * 2,
+          globalBestStreak: 5,
+        },
+      })
+    );
+  }, seed);
+  await page.goto("/");
+}
+
+test.describe("Feature Discovery — Next Challenge card", () => {
+  test("shows a suggestion after enough sessions and hides it on dismiss", async ({
+    page,
+  }) => {
+    // 4 flashcard (card-only) sessions: ≥ DISCOVERY_MIN_SESSIONS (3) but <
+    // SHARE_NUDGE_MIN_SESSIONS (5), so the discovery card shows and the share
+    // nudge stays dormant.
+    await seedAndOpenHome(page, {
+      sessions: [0, 1, 2, 3].map((index) =>
+        session(`seed-${index}`, {
+          mode: "flashcard",
+          flashcardMode: "cardonly",
+        })
+      ),
+      totalSessions: 4,
+    });
+
+    const eyebrow = page.getByText(NEW_CHALLENGE_PATTERN);
+    await expect(eyebrow).toBeVisible();
+    await expect(page.getByRole("link", { name: "Try it" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Dismiss" }).click();
+
+    // Dismiss retires the suggestion and snoozes the surface — the card is gone.
+    await expect(eyebrow).toHaveCount(0);
+
+    // The dismissal must survive a reload: this asserts the write to
+    // FEATURE_DISCOVERY_LSK actually landed, not just the in-memory store update
+    // (a silently-failed localStorage write would resurface the card here).
+    await page.reload();
+    await expect(eyebrow).toHaveCount(0);
+  });
+
+  test("Try it navigates to the deep-linked route", async ({ page }) => {
+    await seedAndOpenHome(page, ALL_WHOLE_MODES_SEED);
+
+    await expect(page.getByText(NEW_CHALLENGE_PATTERN)).toBeVisible();
+    await page.getByRole("link", { name: "Try it" }).click();
+
+    // The flashcard page does not consume `?try=` yet — accepting lands in the
+    // default mode. #696 will honor the param; this assertion should then also
+    // verify the suggested variant is preselected.
+    await expect(page).toHaveURL(NUMBERONLY_DEEP_LINK);
+  });
+
+  test("accepting a suggestion retires it across a reload", async ({
+    page,
+  }) => {
+    await seedAndOpenHome(page, ALL_WHOLE_MODES_SEED);
+
+    // Top suggestion is flashcard-numberonly; accept it via the CTA.
+    const tryLink = page.getByRole("link", { name: "Try it" });
+    await expect(tryLink).toHaveAttribute("href", NUMBERONLY_DEEP_LINK);
+    await tryLink.click();
+    await expect(page).toHaveURL(NUMBERONLY_DEEP_LINK);
+
+    // Return home with a full navigation — page.goto reloads the document and
+    // re-hydrates from localStorage. If the accept write to
+    // FEATURE_DISCOVERY_LSK landed, flashcard-numberonly is retired and the
+    // next suggestion (flashcard-neighbor) takes its place — proving retirement
+    // persisted, not just an in-memory store update.
+    await page.goto("/");
+
+    await expect(page.getByText(NEW_CHALLENGE_PATTERN)).toBeVisible();
+    await expect(page.getByRole("link", { name: "Try it" })).toHaveAttribute(
+      "href",
+      NEIGHBOR_DEEP_LINK
+    );
+  });
+});

--- a/index.html
+++ b/index.html
@@ -199,6 +199,7 @@
           "Card Spelling",
           "Stay Stack Sequences",
           "Session Statistics",
+          "Guided Discovery",
         ],
         inLanguage: ["en", "fr", "es", "de", "it", "nl", "pt"],
         screenshot: "https://memdeck.org/screenshots/home-desktop.png",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > MemDeck is a free, open-source memorized deck trainer for magicians and memory enthusiasts. It helps users master famous memorized deck systems through flashcard exercises, spot checks, ACAAN practice, and deck utilities. Available as a PWA that works offline, in 7 languages, with no account required.
 
-Last updated: 2026-04-05
+Last updated: 2026-06-04
 
 ## What Is a Memorized Deck?
 
@@ -85,6 +85,10 @@ A collection of memorized deck utilities:
 - Track accuracy trends over time
 - All-time aggregated statistics per mode and stack combination
 - Data stored locally - never leaves your device
+
+### Guided Discovery (New challenge)
+
+A calm, history-driven discovery system that nudges users toward training modes and sub-variants they haven't tried yet. After at least three completed sessions, the home page surfaces a single dismissible "New challenge" card, deduced entirely from the user's own session history (no server involved). It suggests untried whole modes (Spot Check, Distance Number, ACAAN) and untried sub-variants (Flashcard number-only or neighbor, Spot Check swapped or moved, Distance apply or signed), prioritizing a variant of the user's most-used mode. Accepting or dismissing a suggestion retires it permanently; dismissing also snoozes the surface for a couple of sessions. Only one card shows at a time — it never appears during a drill and yields to the share prompt. (Timed-session suggestions are not part of this system yet; they are planned separately.)
 
 ### Guide
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,7 +2,7 @@
 
 > MemDeck is a free, open-source memorized deck trainer for magicians and memory enthusiasts. It helps users master famous memorized deck systems through flashcard exercises, spot checks, ACAAN practice, and deck utilities. Available as a PWA that works offline, in 7 languages, with no account required.
 
-Last updated: 2026-04-05
+Last updated: 2026-06-04
 
 MemDeck is designed for card magicians who use memorized stacks (also known as memorized decks or mem-decks). A memorized stack is a specific, pre-arranged order of all 52 cards that a magician commits to memory, enabling powerful card effects. MemDeck provides interactive training tools to help memorize and maintain recall of these systems.
 
@@ -20,6 +20,7 @@ A global per-stack setting lets users focus training on a specific range of posi
 - [Distance Number](https://memdeck.org/distance/): Drill the offset between two cards in your stack — the math behind Pit Hartling's Quartets routines (*In Order to Amaze*). Two sub-modes (compute, apply) and two conventions (cyclic 1..N-1, signed shortest). Respects the stack range setting (needs at least 6 cards).
 - [Toolbox](https://memdeck.org/toolbox/): Stack lookup, faro shuffle simulator, card spelling tool, and stay stack sequence finder. Stack lookup and card spelling respect the stack range; faro shuffle and stay stack use the full deck.
 - [Stats](https://memdeck.org/stats/): Track session history, accuracy, and progress over time.
+- Guided Discovery (home page, not a separate route): After at least three completed sessions, the home page surfaces a dismissible "New challenge" card suggesting a training mode or sub-variant the user hasn't tried yet, deduced from their own session history. One suggestion at a time, personalized to the most-used mode; retires on accept or dismiss, and dismissing also snoozes the surface for a couple of sessions.
 - [Guide](https://memdeck.org/guide/): Getting started instructions and training tips.
 - [FAQ](https://memdeck.org/faq/): Frequently asked questions about memorized decks and MemDeck.
 - [Resources](https://memdeck.org/resources/): Curated books, PDFs, and links for memorized deck study.

--- a/src/components/next-challenge-card.test.tsx
+++ b/src/components/next-challenge-card.test.tsx
@@ -1,0 +1,121 @@
+import { IconCards } from "@tabler/icons-react";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ROUTES } from "../constants";
+import type { UseFeatureDiscoveryResult } from "../hooks/use-feature-discovery";
+import { render } from "../test-utils";
+import type { FeatureSuggestion } from "../types/discovery";
+import { NextChallengeCard } from "./next-challenge-card";
+
+const suggestion: FeatureSuggestion = {
+  id: "spotcheck-swapped",
+  mode: "spotcheck",
+  isUsed: () => false,
+  isApplicable: () => true,
+  priority: 2,
+  route: ROUTES.spotCheck,
+  deepLink: { param: "try", value: "swapped" },
+  icon: IconCards,
+  i18n: { titleKey: "discovery.spotCheckSwappedTitle" },
+};
+
+const mockAccept = vi.fn();
+const mockDismiss = vi.fn();
+let hookValue: UseFeatureDiscoveryResult;
+
+vi.mock("../hooks/use-feature-discovery", () => ({
+  useFeatureDiscovery: () => hookValue,
+}));
+
+const mockTrackShown = vi.fn();
+vi.mock("../services/analytics", () => ({
+  analytics: {
+    trackFeatureSuggestionShown: (...args: unknown[]) =>
+      mockTrackShown(...args),
+  },
+}));
+
+const EYEBROW = "New challenge";
+const TITLE = "Two cards trade places — can you catch the swap?";
+
+beforeEach(() => {
+  mockAccept.mockReset();
+  mockDismiss.mockReset();
+  mockTrackShown.mockReset();
+  hookValue = {
+    nextSuggestion: suggestion,
+    accept: mockAccept,
+    dismiss: mockDismiss,
+    exploredCount: 2,
+    totalCount: 9,
+  };
+});
+
+describe("NextChallengeCard", () => {
+  it("renders nothing when there is no suggestion", () => {
+    hookValue = { ...hookValue, nextSuggestion: null };
+
+    render(<NextChallengeCard surface="home" />);
+
+    expect(screen.queryByText(EYEBROW)).not.toBeInTheDocument();
+  });
+
+  it("renders the eyebrow, suggestion title and progress hint", () => {
+    render(<NextChallengeCard surface="home" />);
+
+    expect(screen.getByText(EYEBROW)).toBeInTheDocument();
+    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(screen.getByText("2 of 9 explored")).toBeInTheDocument();
+  });
+
+  it("exposes the card as a region landmark labelled by the eyebrow", () => {
+    render(<NextChallengeCard surface="home" />);
+
+    expect(screen.getByRole("region", { name: EYEBROW })).toBeInTheDocument();
+  });
+
+  it("links the CTA to the deep-linked route", () => {
+    render(<NextChallengeCard surface="home" />);
+
+    expect(screen.getByRole("link", { name: "Try it" })).toHaveAttribute(
+      "href",
+      "/spot-check/?try=swapped"
+    );
+  });
+
+  it("describes the CTA with the suggestion title for link purpose", () => {
+    render(<NextChallengeCard surface="home" />);
+
+    const link = screen.getByRole("link", { name: "Try it" });
+    const describedBy = link.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    // The visible name stays the generic "Try it" (no Label-in-Name break);
+    // the destination is conveyed via the associated title.
+    expect(screen.getByText(TITLE)).toHaveAttribute("id", describedBy);
+  });
+
+  it("tracks the suggestion as shown on mount", () => {
+    render(<NextChallengeCard surface="home" />);
+
+    expect(mockTrackShown).toHaveBeenCalledWith("spotcheck-swapped", "home");
+  });
+
+  it("accepts the suggestion when the CTA is clicked", async () => {
+    const user = userEvent.setup();
+    render(<NextChallengeCard surface="home" />);
+
+    await user.click(screen.getByRole("link", { name: "Try it" }));
+
+    expect(mockAccept).toHaveBeenCalledWith("spotcheck-swapped", "home");
+  });
+
+  it("dismisses the suggestion when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<NextChallengeCard surface="home" />);
+
+    await user.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(mockDismiss).toHaveBeenCalledWith("spotcheck-swapped", "home");
+  });
+});

--- a/src/components/next-challenge-card.tsx
+++ b/src/components/next-challenge-card.tsx
@@ -1,0 +1,93 @@
+import { ActionIcon, Button, Group, Paper, Stack, Text } from "@mantine/core";
+import { IconX } from "@tabler/icons-react";
+import { useEffect, useId } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
+import { useFeatureDiscovery } from "../hooks/use-feature-discovery";
+import { analytics } from "../services/analytics";
+import type { DiscoverySurface } from "../types/discovery";
+
+type NextChallengeCardProps = {
+  surface: DiscoverySurface;
+};
+
+export const NextChallengeCard = ({ surface }: NextChallengeCardProps) => {
+  const { t } = useTranslation();
+  const { nextSuggestion, accept, dismiss, exploredCount, totalCount } =
+    useFeatureDiscovery();
+  // `eyebrowId` names the region landmark ("New challenge"); `titleId`
+  // associates the generic "Try it" CTA with the suggestion title so the
+  // link's purpose is unambiguous out of context (WCAG 2.4.4). `useId` keeps
+  // both unique even if two cards mount (e.g. different `surface`s).
+  const eyebrowId = useId();
+  const titleId = useId();
+  const suggestionId = nextSuggestion?.id;
+
+  useEffect(() => {
+    if (suggestionId) {
+      analytics.trackFeatureSuggestionShown(suggestionId, surface);
+    }
+  }, [suggestionId, surface]);
+
+  if (!nextSuggestion) {
+    return null;
+  }
+
+  const { deepLink } = nextSuggestion;
+  const to = `${nextSuggestion.route}${
+    deepLink ? `?${deepLink.param}=${deepLink.value}` : ""
+  }`;
+  const Icon = nextSuggestion.icon;
+  const handleAccept = () => accept(nextSuggestion.id, surface);
+  const handleDismiss = () => dismiss(nextSuggestion.id, surface);
+
+  return (
+    <Paper
+      aria-labelledby={eyebrowId}
+      component="section"
+      p="sm"
+      radius="md"
+      shadow="xs"
+      withBorder
+    >
+      <Group align="flex-start" gap="sm" justify="space-between" wrap="nowrap">
+        <Stack gap={4}>
+          <Text c="dimmed" fw={700} id={eyebrowId} size="xs" tt="uppercase">
+            {t("discovery.eyebrow")}
+          </Text>
+          <Text id={titleId} size="sm">
+            {t(nextSuggestion.i18n.titleKey)}
+          </Text>
+          <Text c="dimmed" size="xs">
+            {t("discovery.progress", {
+              explored: exploredCount,
+              total: totalCount,
+            })}
+          </Text>
+        </Stack>
+        <Group gap="xs" wrap="nowrap">
+          <Button
+            aria-describedby={titleId}
+            component={Link}
+            leftSection={<Icon aria-hidden="true" size={14} />}
+            onClick={handleAccept}
+            size="xs"
+            to={to}
+            variant="light"
+          >
+            {t(nextSuggestion.i18n.ctaKey ?? "discovery.cta")}
+          </Button>
+          <ActionIcon
+            aria-label={t("discovery.dismiss")}
+            c="dimmed"
+            onClick={handleDismiss}
+            size="sm"
+            variant="subtle"
+          >
+            <IconX aria-hidden="true" size={14} />
+          </ActionIcon>
+        </Group>
+      </Group>
+    </Paper>
+  );
+};

--- a/src/components/share-nudge.tsx
+++ b/src/components/share-nudge.tsx
@@ -2,10 +2,7 @@ import { ActionIcon, Group, Paper, Text } from "@mantine/core";
 import { IconShare, IconX } from "@tabler/icons-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  SHARE_NUDGE_DISMISSED_LSK,
-  SHARE_NUDGE_MIN_SESSIONS,
-} from "../constants";
+import { SHARE_NUDGE_DISMISSED_LSK } from "../constants";
 import { useAllTimeStats } from "../hooks/use-all-time-stats";
 import { analytics } from "../services/analytics";
 import { useLocalDb } from "../utils/localstorage";
@@ -14,6 +11,7 @@ import {
   reportLocalDbCorruption,
 } from "../utils/localstorage-telemetry";
 import { shareMemDeck } from "../utils/share";
+import { isShareNudgePending } from "../utils/share-nudge-eligibility";
 
 const isBoolean = (value: unknown): value is boolean =>
   typeof value === "boolean";
@@ -48,9 +46,7 @@ export const ShareNudge = () => {
   }, [handleDismiss, t]);
 
   if (
-    dismissed ||
-    !globalStats ||
-    globalStats.totalSessions < SHARE_NUDGE_MIN_SESSIONS
+    !(globalStats && isShareNudgePending(dismissed, globalStats.totalSessions))
   ) {
     return null;
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,6 +88,15 @@ export const SHARE_NUDGE_DISMISSED_LSK = "memdeck-app-share-nudge-dismissed";
 /** Minimum number of completed sessions before showing the share nudge */
 export const SHARE_NUDGE_MIN_SESSIONS = 5;
 
+/** localStorage key for the feature-discovery state (dismissed ids + snooze) */
+export const FEATURE_DISCOVERY_LSK = "memdeck-app-feature-discovery";
+
+/** Minimum completed sessions before any discovery suggestion is shown */
+export const DISCOVERY_MIN_SESSIONS = 3;
+
+/** How many further sessions a dismissed suggestion snoozes the whole surface */
+export const DISCOVERY_SNOOZE_SESSIONS = 2;
+
 export const STACK_LIMITS_LSK = "memdeck-app-stack-limits";
 export const MIN_FLASHCARD_RANGE = 6;
 export const MIN_SPOT_CHECK_RANGE = 10;
@@ -95,7 +104,7 @@ export const MIN_DISTANCE_RANGE = 6;
 export const RANGE_PRESETS = [13, 26, 39, 52] as const;
 
 /** Canonical route format — leading + trailing slash, so consumers (sitemap, internal links) never trip a 301 redirect. */
-type RoutePath = "/" | `/${string}/`;
+export type RoutePath = "/" | `/${string}/`;
 
 /** All route paths used by the app — shared between routes.tsx and the pre-render script */
 export const ROUTES = {

--- a/src/hooks/use-feature-discovery.test.ts
+++ b/src/hooks/use-feature-discovery.test.ts
@@ -1,0 +1,338 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DISCOVERY_SNOOZE_SESSIONS, FEATURE_DISCOVERY_LSK } from "../constants";
+import { createGatedSetterMock } from "../test-utils/mock-local-db-setter";
+import type { FeatureDiscoveryState } from "../types/discovery";
+import type { FlashcardMode } from "../types/flashcard";
+import type { SessionRecord } from "../types/session";
+import type { SpotCheckMode } from "../types/spot-check";
+import { useFeatureDiscovery } from "./use-feature-discovery";
+
+// --- Session-record builders ------------------------------------------------
+
+type BaseFields = Omit<Extract<SessionRecord, { mode: "acaan" }>, "mode">;
+
+const base = (id: string): BaseFields => ({
+  id,
+  stackKey: "mnemonica",
+  config: { type: "open" },
+  startedAt: "2026-01-01T00:00:00.000Z",
+  endedAt: "2026-01-01T00:05:00.000Z",
+  durationSeconds: 300,
+  successes: 8,
+  fails: 2,
+  questionsCompleted: 10,
+  accuracy: 0.8,
+  bestStreak: 5,
+});
+
+const flashcard = (
+  id: string,
+  flashcardMode?: FlashcardMode
+): SessionRecord => ({
+  ...base(id),
+  mode: "flashcard",
+  flashcardMode,
+});
+
+const spotcheck = (
+  id: string,
+  spotCheckMode?: SpotCheckMode
+): SessionRecord => ({
+  ...base(id),
+  mode: "spotcheck",
+  spotCheckMode,
+});
+
+const distance = (id: string): SessionRecord => ({
+  ...base(id),
+  mode: "distance",
+  distanceMode: "compute",
+  distanceConvention: "cyclic",
+});
+
+const acaan = (id: string): SessionRecord => ({ ...base(id), mode: "acaan" });
+
+// --- Mocks ------------------------------------------------------------------
+
+let mockHistory: SessionRecord[] = [];
+vi.mock("./use-session-history", () => ({
+  useSessionHistory: () => ({ history: mockHistory }),
+}));
+
+const mockGetGlobalStats = vi.fn();
+vi.mock("./use-all-time-stats", () => ({
+  useAllTimeStats: () => ({ getGlobalStats: mockGetGlobalStats }),
+}));
+
+const mockTrackAccepted = vi.fn();
+const mockTrackDismissed = vi.fn();
+vi.mock("../services/analytics", () => ({
+  analytics: {
+    trackFeatureSuggestionAccepted: (...args: unknown[]) =>
+      mockTrackAccepted(...args),
+    trackFeatureSuggestionDismissed: (...args: unknown[]) =>
+      mockTrackDismissed(...args),
+  },
+}));
+
+vi.mock("../utils/localstorage-telemetry", () => ({
+  handleLocalDbWriteFailed: vi.fn(),
+  reportLocalDbCorruption: vi.fn(),
+}));
+
+let discoveryState: FeatureDiscoveryState = { dismissed: [], snoozedUntil: 0 };
+let shareDismissed = false;
+let setterSucceeds = true;
+// Typed with `unknown` so the mock setter is assignable to `useLocalDb`'s
+// `UseLocalDbSetter<unknown>` slot, and so a recorded updater argument narrows
+// to a callable via `typeof === "function"`.
+const mockSetState = createGatedSetterMock<unknown>(() => setterSucceeds);
+
+vi.mock("../utils/localstorage", () => ({ useLocalDb: vi.fn() }));
+const { useLocalDb } = await import("../utils/localstorage");
+const mockedUseLocalDb = vi.mocked(useLocalDb);
+
+const stats = (totalSessions: number) => ({
+  totalSessions,
+  totalQuestions: 0,
+  totalSuccesses: 0,
+  totalFails: 0,
+  globalBestStreak: 0,
+});
+
+beforeEach(() => {
+  mockHistory = [flashcard("1", "cardonly")];
+  discoveryState = { dismissed: [], snoozedUntil: 0 };
+  shareDismissed = false;
+  setterSucceeds = true;
+  mockTrackAccepted.mockReset();
+  mockTrackDismissed.mockReset();
+  mockSetState.mockClear();
+  // 4 sessions: ≥ DISCOVERY_MIN_SESSIONS (3) but < SHARE_NUDGE_MIN_SESSIONS (5),
+  // so discovery is eligible and the share nudge is not pending.
+  mockGetGlobalStats.mockReturnValue(stats(4));
+  mockedUseLocalDb.mockImplementation((key) =>
+    key === FEATURE_DISCOVERY_LSK
+      ? [discoveryState, mockSetState, vi.fn()]
+      : [shareDismissed, vi.fn(), vi.fn()]
+  );
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useFeatureDiscovery", () => {
+  it("returns null below the minimum session count", () => {
+    mockGetGlobalStats.mockReturnValue(stats(2));
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion).toBeNull();
+  });
+
+  it("suggests the highest-priority untried whole mode for a flashcard-only user", () => {
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion?.id).toBe("mode-spotcheck");
+  });
+
+  it("prioritizes a variant of the most-used mode once whole modes are tried", () => {
+    // Distance is the most-used mode; all whole modes have been tried.
+    mockHistory = [
+      flashcard("1", "cardonly"),
+      spotcheck("2", "missing"),
+      acaan("3"),
+      distance("4"),
+      distance("5"),
+      distance("6"),
+    ];
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion?.id).toBe("distance-apply");
+  });
+
+  it("suppresses suggestions while snoozed and resumes afterward", () => {
+    discoveryState = { dismissed: [], snoozedUntil: 6 };
+    const snoozed = renderHook(() => useFeatureDiscovery());
+    expect(snoozed.result.current.nextSuggestion).toBeNull();
+
+    discoveryState = { dismissed: [], snoozedUntil: 4 };
+    const resumed = renderHook(() => useFeatureDiscovery());
+    expect(resumed.result.current.nextSuggestion).not.toBeNull();
+  });
+
+  it("never resurfaces a retired suggestion", () => {
+    discoveryState = { dismissed: ["mode-spotcheck"], snoozedUntil: 0 };
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion?.id).toBe("mode-distance");
+  });
+
+  it("stays silent while the share nudge is pending", () => {
+    mockGetGlobalStats.mockReturnValue(stats(5));
+    shareDismissed = false;
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion).toBeNull();
+  });
+
+  it("surfaces a suggestion once the share nudge is dismissed at its threshold", () => {
+    mockGetGlobalStats.mockReturnValue(stats(5));
+    shareDismissed = true;
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion).not.toBeNull();
+  });
+
+  it("returns null when every suggestion has been retired", () => {
+    discoveryState = {
+      dismissed: [
+        "mode-spotcheck",
+        "mode-distance",
+        "mode-acaan",
+        "flashcard-numberonly",
+        "flashcard-neighbor",
+        "spotcheck-swapped",
+        "spotcheck-moved",
+        "distance-apply",
+        "distance-signed",
+      ],
+      snoozedUntil: 0,
+    };
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion).toBeNull();
+  });
+
+  it("orders by catalog index when there is no most-used mode", () => {
+    // history (session-history) and totalSessions (all-time-stats) are separate
+    // stores; an empty history with a non-zero session count leaves
+    // mostUsedMode null, so the comparator must fall through to catalog order
+    // without throwing on the null comparison.
+    mockHistory = [];
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    expect(result.current.nextSuggestion?.id).toBe("mode-spotcheck");
+  });
+
+  it("does not duplicate an already-retired id when accepting again", () => {
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.accept("mode-spotcheck", "home");
+    });
+
+    const updater = mockSetState.mock.calls[0]?.[0];
+    if (typeof updater !== "function") {
+      throw new Error("expected an updater function");
+    }
+    expect(updater({ dismissed: ["mode-spotcheck"], snoozedUntil: 0 })).toEqual(
+      {
+        dismissed: ["mode-spotcheck"],
+        snoozedUntil: 0,
+      }
+    );
+  });
+
+  it("retires the suggestion and tracks acceptance on a successful write", () => {
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.accept("mode-spotcheck", "home");
+    });
+
+    expect(mockSetState).toHaveBeenCalledWith(expect.any(Function), {
+      onSuccess: expect.any(Function),
+    });
+    const updater = mockSetState.mock.calls[0]?.[0];
+    if (typeof updater !== "function") {
+      throw new Error("expected an updater function");
+    }
+    expect(updater({ dismissed: [], snoozedUntil: 0 })).toEqual({
+      dismissed: ["mode-spotcheck"],
+      snoozedUntil: 0,
+    });
+    expect(mockTrackAccepted).toHaveBeenCalledWith("mode-spotcheck", "home");
+  });
+
+  it("snoozes the surface and tracks dismissal", () => {
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.dismiss("mode-spotcheck", "home");
+    });
+
+    const updater = mockSetState.mock.calls[0]?.[0];
+    if (typeof updater !== "function") {
+      throw new Error("expected an updater function");
+    }
+    expect(updater({ dismissed: [], snoozedUntil: 0 })).toEqual({
+      dismissed: ["mode-spotcheck"],
+      snoozedUntil: 4 + DISCOVERY_SNOOZE_SESSIONS,
+    });
+    expect(mockTrackDismissed).toHaveBeenCalledWith("mode-spotcheck", "home");
+  });
+
+  it("does not duplicate an already-retired id when dismissing again", () => {
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.dismiss("mode-spotcheck", "home");
+    });
+
+    const updater = mockSetState.mock.calls[0]?.[0];
+    if (typeof updater !== "function") {
+      throw new Error("expected an updater function");
+    }
+    // Re-running over a state that already holds the id keeps a single entry
+    // but still refreshes the snooze gate.
+    expect(updater({ dismissed: ["mode-spotcheck"], snoozedUntil: 0 })).toEqual(
+      {
+        dismissed: ["mode-spotcheck"],
+        snoozedUntil: 4 + DISCOVERY_SNOOZE_SESSIONS,
+      }
+    );
+  });
+
+  it("does not track analytics when the write fails", () => {
+    setterSucceeds = false;
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.accept("mode-spotcheck", "home");
+    });
+
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+    expect(mockTrackAccepted).not.toHaveBeenCalled();
+  });
+
+  it("does not track dismissal analytics when the write fails", () => {
+    setterSucceeds = false;
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    act(() => {
+      result.current.dismiss("mode-spotcheck", "home");
+    });
+
+    expect(mockSetState).toHaveBeenCalledTimes(1);
+    expect(mockTrackDismissed).not.toHaveBeenCalled();
+  });
+
+  it("reports exploredCount over the catalog and a fixed totalCount", () => {
+    mockHistory = [flashcard("1", "neighbor"), spotcheck("2", "swapped")];
+
+    const { result } = renderHook(() => useFeatureDiscovery());
+
+    // Used catalog items: mode-spotcheck, flashcard-neighbor, spotcheck-swapped.
+    expect(result.current.exploredCount).toBe(3);
+    expect(result.current.totalCount).toBe(9);
+  });
+});

--- a/src/hooks/use-feature-discovery.ts
+++ b/src/hooks/use-feature-discovery.ts
@@ -1,0 +1,161 @@
+import { useCallback, useMemo } from "react";
+import {
+  DISCOVERY_MIN_SESSIONS,
+  DISCOVERY_SNOOZE_SESSIONS,
+  FEATURE_DISCOVERY_LSK,
+  SHARE_NUDGE_DISMISSED_LSK,
+} from "../constants";
+import { analytics } from "../services/analytics";
+import type {
+  DiscoverySurface,
+  FeatureDiscoveryState,
+  FeatureSuggestion,
+} from "../types/discovery";
+import { isFeatureDiscoveryState } from "../utils/discovery-typeguards";
+import { deriveFeatureUsage } from "../utils/feature-usage";
+import { useLocalDb } from "../utils/localstorage";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
+import { isShareNudgePending } from "../utils/share-nudge-eligibility";
+import {
+  SUGGESTION_CATALOG,
+  TOTAL_SUGGESTIONS,
+} from "../utils/suggestion-catalog";
+import { useAllTimeStats } from "./use-all-time-stats";
+import { useSessionHistory } from "./use-session-history";
+
+const DEFAULT_DISCOVERY_STATE: FeatureDiscoveryState = {
+  dismissed: [],
+  snoozedUntil: 0,
+};
+
+const isBoolean = (value: unknown): value is boolean =>
+  typeof value === "boolean";
+
+export type UseFeatureDiscoveryResult = {
+  /** Highest-priority eligible suggestion, or null when nothing should show. */
+  nextSuggestion: FeatureSuggestion | null;
+  /** Retire-on-accept: permanently drops the suggestion and tracks acceptance. */
+  accept: (id: string, surface: DiscoverySurface) => void;
+  /** Drops the suggestion and snoozes the whole surface for a few sessions. */
+  dismiss: (id: string, surface: DiscoverySurface) => void;
+  /** How many catalog items the user has tried (monotonic). */
+  exploredCount: number;
+  /** Fixed full-catalog size — the progress denominator. */
+  totalCount: number;
+};
+
+export const useFeatureDiscovery = (): UseFeatureDiscoveryResult => {
+  const { history } = useSessionHistory();
+  const { getGlobalStats } = useAllTimeStats();
+  const { totalSessions } = getGlobalStats();
+
+  const [state, setState] = useLocalDb<FeatureDiscoveryState>(
+    FEATURE_DISCOVERY_LSK,
+    DEFAULT_DISCOVERY_STATE,
+    isFeatureDiscoveryState,
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
+  );
+
+  // Read-only mirror of the share-nudge flag so the discovery card reappears
+  // reactively once the share nudge is dismissed. This instance never writes.
+  const [shareDismissed] = useLocalDb<boolean>(
+    SHARE_NUDGE_DISMISSED_LSK,
+    false,
+    isBoolean,
+    { onCorrupt: reportLocalDbCorruption }
+  );
+
+  const usage = useMemo(() => deriveFeatureUsage(history), [history]);
+
+  const exploredCount = useMemo(
+    () =>
+      SUGGESTION_CATALOG.filter((suggestion) => suggestion.isUsed(usage))
+        .length,
+    [usage]
+  );
+
+  const nextSuggestion = useMemo<FeatureSuggestion | null>(() => {
+    // One card at a time: yield while the share nudge is still pending.
+    if (isShareNudgePending(shareDismissed, totalSessions)) {
+      return null;
+    }
+    if (totalSessions < DISCOVERY_MIN_SESSIONS) {
+      return null;
+    }
+    if (totalSessions < state.snoozedUntil) {
+      return null;
+    }
+
+    const candidates = SUGGESTION_CATALOG.filter(
+      (suggestion) =>
+        suggestion.isApplicable(usage) &&
+        !suggestion.isUsed(usage) &&
+        !state.dismissed.includes(suggestion.id)
+    );
+
+    // Untried whole modes → untried variants of the most-used mode → others.
+    const mostUsedBoost = (suggestion: FeatureSuggestion): number =>
+      suggestion.mode === usage.mostUsedMode ? 0 : 1;
+    const sorted = [...candidates].sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority;
+      }
+      const boostDelta = mostUsedBoost(a) - mostUsedBoost(b);
+      if (boostDelta !== 0) {
+        return boostDelta;
+      }
+      return SUGGESTION_CATALOG.indexOf(a) - SUGGESTION_CATALOG.indexOf(b);
+    });
+    return sorted[0] ?? null;
+  }, [shareDismissed, totalSessions, state, usage]);
+
+  const accept = useCallback(
+    (id: string, surface: DiscoverySurface): void => {
+      setState(
+        (prev) => ({
+          ...prev,
+          dismissed: prev.dismissed.includes(id)
+            ? prev.dismissed
+            : [...prev.dismissed, id],
+        }),
+        {
+          onSuccess: () =>
+            analytics.trackFeatureSuggestionAccepted(id, surface),
+        }
+      );
+    },
+    [setState]
+  );
+
+  const dismiss = useCallback(
+    (id: string, surface: DiscoverySurface): void => {
+      setState(
+        (prev) => ({
+          dismissed: prev.dismissed.includes(id)
+            ? prev.dismissed
+            : [...prev.dismissed, id],
+          snoozedUntil: totalSessions + DISCOVERY_SNOOZE_SESSIONS,
+        }),
+        {
+          onSuccess: () =>
+            analytics.trackFeatureSuggestionDismissed(id, surface),
+        }
+      );
+    },
+    [setState, totalSessions]
+  );
+
+  return {
+    nextSuggestion,
+    accept,
+    dismiss,
+    exploredCount,
+    totalCount: TOTAL_SUGGESTIONS,
+  };
+};

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Neue Herausforderung",
+    "cta": "Ausprobieren",
+    "progress": "{{explored}} von {{total}} erkundet",
+    "dismiss": "Schließen",
+    "spotCheckTitle": "Prüfe ein ausgebreitetes Deck und finde die falsch platzierte Karte.",
+    "distanceTitle": "Übe die Distanzen zwischen Karten — die Mathematik hinter den Quartets.",
+    "acaanTitle": "Any Card At Any Number — beherrsche die Berechnung aus dem Stand.",
+    "flashcardNumberOnlyTitle": "Nenne Karten allein aus der Position — ohne Kartenbild.",
+    "flashcardNeighborTitle": "Nenne die Karte direkt vor oder nach der gezeigten.",
+    "spotCheckSwappedTitle": "Zwei Karten tauschen den Platz — erkennst du den Tausch?",
+    "spotCheckMovedTitle": "Eine Karte rutscht an eine neue Stelle — finde sie.",
+    "distanceApplyTitle": "Eine Karte und eine Distanz — nenne die Zielkarte.",
+    "distanceSignedTitle": "Übe vorzeichenbehaftete Distanzen, vorwärts und rückwärts."
+  },
   "common": {
     "comingSoon": "Demnächst verfügbar...",
     "learnMore": "Mehr erfahren",
@@ -512,6 +527,7 @@
       "free": "Für immer kostenlos — kein Abo erforderlich."
     },
     "tips": {
+      "discovery": "Nach ein paar Sitzungen zeigt die Startseite eine „Neue Herausforderung“-Karte — einen Modus oder eine Variante, die du noch nicht ausprobiert hast, basierend auf deinem eigenen Trainingsverlauf.",
       "title": "Tipps",
       "dataLocal": "Alle deine Daten bleiben in deinem Browser — nichts wird an einen Server gesendet.",
       "darkMode": "Wechsle zwischen dunklem und hellem Modus mit dem Symbol in der Kopfzeile.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "New challenge",
+    "cta": "Try it",
+    "progress": "{{explored}} of {{total}} explored",
+    "dismiss": "Dismiss",
+    "spotCheckTitle": "Inspect a spread and catch the card that's out of place.",
+    "distanceTitle": "Drill the offsets between cards — the math behind Quartets.",
+    "acaanTitle": "Any Card At Any Number — drill the calculation cold.",
+    "flashcardNumberOnlyTitle": "Recall cards from position alone — no face to lean on.",
+    "flashcardNeighborTitle": "Name the card just before or after the one shown.",
+    "spotCheckSwappedTitle": "Two cards trade places — can you catch the swap?",
+    "spotCheckMovedTitle": "One card slips to a new spot — find it.",
+    "distanceApplyTitle": "Given a card and an offset, name where you land.",
+    "distanceSignedTitle": "Train shortest-path offsets, forward and back."
+  },
   "common": {
     "comingSoon": "Coming soon...",
     "learnMore": "Learn more",
@@ -555,6 +570,7 @@
     },
     "tips": {
       "title": "Tips",
+      "discovery": "After a few sessions, the homepage shows a \"New challenge\" card — a mode or variant you haven't tried yet, drawn from your own training history.",
       "dataLocal": "All your data stays in your browser — nothing is sent to a server.",
       "darkMode": "Toggle between dark and light mode using the icon in the header.",
       "gearIcon": "In training modes, tap the gear icon to adjust mode and timer settings, or the target icon to start a session.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Nuevo reto",
+    "cta": "Probar",
+    "progress": "{{explored}} de {{total}} explorados",
+    "dismiss": "Cerrar",
+    "spotCheckTitle": "Inspecciona una baraja extendida y detecta la carta fuera de lugar.",
+    "distanceTitle": "Practica las diferencias entre cartas — las matemáticas detrás de los Quartets.",
+    "acaanTitle": "Any Card At Any Number — domina el cálculo en frío.",
+    "flashcardNumberOnlyTitle": "Recuerda las cartas solo por su posición — sin ver la cara.",
+    "flashcardNeighborTitle": "Nombra la carta justo antes o después de la mostrada.",
+    "spotCheckSwappedTitle": "Dos cartas intercambian posiciones — ¿detectas el cambio?",
+    "spotCheckMovedTitle": "Una carta se desliza a un nuevo lugar — encuéntrala.",
+    "distanceApplyTitle": "Una carta y una diferencia: nombra la carta de destino.",
+    "distanceSignedTitle": "Practica las diferencias con signo, hacia adelante y atrás."
+  },
   "common": {
     "comingSoon": "Próximamente...",
     "learnMore": "Más información",
@@ -512,6 +527,7 @@
       "free": "Gratis para siempre — sin suscripción."
     },
     "tips": {
+      "discovery": "Tras unas sesiones, la página de inicio muestra una tarjeta «Nuevo reto» — un modo o variante que aún no has probado, a partir de tu propio historial de entrenamiento.",
       "title": "Consejos",
       "dataLocal": "Todos tus datos permanecen en tu navegador — nada se envía a un servidor.",
       "darkMode": "Alterna entre modo oscuro y claro usando el icono en la cabecera.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Nouveau défi",
+    "cta": "Essayer",
+    "progress": "{{explored}} sur {{total}} explorés",
+    "dismiss": "Fermer",
+    "spotCheckTitle": "Inspectez un jeu étalé et repérez la carte mal placée.",
+    "distanceTitle": "Travaillez les écarts entre les cartes — les maths derrière les Quartets.",
+    "acaanTitle": "Any Card At Any Number — maîtrisez le calcul à froid.",
+    "flashcardNumberOnlyTitle": "Retrouvez les cartes à partir de la seule position — sans la face.",
+    "flashcardNeighborTitle": "Nommez la carte juste avant ou après celle affichée.",
+    "spotCheckSwappedTitle": "Deux cartes échangent leur place — saurez-vous repérer l'échange ?",
+    "spotCheckMovedTitle": "Une carte glisse à un nouvel emplacement — trouvez-la.",
+    "distanceApplyTitle": "Une carte et un écart : nommez la carte d'arrivée.",
+    "distanceSignedTitle": "Travaillez les écarts signés, en avant comme en arrière."
+  },
   "common": {
     "comingSoon": "Bientôt disponible...",
     "learnMore": "En savoir plus",
@@ -512,6 +527,7 @@
       "free": "Gratuit pour toujours — aucun abonnement requis."
     },
     "tips": {
+      "discovery": "Après quelques sessions, la page d'accueil affiche une carte « Nouveau défi » — un mode ou une variante que vous n'avez pas encore essayé, d'après votre propre historique d'entraînement.",
       "title": "Conseils",
       "dataLocal": "Toutes vos données restent dans votre navigateur — rien n'est envoyé à un serveur.",
       "darkMode": "Basculez entre le mode sombre et le mode clair avec l'icône dans l'en-tête.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Nuova sfida",
+    "cta": "Prova",
+    "progress": "{{explored}} di {{total}} esplorate",
+    "dismiss": "Chiudi",
+    "spotCheckTitle": "Ispeziona un mazzo steso e individua la carta fuori posto.",
+    "distanceTitle": "Allena gli scarti tra le carte — la matematica dietro i Quartets.",
+    "acaanTitle": "Any Card At Any Number — padroneggia il calcolo a freddo.",
+    "flashcardNumberOnlyTitle": "Ricorda le carte dalla sola posizione — senza vedere la faccia.",
+    "flashcardNeighborTitle": "Nomina la carta appena prima o dopo quella mostrata.",
+    "spotCheckSwappedTitle": "Due carte si scambiano di posto — sai cogliere lo scambio?",
+    "spotCheckMovedTitle": "Una carta scivola in un nuovo punto — trovala.",
+    "distanceApplyTitle": "Una carta e uno scarto: nomina la carta d'arrivo.",
+    "distanceSignedTitle": "Allena gli scarti con segno, in avanti e indietro."
+  },
   "common": {
     "comingSoon": "Prossimamente...",
     "learnMore": "Scopri di più",
@@ -512,6 +527,7 @@
       "free": "Gratuito per sempre — nessun abbonamento richiesto."
     },
     "tips": {
+      "discovery": "Dopo qualche sessione, la pagina principale mostra una scheda «Nuova sfida» — una modalità o variante che non hai ancora provata, in base alla tua cronologia di allenamento.",
       "title": "Consigli",
       "dataLocal": "Tutti i tuoi dati restano nel tuo browser — nulla viene inviato a un server.",
       "darkMode": "Alterna tra modalità scura e chiara usando l'icona nella barra in alto.",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Nieuwe uitdaging",
+    "cta": "Proberen",
+    "progress": "{{explored}} van {{total}} verkend",
+    "dismiss": "Sluiten",
+    "spotCheckTitle": "Inspecteer een uitgespreid spel en spot de verkeerd geplaatste kaart.",
+    "distanceTitle": "Oefen de verschillen tussen kaarten — de wiskunde achter de Quartets.",
+    "acaanTitle": "Any Card At Any Number — beheers de berekening op commando.",
+    "flashcardNumberOnlyTitle": "Noem kaarten alleen op positie — zonder de voorkant.",
+    "flashcardNeighborTitle": "Noem de kaart vlak voor of na de getoonde.",
+    "spotCheckSwappedTitle": "Twee kaarten wisselen van plek — zie jij de wissel?",
+    "spotCheckMovedTitle": "Eén kaart schuift naar een nieuwe plek — vind hem.",
+    "distanceApplyTitle": "Een kaart en een verschil: noem de doelkaart.",
+    "distanceSignedTitle": "Oefen de kortste verschillen met teken, voor- en achterwaarts."
+  },
   "common": {
     "comingSoon": "Binnenkort beschikbaar...",
     "learnMore": "Meer informatie",
@@ -512,6 +527,7 @@
       "free": "Voor altijd gratis — geen abonnement nodig."
     },
     "tips": {
+      "discovery": "Na een paar sessies toont de startpagina een \"Nieuwe uitdaging\"-kaart — een modus of variant die je nog niet hebt geprobeerd, op basis van je eigen trainingsgeschiedenis.",
       "title": "Tips",
       "dataLocal": "Al je gegevens blijven in je browser — er wordt niets naar een server gestuurd.",
       "darkMode": "Wissel tussen donkere en lichte modus met het pictogram in de header.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1,4 +1,19 @@
 {
+  "discovery": {
+    "eyebrow": "Novo desafio",
+    "cta": "Experimentar",
+    "progress": "{{explored}} de {{total}} explorados",
+    "dismiss": "Fechar",
+    "spotCheckTitle": "Inspecione um baralho estendido e detete a carta fora do lugar.",
+    "distanceTitle": "Treine os deslocamentos entre cartas — a matemática por trás das Quartets.",
+    "acaanTitle": "Any Card At Any Number — treine o cálculo a frio.",
+    "flashcardNumberOnlyTitle": "Recorde as cartas apenas pela posição — sem ver a face.",
+    "flashcardNeighborTitle": "Diga a carta logo antes ou depois da mostrada.",
+    "spotCheckSwappedTitle": "Duas cartas trocam de lugar — consegue detetar a troca?",
+    "spotCheckMovedTitle": "Uma carta desliza para um novo lugar — encontre-a.",
+    "distanceApplyTitle": "Uma carta e um deslocamento — diga a carta de chegada.",
+    "distanceSignedTitle": "Treine os deslocamentos com sinal, para a frente e para trás."
+  },
   "common": {
     "comingSoon": "Em breve...",
     "learnMore": "Saber mais",
@@ -512,6 +527,7 @@
       "free": "Gratuito para sempre — sem subscrição."
     },
     "tips": {
+      "discovery": "Após algumas sessões, a página inicial mostra um cartão «Novo desafio» — um modo ou variante que ainda não experimentou, a partir do seu próprio histórico de treino.",
       "title": "Dicas",
       "dataLocal": "Todos os seus dados ficam no seu navegador — nada é enviado para um servidor.",
       "darkMode": "Alterne entre modo escuro e claro usando o ícone no cabeçalho.",

--- a/src/pages/guide/tips-section.tsx
+++ b/src/pages/guide/tips-section.tsx
@@ -19,6 +19,7 @@ export const TipsSection = () => {
         <List.Item>{t("guide.tips.darkMode")}</List.Item>
         <List.Item>{t("guide.tips.gearIcon")}</List.Item>
         <List.Item>{t("guide.tips.switchStacks")}</List.Item>
+        <List.Item>{t("guide.tips.discovery")}</List.Item>
         <List.Item>{t("guide.tips.pwa")}</List.Item>
         <List.Item>{t("guide.tips.language")}</List.Item>
         <List.Item>{t("guide.tips.share")}</List.Item>

--- a/src/pages/home/home-with-stack.tsx
+++ b/src/pages/home/home-with-stack.tsx
@@ -10,6 +10,7 @@ import {
 import { useMemo } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router";
+import { NextChallengeCard } from "../../components/next-challenge-card";
 import { ShareNudge } from "../../components/share-nudge";
 import { StatDisplay } from "../../components/stat-display";
 import { ROUTES } from "../../constants";
@@ -149,6 +150,7 @@ export const HomeWithStack = ({ stackKey, stackName }: HomeWithStackProps) => {
       </div>
 
       <ShareNudge />
+      <NextChallengeCard surface="home" />
     </Stack>
   );
 };

--- a/src/services/analytics.test.ts
+++ b/src/services/analytics.test.ts
@@ -962,6 +962,42 @@ describe("analytics", () => {
     });
   });
 
+  describe("trackFeatureSuggestionShown", () => {
+    it("sends suggestion shown event with id and surface", () => {
+      analytics.trackFeatureSuggestionShown("mode-spotcheck", "home");
+
+      expect(mockEvent).toHaveBeenCalledWith({
+        category: "Feature Discovery",
+        action: "Suggestion Shown",
+        label: "mode-spotcheck:home",
+      });
+    });
+  });
+
+  describe("trackFeatureSuggestionAccepted", () => {
+    it("sends suggestion accepted event with id and surface", () => {
+      analytics.trackFeatureSuggestionAccepted("distance-signed", "summary");
+
+      expect(mockEvent).toHaveBeenCalledWith({
+        category: "Feature Discovery",
+        action: "Suggestion Accepted",
+        label: "distance-signed:summary",
+      });
+    });
+  });
+
+  describe("trackFeatureSuggestionDismissed", () => {
+    it("sends suggestion dismissed event with id and surface", () => {
+      analytics.trackFeatureSuggestionDismissed("flashcard-neighbor", "stats");
+
+      expect(mockEvent).toHaveBeenCalledWith({
+        category: "Feature Discovery",
+        action: "Suggestion Dismissed",
+        label: "flashcard-neighbor:stats",
+      });
+    });
+  });
+
   describe("trackError", () => {
     it("sends error event with error name and message", () => {
       const error = new TypeError("Cannot read property 'foo' of undefined");
@@ -1173,6 +1209,24 @@ describe("analytics", () => {
 
     it("does not track share nudge dismissed", () => {
       analytics.trackShareNudgeDismissed();
+
+      expect(mockEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not track feature suggestion shown", () => {
+      analytics.trackFeatureSuggestionShown("mode-spotcheck", "home");
+
+      expect(mockEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not track feature suggestion accepted", () => {
+      analytics.trackFeatureSuggestionAccepted("mode-spotcheck", "home");
+
+      expect(mockEvent).not.toHaveBeenCalled();
+    });
+
+    it("does not track feature suggestion dismissed", () => {
+      analytics.trackFeatureSuggestionDismissed("mode-spotcheck", "home");
 
       expect(mockEvent).not.toHaveBeenCalled();
     });

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -1,5 +1,6 @@
 import { ReactGAImplementation } from "react-ga4";
 import { type Metric, onCLS, onINP, onLCP } from "web-vitals";
+import type { DiscoverySurface } from "../types/discovery";
 import type { DistanceConvention, DistanceMode } from "../types/distance";
 import type { FlashcardMode, NeighborDirection } from "../types/flashcard";
 import type { SessionConfig, TrainingMode } from "../types/session";
@@ -358,6 +359,39 @@ export const analytics = {
     ReactGA.event({
       category: "Share",
       action: "Nudge Dismissed",
+    });
+  },
+
+  trackFeatureSuggestionShown: (id: string, surface: DiscoverySurface) => {
+    if (!isEnabled()) {
+      return;
+    }
+    ReactGA.event({
+      category: "Feature Discovery",
+      action: "Suggestion Shown",
+      label: `${id}:${surface}`,
+    });
+  },
+
+  trackFeatureSuggestionAccepted: (id: string, surface: DiscoverySurface) => {
+    if (!isEnabled()) {
+      return;
+    }
+    ReactGA.event({
+      category: "Feature Discovery",
+      action: "Suggestion Accepted",
+      label: `${id}:${surface}`,
+    });
+  },
+
+  trackFeatureSuggestionDismissed: (id: string, surface: DiscoverySurface) => {
+    if (!isEnabled()) {
+      return;
+    }
+    ReactGA.event({
+      category: "Feature Discovery",
+      action: "Suggestion Dismissed",
+      label: `${id}:${surface}`,
     });
   },
 

--- a/src/types/discovery.ts
+++ b/src/types/discovery.ts
@@ -1,0 +1,51 @@
+import type { Icon } from "@tabler/icons-react";
+import type { ParseKeys } from "i18next";
+import type { RoutePath } from "../constants";
+import type { DistanceConvention, DistanceMode } from "./distance";
+import type { FlashcardMode } from "./flashcard";
+import type { TrainingMode } from "./session";
+import type { SpotCheckMode } from "./spot-check";
+
+/** Where a discovery suggestion is surfaced. */
+export type DiscoverySurface = "home" | "summary" | "stats";
+
+/**
+ * Which training modes and sub-variants a user has already tried, derived from
+ * their session history. One boolean per mode and per sub-variant, plus the
+ * most-used mode for personalizing suggestion priority.
+ */
+export type UsageFlags = {
+  modes: Record<TrainingMode, boolean>;
+  flashcardModes: Record<FlashcardMode, boolean>;
+  spotCheckModes: Record<SpotCheckMode, boolean>;
+  distanceModes: Record<DistanceMode, boolean>;
+  distanceConventions: Record<DistanceConvention, boolean>;
+  /** Most-used mode by completed-session count, or null when there is no history. */
+  mostUsedMode: TrainingMode | null;
+};
+
+/**
+ * A single discoverable feature — either a whole training mode or a sub-variant
+ * of one. `isUsed`/`isApplicable` are pure predicates over {@link UsageFlags}.
+ */
+export type FeatureSuggestion = {
+  id: string;
+  mode: TrainingMode;
+  /** True once the user has tried this exact mode/variant — drops the suggestion. */
+  isUsed: (usage: UsageFlags) => boolean;
+  /** Whole modes are always applicable; variants require the parent mode tried. */
+  isApplicable: (usage: UsageFlags) => boolean;
+  /** Lower sorts first. Whole modes outrank variants. */
+  priority: number;
+  route: RoutePath;
+  /** Preselect param the page will honor from #696; until then it lands in the default mode. */
+  deepLink?: { param: "try" | "timed"; value: string };
+  icon: Icon;
+  i18n: { titleKey: ParseKeys; ctaKey?: ParseKeys };
+};
+
+/** Persisted discovery state: retired/dismissed ids + a session-count snooze gate. */
+export type FeatureDiscoveryState = {
+  dismissed: string[];
+  snoozedUntil: number;
+};

--- a/src/utils/discovery-typeguards.test.ts
+++ b/src/utils/discovery-typeguards.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { isFeatureDiscoveryState } from "./discovery-typeguards";
+
+describe("isFeatureDiscoveryState", () => {
+  it("accepts a well-formed state", () => {
+    expect(
+      isFeatureDiscoveryState({
+        dismissed: ["mode-spotcheck"],
+        snoozedUntil: 4,
+      })
+    ).toBe(true);
+  });
+
+  it("accepts an empty dismissed list and zero snooze", () => {
+    expect(isFeatureDiscoveryState({ dismissed: [], snoozedUntil: 0 })).toBe(
+      true
+    );
+  });
+
+  it("rejects null and non-objects", () => {
+    expect(isFeatureDiscoveryState(null)).toBe(false);
+    expect(isFeatureDiscoveryState("nope")).toBe(false);
+    expect(isFeatureDiscoveryState(42)).toBe(false);
+  });
+
+  it("rejects objects missing required fields", () => {
+    expect(isFeatureDiscoveryState({ dismissed: [] })).toBe(false);
+    expect(isFeatureDiscoveryState({ snoozedUntil: 0 })).toBe(false);
+  });
+
+  it("rejects a non-array dismissed", () => {
+    expect(
+      isFeatureDiscoveryState({ dismissed: "mode-spotcheck", snoozedUntil: 0 })
+    ).toBe(false);
+  });
+
+  it("rejects a dismissed list containing a non-string", () => {
+    expect(
+      isFeatureDiscoveryState({ dismissed: ["ok", 3], snoozedUntil: 0 })
+    ).toBe(false);
+  });
+
+  it("rejects a non-number snoozedUntil", () => {
+    expect(isFeatureDiscoveryState({ dismissed: [], snoozedUntil: "5" })).toBe(
+      false
+    );
+  });
+
+  it("rejects a non-finite snoozedUntil", () => {
+    expect(
+      isFeatureDiscoveryState({ dismissed: [], snoozedUntil: Number.NaN })
+    ).toBe(false);
+  });
+});

--- a/src/utils/discovery-typeguards.ts
+++ b/src/utils/discovery-typeguards.ts
@@ -1,0 +1,19 @@
+import type { FeatureDiscoveryState } from "../types/discovery";
+
+/** Validates a localStorage-parsed value as a {@link FeatureDiscoveryState}. */
+export const isFeatureDiscoveryState = (
+  value: unknown
+): value is FeatureDiscoveryState => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  if (!("dismissed" in value && "snoozedUntil" in value)) {
+    return false;
+  }
+  return (
+    Array.isArray(value.dismissed) &&
+    value.dismissed.every((entry: unknown) => typeof entry === "string") &&
+    typeof value.snoozedUntil === "number" &&
+    Number.isFinite(value.snoozedUntil)
+  );
+};

--- a/src/utils/feature-usage.test.ts
+++ b/src/utils/feature-usage.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import type { DistanceConvention, DistanceMode } from "../types/distance";
+import type { FlashcardMode } from "../types/flashcard";
+import type { SessionRecord } from "../types/session";
+import type { SpotCheckMode } from "../types/spot-check";
+import { deriveFeatureUsage } from "./feature-usage";
+
+/** Shared base fields for a persisted record, minus the mode discriminator. */
+type BaseFields = Omit<Extract<SessionRecord, { mode: "acaan" }>, "mode">;
+
+const base = (id: string): BaseFields => ({
+  id,
+  stackKey: "mnemonica",
+  config: { type: "open" },
+  startedAt: "2026-01-01T00:00:00.000Z",
+  endedAt: "2026-01-01T00:05:00.000Z",
+  durationSeconds: 300,
+  successes: 8,
+  fails: 2,
+  questionsCompleted: 10,
+  accuracy: 0.8,
+  bestStreak: 5,
+});
+
+const flashcard = (
+  id: string,
+  flashcardMode?: FlashcardMode
+): SessionRecord => ({
+  ...base(id),
+  mode: "flashcard",
+  flashcardMode,
+});
+
+const spotcheck = (
+  id: string,
+  spotCheckMode?: SpotCheckMode
+): SessionRecord => ({
+  ...base(id),
+  mode: "spotcheck",
+  spotCheckMode,
+});
+
+const distance = (
+  id: string,
+  distanceMode?: DistanceMode,
+  distanceConvention?: DistanceConvention
+): SessionRecord => ({
+  ...base(id),
+  mode: "distance",
+  distanceMode,
+  distanceConvention,
+});
+
+const acaan = (id: string): SessionRecord => ({ ...base(id), mode: "acaan" });
+
+describe("deriveFeatureUsage", () => {
+  it("returns all-false flags and null mostUsedMode for empty history", () => {
+    const usage = deriveFeatureUsage([]);
+
+    expect(usage.modes).toEqual({
+      flashcard: false,
+      acaan: false,
+      spotcheck: false,
+      distance: false,
+    });
+    expect(Object.values(usage.flashcardModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(Object.values(usage.spotCheckModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(Object.values(usage.distanceModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(
+      Object.values(usage.distanceConventions).every((v) => v === false)
+    ).toBe(true);
+    expect(usage.mostUsedMode).toBeNull();
+  });
+
+  it("flags the tried mode and sub-variant for a single flashcard session", () => {
+    const usage = deriveFeatureUsage([flashcard("1", "numberonly")]);
+
+    expect(usage.modes.flashcard).toBe(true);
+    expect(usage.modes.spotcheck).toBe(false);
+    expect(usage.flashcardModes.numberonly).toBe(true);
+    expect(usage.flashcardModes.cardonly).toBe(false);
+    expect(usage.mostUsedMode).toBe("flashcard");
+  });
+
+  it("flags every mode and sub-variant when all are present", () => {
+    const usage = deriveFeatureUsage([
+      flashcard("1", "cardonly"),
+      flashcard("2", "bothmodes"),
+      flashcard("3", "numberonly"),
+      flashcard("4", "neighbor"),
+      spotcheck("5", "missing"),
+      spotcheck("6", "swapped"),
+      spotcheck("7", "moved"),
+      distance("8", "compute", "cyclic"),
+      distance("9", "apply", "signed"),
+      distance("10", "both", "cyclic"),
+      acaan("11"),
+    ]);
+
+    expect(usage.modes).toEqual({
+      flashcard: true,
+      acaan: true,
+      spotcheck: true,
+      distance: true,
+    });
+    expect(usage.flashcardModes).toEqual({
+      cardonly: true,
+      bothmodes: true,
+      numberonly: true,
+      neighbor: true,
+    });
+    expect(usage.spotCheckModes).toEqual({
+      missing: true,
+      swapped: true,
+      moved: true,
+    });
+    expect(usage.distanceModes).toEqual({
+      compute: true,
+      apply: true,
+      both: true,
+    });
+    expect(usage.distanceConventions).toEqual({ cyclic: true, signed: true });
+  });
+
+  it("leaves sub-variant flags false for records missing the optional field", () => {
+    const usage = deriveFeatureUsage([
+      flashcard("1"),
+      spotcheck("2"),
+      distance("3"),
+    ]);
+
+    expect(usage.modes.flashcard).toBe(true);
+    expect(usage.modes.spotcheck).toBe(true);
+    expect(usage.modes.distance).toBe(true);
+    expect(Object.values(usage.flashcardModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(Object.values(usage.spotCheckModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(Object.values(usage.distanceModes).every((v) => v === false)).toBe(
+      true
+    );
+    expect(
+      Object.values(usage.distanceConventions).every((v) => v === false)
+    ).toBe(true);
+  });
+
+  it("picks the most-used mode by session count", () => {
+    const usage = deriveFeatureUsage([
+      flashcard("1"),
+      distance("2"),
+      distance("3"),
+      distance("4"),
+    ]);
+
+    expect(usage.mostUsedMode).toBe("distance");
+  });
+
+  it("breaks most-used-mode ties by TRAINING_MODES order", () => {
+    // Two flashcard and two spotcheck sessions tie; flashcard is declared first.
+    const usage = deriveFeatureUsage([
+      spotcheck("1"),
+      spotcheck("2"),
+      flashcard("3"),
+      flashcard("4"),
+    ]);
+
+    expect(usage.mostUsedMode).toBe("flashcard");
+  });
+});

--- a/src/utils/feature-usage.ts
+++ b/src/utils/feature-usage.ts
@@ -1,0 +1,101 @@
+import type { UsageFlags } from "../types/discovery";
+import type { DistanceConvention, DistanceMode } from "../types/distance";
+import type { FlashcardMode } from "../types/flashcard";
+import {
+  type SessionRecord,
+  TRAINING_MODES,
+  type TrainingMode,
+} from "../types/session";
+import type { SpotCheckMode } from "../types/spot-check";
+
+/**
+ * Derive which training modes and sub-variants a user has tried from their
+ * completed-session history. Pure; scans the history once. Optional per-mode
+ * fields are guarded against `undefined` on old records (pre-#694 and any
+ * record persisted before a sub-variant existed).
+ */
+export const deriveFeatureUsage = (history: SessionRecord[]): UsageFlags => {
+  // Explicit `Record<…>` annotations (not `satisfies`) so the fields widen to
+  // `boolean`/`number` for later mutation while still requiring every union
+  // member as a key — a new mode/variant is a compile error here.
+  const modes: Record<TrainingMode, boolean> = {
+    flashcard: false,
+    acaan: false,
+    spotcheck: false,
+    distance: false,
+  };
+  const flashcardModes: Record<FlashcardMode, boolean> = {
+    cardonly: false,
+    bothmodes: false,
+    numberonly: false,
+    neighbor: false,
+  };
+  const spotCheckModes: Record<SpotCheckMode, boolean> = {
+    missing: false,
+    swapped: false,
+    moved: false,
+  };
+  const distanceModes: Record<DistanceMode, boolean> = {
+    compute: false,
+    apply: false,
+    both: false,
+  };
+  const distanceConventions: Record<DistanceConvention, boolean> = {
+    cyclic: false,
+    signed: false,
+  };
+  const counts: Record<TrainingMode, number> = {
+    flashcard: 0,
+    acaan: 0,
+    spotcheck: 0,
+    distance: 0,
+  };
+
+  for (const record of history) {
+    modes[record.mode] = true;
+    counts[record.mode] += 1;
+    switch (record.mode) {
+      case "flashcard":
+        if (record.flashcardMode) {
+          flashcardModes[record.flashcardMode] = true;
+        }
+        break;
+      case "spotcheck":
+        if (record.spotCheckMode) {
+          spotCheckModes[record.spotCheckMode] = true;
+        }
+        break;
+      case "distance":
+        if (record.distanceMode) {
+          distanceModes[record.distanceMode] = true;
+        }
+        if (record.distanceConvention) {
+          distanceConventions[record.distanceConvention] = true;
+        }
+        break;
+      default:
+        // acaan has no sub-variants.
+        break;
+    }
+  }
+
+  // Most-used mode by session count; iterating TRAINING_MODES with a strict `>`
+  // keeps the earlier-declared mode on ties, so the result is deterministic.
+  let mostUsedMode: TrainingMode | null = null;
+  let maxCount = 0;
+  for (const mode of TRAINING_MODES) {
+    if (counts[mode] > maxCount) {
+      maxCount = counts[mode];
+      mostUsedMode = mode;
+    }
+  }
+
+  return {
+    modes,
+    flashcardModes,
+    spotCheckModes,
+    distanceModes,
+    distanceConventions,
+    mostUsedMode,
+  };
+};

--- a/src/utils/share-nudge-eligibility.test.ts
+++ b/src/utils/share-nudge-eligibility.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { SHARE_NUDGE_MIN_SESSIONS } from "../constants";
+import { isShareNudgePending } from "./share-nudge-eligibility";
+
+describe("isShareNudgePending", () => {
+  it("is false when dismissed, regardless of session count", () => {
+    expect(isShareNudgePending(true, SHARE_NUDGE_MIN_SESSIONS + 10)).toBe(
+      false
+    );
+  });
+
+  it("is false below the session threshold", () => {
+    expect(isShareNudgePending(false, SHARE_NUDGE_MIN_SESSIONS - 1)).toBe(
+      false
+    );
+  });
+
+  it("is true at the threshold when not dismissed", () => {
+    expect(isShareNudgePending(false, SHARE_NUDGE_MIN_SESSIONS)).toBe(true);
+  });
+
+  it("is true above the threshold when not dismissed", () => {
+    expect(isShareNudgePending(false, SHARE_NUDGE_MIN_SESSIONS + 1)).toBe(true);
+  });
+});

--- a/src/utils/share-nudge-eligibility.ts
+++ b/src/utils/share-nudge-eligibility.ts
@@ -1,0 +1,11 @@
+import { SHARE_NUDGE_MIN_SESSIONS } from "../constants";
+
+/**
+ * Whether the share nudge would currently show. Shared by `ShareNudge` and the
+ * discovery card so only one home card surfaces at a time — the discovery card
+ * yields (renders nothing) while the share nudge is still pending.
+ */
+export const isShareNudgePending = (
+  shareDismissed: boolean,
+  totalSessions: number
+): boolean => !shareDismissed && totalSessions >= SHARE_NUDGE_MIN_SESSIONS;

--- a/src/utils/suggestion-catalog.test.ts
+++ b/src/utils/suggestion-catalog.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { ROUTES } from "../constants";
+import type { UsageFlags } from "../types/discovery";
+import type { TrainingMode } from "../types/session";
+import { SUGGESTION_CATALOG, TOTAL_SUGGESTIONS } from "./suggestion-catalog";
+
+/** A fresh all-false usage object, so each case can flip exactly one flag. */
+const noUsage = (): UsageFlags => ({
+  modes: { flashcard: false, acaan: false, spotcheck: false, distance: false },
+  flashcardModes: {
+    cardonly: false,
+    bothmodes: false,
+    numberonly: false,
+    neighbor: false,
+  },
+  spotCheckModes: { missing: false, swapped: false, moved: false },
+  distanceModes: { compute: false, apply: false, both: false },
+  distanceConventions: { cyclic: false, signed: false },
+  mostUsedMode: null,
+});
+
+const allFalse: UsageFlags = noUsage();
+
+const allTrue: UsageFlags = {
+  modes: { flashcard: true, acaan: true, spotcheck: true, distance: true },
+  flashcardModes: {
+    cardonly: true,
+    bothmodes: true,
+    numberonly: true,
+    neighbor: true,
+  },
+  spotCheckModes: { missing: true, swapped: true, moved: true },
+  distanceModes: { compute: true, apply: true, both: true },
+  distanceConventions: { cyclic: true, signed: true },
+  mostUsedMode: "flashcard",
+};
+
+/**
+ * One usage object per suggestion, each setting only the single flag that
+ * should mark THAT suggestion as used. Drives the discrimination test that
+ * catches a predicate wired to the wrong flag.
+ */
+const singleUsedCases: { id: string; usage: UsageFlags }[] = [
+  {
+    id: "mode-spotcheck",
+    usage: { ...noUsage(), modes: { ...noUsage().modes, spotcheck: true } },
+  },
+  {
+    id: "mode-distance",
+    usage: { ...noUsage(), modes: { ...noUsage().modes, distance: true } },
+  },
+  {
+    id: "mode-acaan",
+    usage: { ...noUsage(), modes: { ...noUsage().modes, acaan: true } },
+  },
+  {
+    id: "flashcard-numberonly",
+    usage: {
+      ...noUsage(),
+      flashcardModes: { ...noUsage().flashcardModes, numberonly: true },
+    },
+  },
+  {
+    id: "flashcard-neighbor",
+    usage: {
+      ...noUsage(),
+      flashcardModes: { ...noUsage().flashcardModes, neighbor: true },
+    },
+  },
+  {
+    id: "spotcheck-swapped",
+    usage: {
+      ...noUsage(),
+      spotCheckModes: { ...noUsage().spotCheckModes, swapped: true },
+    },
+  },
+  {
+    id: "spotcheck-moved",
+    usage: {
+      ...noUsage(),
+      spotCheckModes: { ...noUsage().spotCheckModes, moved: true },
+    },
+  },
+  {
+    id: "distance-apply",
+    usage: {
+      ...noUsage(),
+      distanceModes: { ...noUsage().distanceModes, apply: true },
+    },
+  },
+  {
+    id: "distance-signed",
+    usage: {
+      ...noUsage(),
+      distanceConventions: { ...noUsage().distanceConventions, signed: true },
+    },
+  },
+];
+
+describe("SUGGESTION_CATALOG", () => {
+  it("contains 9 suggestions and TOTAL_SUGGESTIONS matches", () => {
+    expect(SUGGESTION_CATALOG).toHaveLength(9);
+    expect(TOTAL_SUGGESTIONS).toBe(9);
+  });
+
+  it("has unique ids", () => {
+    const ids = SUGGESTION_CATALOG.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("routes every suggestion to a known ROUTES path", () => {
+    const knownRoutes = new Set<string>(Object.values(ROUTES));
+    for (const suggestion of SUGGESTION_CATALOG) {
+      expect(knownRoutes.has(suggestion.route)).toBe(true);
+    }
+  });
+
+  it("attaches a deepLink to variants and none to whole modes", () => {
+    for (const suggestion of SUGGESTION_CATALOG) {
+      if (suggestion.priority === 1) {
+        expect(suggestion.deepLink).toBeUndefined();
+      } else {
+        expect(suggestion.deepLink?.param).toBe("try");
+      }
+    }
+  });
+
+  it("marks every suggestion used when all usage flags are set", () => {
+    for (const suggestion of SUGGESTION_CATALOG) {
+      expect(suggestion.isUsed(allTrue)).toBe(true);
+    }
+  });
+
+  it("marks no suggestion used when no usage flags are set", () => {
+    for (const suggestion of SUGGESTION_CATALOG) {
+      expect(suggestion.isUsed(allFalse)).toBe(false);
+    }
+  });
+
+  it("each suggestion's isUsed reads its own flag and no other", () => {
+    // Setting exactly one flag must mark ONLY the matching suggestion used. A
+    // predicate wired to the wrong flag (e.g. numberonly reading neighbor)
+    // would fail here — the all-true/all-false tests above cannot catch it.
+    for (const { id, usage } of singleUsedCases) {
+      for (const suggestion of SUGGESTION_CATALOG) {
+        expect(suggestion.isUsed(usage)).toBe(suggestion.id === id);
+      }
+    }
+  });
+
+  it("treats whole modes as always applicable and variants as parent-gated", () => {
+    for (const suggestion of SUGGESTION_CATALOG) {
+      expect(suggestion.isApplicable(allTrue)).toBe(true);
+      // With no usage, only whole modes (priority 1) are applicable.
+      expect(suggestion.isApplicable(allFalse)).toBe(suggestion.priority === 1);
+    }
+  });
+
+  it("gates each variant on its own parent mode and no other", () => {
+    // One parent mode true at a time: only that mode's variants become
+    // applicable. Catches a variant gated on the wrong parent (e.g. a
+    // spotcheck variant requiring modes.flashcard).
+    const parents: { mode: TrainingMode; variantIds: string[] }[] = [
+      {
+        mode: "flashcard",
+        variantIds: ["flashcard-numberonly", "flashcard-neighbor"],
+      },
+      {
+        mode: "spotcheck",
+        variantIds: ["spotcheck-swapped", "spotcheck-moved"],
+      },
+      { mode: "distance", variantIds: ["distance-apply", "distance-signed"] },
+    ];
+    for (const { mode, variantIds } of parents) {
+      const usage: UsageFlags = {
+        ...noUsage(),
+        modes: { ...noUsage().modes, [mode]: true },
+      };
+      for (const suggestion of SUGGESTION_CATALOG) {
+        if (suggestion.priority === 1) {
+          expect(suggestion.isApplicable(usage)).toBe(true);
+        } else {
+          expect(suggestion.isApplicable(usage)).toBe(
+            variantIds.includes(suggestion.id)
+          );
+        }
+      }
+    }
+  });
+});

--- a/src/utils/suggestion-catalog.ts
+++ b/src/utils/suggestion-catalog.ts
@@ -1,0 +1,118 @@
+import {
+  IconArrowsRightLeft,
+  IconCards,
+  IconEyeSearch,
+  IconTarget,
+} from "@tabler/icons-react";
+import { ROUTES } from "../constants";
+import type { FeatureSuggestion } from "../types/discovery";
+
+/**
+ * Ordered catalog of discoverable features. Whole modes (priority 1) outrank
+ * sub-variants (priority 2); within a priority, earlier entries win ties. The
+ * hook applies a per-user boost so variants of the most-used mode surface first.
+ * Mode + variant items only; "try a timed session" items arrive in #697.
+ */
+export const SUGGESTION_CATALOG: readonly FeatureSuggestion[] = [
+  // Untried whole modes — no deepLink, the card just navigates to the mode.
+  {
+    id: "mode-spotcheck",
+    mode: "spotcheck",
+    isUsed: (u) => u.modes.spotcheck,
+    isApplicable: () => true,
+    priority: 1,
+    route: ROUTES.spotCheck,
+    icon: IconEyeSearch,
+    i18n: { titleKey: "discovery.spotCheckTitle" },
+  },
+  {
+    id: "mode-distance",
+    mode: "distance",
+    isUsed: (u) => u.modes.distance,
+    isApplicable: () => true,
+    priority: 1,
+    route: ROUTES.distance,
+    icon: IconArrowsRightLeft,
+    i18n: { titleKey: "discovery.distanceTitle" },
+  },
+  {
+    id: "mode-acaan",
+    mode: "acaan",
+    isUsed: (u) => u.modes.acaan,
+    isApplicable: () => true,
+    priority: 1,
+    route: ROUTES.acaan,
+    icon: IconTarget,
+    i18n: { titleKey: "discovery.acaanTitle" },
+  },
+  // Untried sub-variants — applicable only once the parent mode has been tried.
+  {
+    id: "flashcard-numberonly",
+    mode: "flashcard",
+    isUsed: (u) => u.flashcardModes.numberonly,
+    isApplicable: (u) => u.modes.flashcard,
+    priority: 2,
+    route: ROUTES.flashcard,
+    deepLink: { param: "try", value: "numberonly" },
+    icon: IconCards,
+    i18n: { titleKey: "discovery.flashcardNumberOnlyTitle" },
+  },
+  {
+    id: "flashcard-neighbor",
+    mode: "flashcard",
+    isUsed: (u) => u.flashcardModes.neighbor,
+    isApplicable: (u) => u.modes.flashcard,
+    priority: 2,
+    route: ROUTES.flashcard,
+    deepLink: { param: "try", value: "neighbor" },
+    icon: IconCards,
+    i18n: { titleKey: "discovery.flashcardNeighborTitle" },
+  },
+  {
+    id: "spotcheck-swapped",
+    mode: "spotcheck",
+    isUsed: (u) => u.spotCheckModes.swapped,
+    isApplicable: (u) => u.modes.spotcheck,
+    priority: 2,
+    route: ROUTES.spotCheck,
+    deepLink: { param: "try", value: "swapped" },
+    icon: IconEyeSearch,
+    i18n: { titleKey: "discovery.spotCheckSwappedTitle" },
+  },
+  {
+    id: "spotcheck-moved",
+    mode: "spotcheck",
+    isUsed: (u) => u.spotCheckModes.moved,
+    isApplicable: (u) => u.modes.spotcheck,
+    priority: 2,
+    route: ROUTES.spotCheck,
+    deepLink: { param: "try", value: "moved" },
+    icon: IconEyeSearch,
+    i18n: { titleKey: "discovery.spotCheckMovedTitle" },
+  },
+  {
+    id: "distance-apply",
+    mode: "distance",
+    isUsed: (u) => u.distanceModes.apply,
+    isApplicable: (u) => u.modes.distance,
+    priority: 2,
+    route: ROUTES.distance,
+    deepLink: { param: "try", value: "apply" },
+    icon: IconArrowsRightLeft,
+    i18n: { titleKey: "discovery.distanceApplyTitle" },
+  },
+  {
+    id: "distance-signed",
+    mode: "distance",
+    isUsed: (u) => u.distanceConventions.signed,
+    isApplicable: (u) => u.modes.distance,
+    priority: 2,
+    route: ROUTES.distance,
+    deepLink: { param: "try", value: "signed" },
+    icon: IconArrowsRightLeft,
+    i18n: { titleKey: "discovery.distanceSignedTitle" },
+  },
+];
+
+/** Fixed full-catalog size — the monotonic denominator for the progress hint. */
+export const TOTAL_SUGGESTIONS = SUGGESTION_CATALOG.length;


### PR DESCRIPTION
## Summary

- Adds a Guided Discovery engine that surfaces one dismissible \"New challenge\" card on the home page after ≥3 completed sessions
- The suggestion is personalised: whole modes (Spot Check, Distance, ACAAN) outrank sub-variants; within sub-variants, modes of the user's most-used training mode are boosted
- Accept retires the suggestion permanently; dismiss retires it and snoozes the whole surface for 2 sessions
- Mutually exclusive with the share nudge — yields silently while the share prompt is still pending
- All state is localStorage-backed via the canonical `useLocalDb` hook with full telemetry wiring

## What's included

**Engine**
- `src/types/discovery.ts` — `UsageFlags`, `FeatureSuggestion`, `FeatureDiscoveryState`, `DiscoverySurface`
- `src/utils/feature-usage.ts` — `deriveFeatureUsage` (pure, scans session history once)
- `src/utils/suggestion-catalog.ts` — 9-item catalog (3 whole modes + 6 sub-variants)
- `src/utils/discovery-typeguards.ts` — localStorage type guard
- `src/utils/share-nudge-eligibility.ts` — `isShareNudgePending` extracted from `ShareNudge` for shared use
- `src/hooks/use-feature-discovery.ts` — hook with accept/dismiss/snooze/exploredCount

**UI**
- `src/components/next-challenge-card.tsx` — card as `<section>` region landmark; `aria-describedby` on the CTA for WCAG 2.4.4 link purpose
- `src/components/share-nudge.tsx` — refactored to use the shared `isShareNudgePending` predicate

**Analytics**
- `src/services/analytics.ts` — `trackFeatureSuggestion{Shown,Accepted,Dismissed}`

**i18n**
- All 7 locales (en, fr, es, de, it, nl, pt) — `discovery.*` block + `guide.tips.discovery`

**Integration**
- `src/constants.ts` — new LSK/constants; exports `RoutePath`
- `src/pages/home/home-with-stack.tsx` — mounts `<NextChallengeCard surface="home" />`
- `src/pages/guide/tips-section.tsx` — discovery tip in the tips list

**Docs & metadata**
- README, CLAUDE.md, index.html JSON-LD, llms.txt, llms-full.txt

## Test plan

- [x] Unit: `deriveFeatureUsage` — empty history, single mode, all modes, optional-field guards, most-used-mode tie-break
- [x] Unit: `SUGGESTION_CATALOG` — discrimination tests asserting each predicate reads its own flag (catches wrong-flag wiring); parent-gate discrimination per variant
- [x] Unit: `isFeatureDiscoveryState` — all rejection branches (null, non-object, missing fields, non-string entry, non-finite snooze)
- [x] Unit: `useFeatureDiscovery` — below-threshold, share-nudge gating, snooze boundary, retired-suggestion suppression, accept/dismiss dedup, write-failure path (analytics not fired)
- [x] Unit: `NextChallengeCard` — null render, region landmark, aria-describedby↔title association, CTA href, accept/dismiss calls, shown tracking
- [x] E2E: dismiss hides card and survives reload (write confirmed persisted)
- [x] E2E: \"Try it\" navigates to the deep-linked route
- [x] E2E: accept retires the suggestion — next suggestion surfaces after full-page navigation

## Notes

- `?try=` deep-links on sub-variant suggestions ship inert; the flashcard/spot-check/distance pages will honour the param in #696
- Timed-session suggestions and post-session/Stats surfaces are tracked in epic #693

Part of #693

Closes #695
