### PR TITLE
fix: deep-linked discovery sessions now record the preselected mode

### DIFF
--- a/e2e/feature-discovery.e2e.ts
+++ b/e2e/feature-discovery.e2e.ts
@@ -8,6 +8,8 @@ const NEIGHBOR_DEEP_LINK = /\/flashcard\/\?try=neighbor$/;
 // The page strips the deep-link param on mount, so the landed URL is bare.
 const STRIPPED_FLASHCARD_URL = /\/flashcard\/$/;
 const STRIPPED_ACAAN_URL = /\/acaan\/$/;
+const STRIPPED_DISTANCE_URL = /\/distance\/$/;
+const SESSION_HISTORY_KEY = "memdeck-app-session-history";
 
 type Seed = {
   sessions: Record<string, unknown>[];
@@ -75,6 +77,65 @@ async function seedAndOpenHome(page: Page, seed: Seed) {
     );
   }, seed);
   await page.goto("/");
+}
+
+// Complete `count` questions on a trainer page (flashcard, distance, …), then
+// navigate away so the auto-started open session is finalized into history.
+// `headingName` is the page's h1 ("Flashcard", "Distance") — asserting it is
+// gone confirms the page unmounted (and thus the save fired).
+//
+// We use the Reveal button, not a card choice: only a CORRECT choice advances
+// the question (use-{flashcard,distance}-game.ts — a wrong answer keeps the same
+// question with questionAdvanced:false), whereas Reveal always advances
+// (questionAdvanced:true), which is what increments questionsCompleted. The
+// open session persists only past the >=3-question threshold, so callers
+// complete at least 3 — in practice 4, one over the threshold, to absorb the
+// brief window after mount before autoStart's passive effect fires, where an
+// early Reveal click advances the game without being session-recorded. Gating
+// each click on the (page-agnostic) Reveal button's visibility confirms a round
+// is interactive before we advance it.
+//
+// An open session has no Stop button (that's structured-only,
+// training-header.tsx); it finalizes on unmount via useSessionAutoSave's
+// cleanup. We leave via the header brand link (a react-router Link, always
+// visible) to unmount the page and trigger the synchronous save.
+async function completeQuestionsThenLeave(
+  page: Page,
+  count: number,
+  headingName: string
+) {
+  const reveal = page.getByRole("button", { name: "Reveal answer" });
+  for (let i = 0; i < count; i++) {
+    await expect(reveal).toBeVisible();
+    await reveal.click();
+  }
+  await page.getByRole("banner").getByRole("link", { name: "MemDeck" }).click();
+  await expect(
+    page.getByRole("heading", { level: 1, name: headingName })
+  ).toHaveCount(0);
+}
+
+// Read the most-recent persisted SessionRecord. The auto-started open session
+// finalizes on unmount — useSessionAutoSave's cleanup calls tryFinalizeSession
+// synchronously when we navigate away — but poll anyway so the helper tolerates
+// async finalize paths too. History is plain JSON under SESSION_HISTORY_KEY.
+async function latestSessionRecord(page: Page) {
+  await expect
+    .poll(() =>
+      page.evaluate<number, string>((key) => {
+        const raw = localStorage.getItem(key);
+        return raw === null ? 0 : JSON.parse(raw).length;
+      }, SESSION_HISTORY_KEY)
+    )
+    .toBeGreaterThan(0);
+  return page.evaluate<Record<string, unknown> | null, string>((key) => {
+    const raw = localStorage.getItem(key);
+    if (raw === null) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.length > 0 ? parsed[0] : null;
+  }, SESSION_HISTORY_KEY);
 }
 
 test.describe("Feature Discovery — Next Challenge card", () => {
@@ -172,5 +233,106 @@ test.describe("Feature Discovery — Next Challenge card", () => {
       localStorage.getItem("memdeck-app-acaan-trainer-timer")
     );
     expect(persistedTimer).toContain('"enabled":true');
+  });
+
+  test("a ?try= deep-linked session records the preselected mode, not the prior default (#704)", async ({
+    page,
+  }) => {
+    // Seed a DIFFERENT prior mode ("cardonly") so the assertion is red before
+    // the fix: pre-fix the auto-started open session captures the prior
+    // "cardonly"; post-fix it captures the deep-linked "numberonly". Never seed
+    // the deep-linked value itself, or the test passes without testing anything.
+    await page.addInitScript(() => {
+      localStorage.setItem("memdeck-app-stack", JSON.stringify("mnemonica"));
+      localStorage.setItem(
+        "memdeck-app-flashcard-option",
+        JSON.stringify("cardonly")
+      );
+    });
+    await page.goto("/flashcard/?try=numberonly");
+    await expect(page).toHaveURL(STRIPPED_FLASHCARD_URL);
+
+    await completeQuestionsThenLeave(page, 4, "Flashcard");
+
+    const record = await latestSessionRecord(page);
+    expect(record).not.toBeNull();
+    expect(record?.mode).toBe("flashcard");
+    expect(record?.flashcardMode).toBe("numberonly");
+  });
+
+  test("a ?timed=1 deep-linked session records timed: true, not the default false (#704)", async ({
+    page,
+  }) => {
+    // The timer defaults to disabled, so the default `timed` is false != the
+    // deep link's true — red before the fix, green after.
+    await page.addInitScript(() => {
+      localStorage.setItem("memdeck-app-stack", JSON.stringify("mnemonica"));
+    });
+    await page.goto("/flashcard/?timed=1");
+    await expect(page).toHaveURL(STRIPPED_FLASHCARD_URL);
+
+    await completeQuestionsThenLeave(page, 4, "Flashcard");
+
+    const record = await latestSessionRecord(page);
+    expect(record).not.toBeNull();
+    expect(record?.timed).toBe(true);
+  });
+
+  test("a ?try= deep-linked distance session records the preselected mode and preserves the other axis (#704)", async ({
+    page,
+  }) => {
+    // Distance is the only two-axis ?try= page (mode + convention). A single
+    // ?try= sets just one axis (disjoint guards), so this deep-links the mode and
+    // asserts the non-deep-linked convention still records its seeded value —
+    // proving both record fields populate, neither silently resets. Seed
+    // DIFFERENT priors for both ("both" mode, "signed" convention) so the mode
+    // assertion is red before the fix: pre-fix the open session captures the
+    // prior "both"; post-fix it captures the deep-linked "apply".
+    await page.addInitScript(() => {
+      localStorage.setItem("memdeck-app-stack", JSON.stringify("mnemonica"));
+      localStorage.setItem(
+        "memdeck-app-distance-option",
+        JSON.stringify("both")
+      );
+      localStorage.setItem(
+        "memdeck-app-distance-convention",
+        JSON.stringify("signed")
+      );
+    });
+    await page.goto("/distance/?try=apply");
+    await expect(page).toHaveURL(STRIPPED_DISTANCE_URL);
+
+    await completeQuestionsThenLeave(page, 4, "Distance");
+
+    const record = await latestSessionRecord(page);
+    expect(record).not.toBeNull();
+    expect(record?.mode).toBe("distance");
+    expect(record?.distanceMode).toBe("apply");
+    expect(record?.distanceConvention).toBe("signed");
+  });
+
+  test("an invalid ?try= value is ignored but auto-start still records the page default (#704)", async ({
+    page,
+  }) => {
+    // A ?try= value matching no enum guard is dropped, but the param is still
+    // stripped — so `pending` settles to false and the auto-start must still
+    // fire, recording the page default. Guards against a "pending stuck true →
+    // session never starts" regression. Seed a known prior so the expected
+    // default is explicit rather than relying on the app's built-in default.
+    await page.addInitScript(() => {
+      localStorage.setItem("memdeck-app-stack", JSON.stringify("mnemonica"));
+      localStorage.setItem(
+        "memdeck-app-flashcard-option",
+        JSON.stringify("cardonly")
+      );
+    });
+    await page.goto("/flashcard/?try=garbage");
+    await expect(page).toHaveURL(STRIPPED_FLASHCARD_URL);
+
+    await completeQuestionsThenLeave(page, 4, "Flashcard");
+
+    const record = await latestSessionRecord(page);
+    expect(record).not.toBeNull();
+    expect(record?.flashcardMode).toBe("cardonly");
   });
 });

--- a/src/hooks/use-suggestion-deep-link.test.tsx
+++ b/src/hooks/use-suggestion-deep-link.test.tsx
@@ -13,8 +13,20 @@ const isBanana = (value: unknown): value is "banana" => value === "banana";
 
 type Options = Parameters<typeof useSuggestionDeepLink>[0];
 
-function DeepLinkProbe({ options, goTo }: { options: Options; goTo?: string }) {
-  useSuggestionDeepLink(options);
+function DeepLinkProbe({
+  options,
+  goTo,
+  onPending,
+}: {
+  options: Options;
+  goTo?: string;
+  onPending?: (pending: boolean) => void;
+}) {
+  const pending = useSuggestionDeepLink(options);
+  // Record every render's value so a test can observe the transient `true`
+  // (present while the param is on the URL) before the layout effect strips it
+  // and the value settles to `false`.
+  onPending?.(pending);
   const { pathname, search } = useLocation();
   const navigate = useNavigate();
   return (
@@ -36,18 +48,33 @@ function DeepLinkProbe({ options, goTo }: { options: Options; goTo?: string }) {
 // co-mounted child is missed because the Router hasn't subscribed yet. Using a
 // real router (not a mocked navigate) lets the tests assert the actual URL
 // strip and exercise the appliedRef latch via a real effect re-run.
-function DeferredMount({ options, goTo }: { options: Options; goTo?: string }) {
+function DeferredMount({
+  options,
+  goTo,
+  onPending,
+}: {
+  options: Options;
+  goTo?: string;
+  onPending?: (pending: boolean) => void;
+}) {
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
-  return mounted ? <DeepLinkProbe goTo={goTo} options={options} /> : null;
+  return mounted ? (
+    <DeepLinkProbe goTo={goTo} onPending={onPending} options={options} />
+  ) : null;
 }
 
-function renderDeepLink(initialEntry: string, options: Options, goTo?: string) {
+function renderDeepLink(
+  initialEntry: string,
+  options: Options,
+  goTo?: string,
+  onPending?: (pending: boolean) => void
+) {
   return render(
     <MemoryRouter initialEntries={[initialEntry]}>
-      <DeferredMount goTo={goTo} options={options} />
+      <DeferredMount goTo={goTo} onPending={onPending} options={options} />
     </MemoryRouter>
   );
 }
@@ -170,5 +197,50 @@ describe("useSuggestionDeepLink", () => {
     );
     expect(apply).toHaveBeenCalledTimes(1);
     expect(apply).not.toHaveBeenCalledWith("banana");
+  });
+
+  // The `pending` return is the contract the mode pages gate their session
+  // auto-start on (`autoStart: !pending`), so the single-shot auto-start fires
+  // only after the deep-link config has settled — capturing the deep-linked
+  // mode/timed in the persisted SessionRecord rather than the page default
+  // (#704).
+  it("reports pending=true while a try param is on the URL, then false once stripped", async () => {
+    const pendings: boolean[] = [];
+    const record = (pending: boolean) => pendings.push(pending);
+    renderDeepLink(
+      "/flashcard/?try=apple",
+      { tryHandlers: [tryHandler(isFruit, vi.fn())] },
+      undefined,
+      record
+    );
+
+    await waitFor(() => expect(currentLocation()).toBe("/flashcard/"));
+    expect(pendings[0]).toBe(true);
+    expect(pendings.at(-1)).toBe(false);
+  });
+
+  it("reports pending=true for a ?timed=1 link, then false once stripped", async () => {
+    const pendings: boolean[] = [];
+    const record = (pending: boolean) => pendings.push(pending);
+    renderDeepLink("/acaan/?timed=1", { onTimed: vi.fn() }, undefined, record);
+
+    await waitFor(() => expect(currentLocation()).toBe("/acaan/"));
+    expect(pendings[0]).toBe(true);
+    expect(pendings.at(-1)).toBe(false);
+  });
+
+  it("reports pending=false throughout when no deep-link params are present", async () => {
+    const pendings: boolean[] = [];
+    const record = (pending: boolean) => pendings.push(pending);
+    renderDeepLink(
+      "/flashcard/",
+      { tryHandlers: [tryHandler(isFruit, vi.fn())] },
+      undefined,
+      record
+    );
+
+    await screen.findByTestId("loc");
+    expect(pendings.length).toBeGreaterThan(0);
+    expect(pendings.every((pending) => pending === false)).toBe(true);
   });
 });

--- a/src/hooks/use-suggestion-deep-link.ts
+++ b/src/hooks/use-suggestion-deep-link.ts
@@ -61,11 +61,16 @@ const TIMED_ENABLED_VALUE = "1";
  * first — the same flicker `use-flashcard-game.ts` avoids with its synchronous
  * in-render reset. The prerender runs the real app in Playwright (not React
  * server rendering), so `useLayoutEffect` raises no SSR warning.
+ *
+ * @returns Whether a deep-link is still pending — `true` while its params are
+ * on the URL, before the layout effect strips them. Callers gate their session
+ * auto-start on this so the first (single-shot) auto-start captures the
+ * deep-linked config, not the page default (#704).
  */
 export const useSuggestionDeepLink = ({
   tryHandlers,
   onTimed,
-}: UseSuggestionDeepLinkOptions): void => {
+}: UseSuggestionDeepLinkOptions): boolean => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -107,4 +112,13 @@ export const useSuggestionDeepLink = ({
     // pathname is safe.
     navigate(pathname, { replace: true });
   }, [searchParams, navigate, pathname]);
+
+  // A deep-link is still "pending" while its params are on the URL — the layout
+  // effect above strips them once applied. Callers gate their session auto-start
+  // on this so the first (single-shot) auto-start captures the deep-linked
+  // config, not the page default. (#704)
+  return (
+    searchParams.get(TRY_PARAM) !== null ||
+    searchParams.get(TIMED_PARAM) !== null
+  );
 };

--- a/src/pages/acaan/acaan.tsx
+++ b/src/pages/acaan/acaan.tsx
@@ -41,7 +41,7 @@ export const Acaan = () => {
   const { timerSettings, setTimerDuration, handleTimerEnabledChange } =
     useAcaanSettings();
 
-  useSuggestionDeepLink({
+  const deepLinkPending = useSuggestionDeepLink({
     onTimed: () => handleTimerEnabledChange(true),
   });
 
@@ -57,7 +57,7 @@ export const Acaan = () => {
   } = useSession({
     mode: "acaan",
     stackKey,
-    autoStart: true,
+    autoStart: !deepLinkPending,
     timed: timerSettings.enabled,
   });
 

--- a/src/pages/distance/distance.tsx
+++ b/src/pages/distance/distance.tsx
@@ -51,7 +51,7 @@ export const Distance = () => {
     handleTimerEnabledChange,
   } = useDistanceSettings();
 
-  useSuggestionDeepLink({
+  const deepLinkPending = useSuggestionDeepLink({
     tryHandlers: [
       tryHandler(isDistanceMode, handleModeChange),
       tryHandler(isDistanceConvention, handleConventionChange),
@@ -75,7 +75,7 @@ export const Distance = () => {
     stackKey,
     distanceMode: mode,
     distanceConvention: convention,
-    autoStart: true,
+    autoStart: !deepLinkPending,
     stackLimits: limits,
     timed: timerSettings.enabled,
   });

--- a/src/pages/flashcard/flashcard.tsx
+++ b/src/pages/flashcard/flashcard.tsx
@@ -44,7 +44,7 @@ export const Flashcard = () => {
     handleTimerEnabledChange,
   } = useFlashcardSettings();
 
-  useSuggestionDeepLink({
+  const deepLinkPending = useSuggestionDeepLink({
     tryHandlers: [tryHandler(isFlashcardMode, handleModeChange)],
     onTimed: () => handleTimerEnabledChange(true),
   });
@@ -64,7 +64,7 @@ export const Flashcard = () => {
     mode: "flashcard",
     stackKey,
     flashcardMode: mode,
-    autoStart: true,
+    autoStart: !deepLinkPending,
     stackLimits: limits,
     timed: timerSettings.enabled,
   });

--- a/src/pages/spot-check/spot-check.tsx
+++ b/src/pages/spot-check/spot-check.tsx
@@ -54,7 +54,7 @@ export const SpotCheck = () => {
     handleTimerEnabledChange,
   } = useSpotCheckSettings();
 
-  useSuggestionDeepLink({
+  const deepLinkPending = useSuggestionDeepLink({
     tryHandlers: [tryHandler(isSpotCheckMode, handleModeChange)],
     onTimed: () => handleTimerEnabledChange(true),
   });
@@ -74,7 +74,7 @@ export const SpotCheck = () => {
     mode: "spotcheck",
     stackKey,
     spotCheckMode: mode,
-    autoStart: true,
+    autoStart: !deepLinkPending,
     stackLimits: limits,
     timed: timerSettings.enabled,
   });


### PR DESCRIPTION
## Summary

When a user tapped a Feature Discovery "Try it" deep link (`/flashcard/?try=numberonly`, `/acaan/?timed=1`, …), the game UI correctly landed in the suggested mode — but the auto-started open session **recorded the default config**, not the deep-linked one. Sessions were mis-attributed in Stats/history.

**Root cause:** `useSession`'s single-shot auto-start (a passive `useEffect` guarded by `initialMountRef`) fired on render #1, before the deep-link's `useLayoutEffect` setter re-rendered with the new config, and then latched — so `startSession` captured the wrong closure.

**Fix:** `useSuggestionDeepLink` now returns a `pending` boolean (true while the deep-link params are on the URL). The four auto-starting pages pass `autoStart: !pending` to `useSession`, deferring the single-shot auto-start to render #2 — after the params are stripped and the setter has applied the deep-linked config. `useSession` itself is unchanged.

## What changed

- `src/hooks/use-suggestion-deep-link.ts` — `void → boolean` return; effect and behavior unchanged
- `src/pages/{flashcard,acaan,distance,spot-check}.tsx` — `autoStart: !deepLinkPending` (one line each)
- `src/hooks/use-suggestion-deep-link.test.tsx` — 3 new unit tests for the `pending` contract
- `e2e/feature-discovery.e2e.ts` — regression tests: flashcard `?try=` and `?timed=1`, distance two-axis (both distanceMode and distanceConvention), invalid-param negative case

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — clean (338 files)
- [x] `pnpm run knip` — clean
- [x] `pnpm run fta` — clean (all files under the 90-point cap)
- [x] `pnpm run test:coverage` — 1938 tests pass, `src/hooks` 95.3% lines (≥85 ratchet)
- [x] `pnpm run test:e2e` — 188 tests pass, including 4 new session-recording regression tests
- [x] Regression tests verified red-before-fix: reverting `autoStart: !deepLinkPending` causes the #704 tests to record `"cardonly"` instead of `"numberonly"` and the distance test to record `"both"` instead of `"apply"`

Closes #704
Part of #693