### PR TITLE
chore: fix stale JSDoc comment on FeatureSuggestion.deepLink

### DIFF
--- a/src/types/discovery.ts
+++ b/src/types/discovery.ts
@@ -40,7 +40,7 @@ export type FeatureSuggestion = {
   /** Lower sorts first. Whole modes outrank variants. */
   priority: number;
   route: RoutePath;
-  /** Preselect param the page will honor from #696; until then it lands in the default mode. */
+  /** Preselect param the target page honors on mount via `useSuggestionDeepLink` — applied through the page's own guard + setter, then stripped. */
   deepLink?: { param: "try" | "timed"; value: string };
   icon: Icon;
   i18n: { titleKey: ParseKeys; ctaKey?: ParseKeys };


### PR DESCRIPTION
## Summary

- Removes the stale "from #696; until then it lands in the default mode" clause from the `deepLink` field JSDoc on `FeatureSuggestion` (`src/types/discovery.ts`).
- The comment described a pre-#696 world. Deep-link preselect shipped with #696 — the param is now honored on mount via `useSuggestionDeepLink`, applied through the page's own guard + setter, then stripped.
- No logic, routing, type signatures, or tests changed — comment-only.

## Test plan

- [x] `pnpm run typecheck` — passes (no type changes)
- [x] `rtk proxy pnpm run lint` — passes (comment change, Biome is silent)
- [x] `pnpm run knip` — passes
- [x] `pnpm run fta` — passes
- [x] `pnpm run test:coverage` — passes (1968 tests, all ratchets met)
- [x] `pnpm run lint:e2e-no-wait` — passes

Part of #693