### PR TITLE
chore: bump knip to 6.16.0, react-router to 7.17.0, add optipng to ignoreBinaries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,3 +1,4 @@
 {
+  "ignoreBinaries": ["optipng"],
   "ignoreDependencies": ["@biomejs/biome", "globals"]
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fta-cli": "3.0.0",
     "globals": "17.6.0",
     "happy-dom": "20.10.1",
-    "knip": "6.15.0",
+    "knip": "6.16.0",
     "lefthook": "2.1.9",
     "postcss": "8.5.15",
     "postcss-preset-mantine": "1.18.0",
@@ -78,7 +78,7 @@
     "react-error-boundary": "6.1.2",
     "react-ga4": "3.0.1",
     "react-i18next": "17.0.8",
-    "react-router": "7.16.0",
+    "react-router": "7.17.0",
     "web-vitals": "5.3.0"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 17.0.8
         version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react-router:
-        specifier: 7.16.0
-        version: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 7.17.0
+        version: 7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       web-vitals:
         specifier: 5.3.0
         version: 5.3.0
@@ -88,8 +88,8 @@ importers:
         specifier: 20.10.1
         version: 20.10.1
       knip:
-        specifier: 6.15.0
-        version: 6.15.0
+        specifier: 6.16.0
+        version: 6.16.0
       lefthook:
         specifier: 2.1.9
         version: 2.1.9
@@ -2833,8 +2833,8 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
-  knip@6.15.0:
-    resolution: {integrity: sha512-uBaKFEGcu/HG4EY2gWFBMr+fBF43Jftoc2riJX51TKME1Z46C8UQIbNEusenYbEWihphxe2PY0Kns0yPvPYz4A==}
+  knip@6.16.0:
+    resolution: {integrity: sha512-znPEmwYmkGHp57VxCQ/k983bVWls74DpRKh/EgYojyssgV2h2dZDvjN3+7WU034LzObjElUVRPoBHq9w/fG1ng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3470,8 +3470,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@7.16.0:
-    resolution: {integrity: sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==}
+  react-router@7.17.0:
+    resolution: {integrity: sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -7108,13 +7108,12 @@ snapshots:
 
   jsonpointer@5.0.1: {}
 
-  knip@6.15.0:
+  knip@6.16.0:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       formatly: 0.3.0
       get-tsconfig: 4.14.0
       jiti: 2.7.0
-      minimist: 1.2.8
       oxc-parser: 0.133.0
       oxc-resolver: 11.20.0
       picomatch: 4.0.4
@@ -7755,7 +7754,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.16
 
-  react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@7.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie: 1.1.1
       react: 19.2.7


### PR DESCRIPTION
## Summary

- Bump `knip` from 6.15.0 → 6.16.0 (drops `minimist` dependency).
- Bump `react-router` from 7.16.0 → 7.17.0.
- Add `optipng` to `ignoreBinaries` in `knip.json` to suppress false-positive unused-binary warnings.

## Test plan

- [ ] CI passes (typecheck, lint, tests, knip).