### PR TITLE
feat: What's New core /whats-new/ page (foundation)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,8 @@ All memorized decks are centralized in `src/types/stacks.ts`:
 - **Pages**: Self-contained in `src/pages/` — each training mode is its own page. Stack-dependent pages are wrapped in `RequireStack`
 - **Components**: Reusable UI in `src/components/` (e.g., `CardSpread`, `StackPicker`, `NumberCard`, `ShareButton`, `ShareNudge`, `NavFooter`, `JsonLd`)
 - **Hooks**: Custom hooks in `src/hooks/` (e.g., `useSelectedStack`, `usePwaInstall`, `useDocumentMeta`)
-- **Utils**: Pure utility functions in `src/utils/` (e.g., `card-selection`, `card-formatting`, `localstorage`, `share`, `is-pwa`)
+- **Utils**: Pure utility functions in `src/utils/` (e.g., `card-selection`, `card-formatting`, `format-release-date`, `localstorage`, `share`, `is-pwa`)
+- **Data**: Typed content modules in `src/data/` (e.g., `whats-new.ts` — the curated changelog; all 7 languages enforced at compile time via `Record<SupportedLanguage, string>`)
 - **Services**: `src/services/analytics.ts` — Google Analytics 4 integration with event tracking. Only initialized when `window.location.hostname === "memdeck.org"` — local dev, preview deployments, and e2e runs are **silent** (no GA events fired). Don't treat "GA didn't log locally" as a bug. Tracks flashcard/spot-check/ACAAN/distance answers, session completions, share actions, web vitals, and errors
 - **i18n**: `src/i18n/` — 7 languages (en, fr, es, de, it, nl, pt) using `react-i18next`. Locale files are lazy-loaded as separate chunks. Type-safe keys derived from the English locale
 - **State**: Primarily local component state with localStorage persistence
@@ -118,6 +119,7 @@ All memorized decks are centralized in `src/types/stacks.ts`:
 - **FAQ** (`src/pages/faq.tsx`): Frequently asked questions about memorized decks, targeting LLM search discoverability. Includes `FAQPage` and `BreadcrumbList` JSON-LD schemas
 - **Resources** (`src/pages/resources.tsx`): Curated reading list of memorized deck books and PDFs. Includes `ItemList`/`Book` and `BreadcrumbList` JSON-LD schemas
 - **About** (`src/pages/about.tsx`): Project info and links
+- **What's New** (`src/pages/whats-new/`): Curated, translated changelog at `/whats-new/` — entries newest-first, each with a localized type badge (`stack`/`feature`/`fix`) and its release date+time rendered in the viewer's locale and local timezone (`<time>` + `src/utils/format-release-date.ts`). Entries live in `src/data/whats-new.ts` (all 7 languages enforced at compile time). Includes a `BreadcrumbList` JSON-LD schema. Foundational for the What's New epic (#717) — siblings add the nav "New" badge (#713), a gated PWA toast (#714), a draft helper (#715), and llms-full.txt injection (#716)
 
 ### PWA & SEO
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Once you've logged a few sessions, MemDeck surfaces a "New challenge" card on th
 
 Curated reading list of memorized deck books and PDFs to deepen your knowledge.
 
+### What's New
+
+A curated changelog at `/whats-new/` — recent updates (new stacks, features, and fixes), newest first, translated into all 7 languages. Each release shows its date and time in your local timezone.
+
 ### Install as App
 
 MemDeck is a Progressive Web App — install it on your phone or desktop for offline access. Silent auto-updates keep you on the latest version.

--- a/e2e/whats-new.e2e.ts
+++ b/e2e/whats-new.e2e.ts
@@ -1,0 +1,48 @@
+import { expect } from "@playwright/test";
+import { test } from "./fixtures/test-setup";
+
+const WHATS_NEW_URL_PATTERN = /\/whats-new\/?$/;
+const WHATS_NEW_HEADING = /what.?s new/i;
+
+test.describe("What's New page", () => {
+  test("loads and lists changelog entries with localized dates", async ({
+    page,
+  }) => {
+    await page.goto("/whats-new/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page).toHaveURL(WHATS_NEW_URL_PATTERN);
+    await expect(
+      page.getByRole("heading", { level: 1, name: WHATS_NEW_HEADING })
+    ).toBeVisible();
+
+    // At least one entry renders, each with a machine-readable <time>.
+    const times = page.locator("time");
+    expect(await times.count()).toBeGreaterThan(0);
+    await expect(times.first()).toBeVisible();
+    const dateTime = await times.first().getAttribute("datetime");
+    expect(dateTime).toBeTruthy();
+    // The visible text is the localized render (formatReleaseDate), not the raw
+    // ISO attribute — assert the year shows (TZ-safe, mirrors the unit test).
+    await expect(times.first()).toContainText("2026");
+  });
+
+  test("reflows on a narrow mobile viewport without horizontal overflow", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto("/whats-new/");
+    await page.waitForLoadState("networkidle");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: WHATS_NEW_HEADING })
+    ).toBeVisible();
+    await expect(page.locator("time").first()).toBeVisible();
+
+    const hasHorizontalOverflow = await page.evaluate(() => {
+      const el = document.documentElement;
+      return el.scrollWidth > el.clientWidth;
+    });
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+});

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -118,6 +118,10 @@ Curated collection of books and resources for memorized deck study:
 - "Particle System" by Joshua Jay - The Particle stack system designed for ease of memorization.
 - Conjuring Archive by Denis Behr - Online database of magic literature, including memorized deck references.
 
+### What's New
+
+A curated, translated changelog at https://memdeck.org/whats-new/ listing recent MemDeck updates — new stacks, training features, and fixes — newest first. Each entry carries a localized type badge and its release date and time, rendered in the reader's own locale and local timezone. Entries are hand-written clean prose (never raw commit messages) and translated into all 7 supported languages.
+
 ## Supported Stacks
 
 MemDeck supports eight memorized deck systems:

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,7 +2,7 @@
 
 > MemDeck is a free, open-source memorized deck trainer for magicians and memory enthusiasts. It helps users master famous memorized deck systems through flashcard exercises, spot checks, ACAAN practice, and deck utilities. Available as a PWA that works offline, in 7 languages, with no account required.
 
-Last updated: 2026-06-04
+Last updated: 2026-06-06
 
 MemDeck is designed for card magicians who use memorized stacks (also known as memorized decks or mem-decks). A memorized stack is a specific, pre-arranged order of all 52 cards that a magician commits to memory, enabling powerful card effects. MemDeck provides interactive training tools to help memorize and maintain recall of these systems.
 
@@ -24,6 +24,7 @@ A global per-stack setting lets users focus training on a specific range of posi
 - [Guide](https://memdeck.org/guide/): Getting started instructions and training tips.
 - [FAQ](https://memdeck.org/faq/): Frequently asked questions about memorized decks and MemDeck.
 - [Resources](https://memdeck.org/resources/): Curated books, PDFs, and links for memorized deck study.
+- [What's New](https://memdeck.org/whats-new/): Curated changelog of recent MemDeck updates — new stacks, features, and fixes, newest first, in all 7 languages.
 
 ## Supported Stacks
 

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -22,6 +22,7 @@ const ROUTE_PRIORITIES: Record<RoutePath, string> = {
   "/toolbox/": "0.5",
   "/stats/": "0.3",
   "/about/": "0.3",
+  "/whats-new/": "0.6",
 };
 
 /**
@@ -41,6 +42,7 @@ const getLastModified = (routePath: RoutePath): string => {
     "/toolbox/": "src/pages/toolbox",
     "/stats/": "src/pages/stats",
     "/about/": "src/pages/about.tsx",
+    "/whats-new/": "src/data/whats-new.ts",
   };
 
   const source = sourceMap[routePath];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -119,6 +119,7 @@ export const ROUTES = {
   toolbox: "/toolbox/",
   stats: "/stats/",
   about: "/about/",
+  whatsNew: "/whats-new/",
 } as const satisfies Record<string, RoutePath>;
 
 /**

--- a/src/data/whats-new.test.ts
+++ b/src/data/whats-new.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { SUPPORTED_LANGUAGES } from "../i18n/language";
+import { WHATS_NEW_ENTRIES } from "./whats-new";
+
+describe("WHATS_NEW_ENTRIES", () => {
+  it("has unique ids", () => {
+    const ids = WHATS_NEW_ENTRIES.map((entry) => entry.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("has at most 20 entries", () => {
+    expect(WHATS_NEW_ENTRIES.length).toBeLessThanOrEqual(20);
+  });
+
+  it("has a valid, parseable releasedAt for every entry", () => {
+    for (const entry of WHATS_NEW_ENTRIES) {
+      expect(Number.isNaN(Date.parse(entry.releasedAt))).toBe(false);
+    }
+  });
+
+  it("is sorted newest-first by releasedAt", () => {
+    const times = WHATS_NEW_ENTRIES.map((entry) =>
+      Date.parse(entry.releasedAt)
+    );
+    const sortedDesc = [...times].sort((a, b) => b - a);
+    expect(times).toEqual(sortedDesc);
+  });
+
+  it("has a non-empty title in all supported languages", () => {
+    for (const entry of WHATS_NEW_ENTRIES) {
+      for (const lang of SUPPORTED_LANGUAGES) {
+        expect(entry.title[lang].trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("has a non-empty body in all supported languages when present", () => {
+    // Forward-looking guard: no seed entry carries a body yet, so this loop is
+    // vacuous today and activates when the first body-bearing entry is added.
+    // WhatsNewEntryCard's body rendering is covered in its own test.
+    for (const entry of WHATS_NEW_ENTRIES) {
+      if (!entry.body) {
+        continue;
+      }
+      for (const lang of SUPPORTED_LANGUAGES) {
+        expect(entry.body[lang].trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+});

--- a/src/data/whats-new.ts
+++ b/src/data/whats-new.ts
@@ -1,0 +1,155 @@
+import type { SupportedLanguage } from "../i18n/language";
+
+/** Category of a changelog entry; surfaced as a localized badge on the page. */
+export type WhatsNewType = "stack" | "feature" | "fix";
+
+/**
+ * A single curated changelog entry. Copy is clean, rewritten prose (never a raw
+ * `feat:`/`fix:` commit subject) and is translated into every supported language
+ * at compile time via `Record<SupportedLanguage, string>`.
+ */
+export type WhatsNewEntry = {
+  /** Stable, unique slug. Siblings key the "new since last seen" state on this. */
+  id: string;
+  /** ISO 8601 instant. Rendered in the viewer's locale and local timezone. */
+  releasedAt: string;
+  type: WhatsNewType;
+  title: Record<SupportedLanguage, string>;
+  body?: Record<SupportedLanguage, string>;
+};
+
+/**
+ * The curated changelog, newest first. Authored pre-sorted by `releasedAt` desc;
+ * `whats-new.test.ts` enforces the ordering, uniqueness, and full-locale coverage.
+ *
+ * Entries 6–9 are foundational milestones that predate git history (which starts
+ * 2026-05-09), so their dates are approximate.
+ */
+export const WHATS_NEW_ENTRIES: readonly WhatsNewEntry[] = [
+  {
+    id: "stats-exploration",
+    releasedAt: "2026-06-05T09:00:00Z",
+    type: "feature",
+    title: {
+      en: 'New Stats "Exploration" view — see which modes and variants you\'ve tried.',
+      fr: "Nouvelle vue « Exploration » des stats — voyez quels modes et variantes vous avez essayés.",
+      es: "Nueva vista «Exploración» en las estadísticas — mira qué modos y variantes has probado.",
+      de: "Neue Statistik-Ansicht „Erkundung“ — sieh, welche Modi und Varianten du ausprobiert hast.",
+      it: "Nuova vista «Esplorazione» nelle statistiche — scopri quali modalità e varianti hai provato.",
+      nl: 'Nieuwe statistiekweergave "Verkenning" — zie welke modi en varianten je hebt geprobeerd.',
+      pt: "Nova vista «Exploração» nas estatísticas — veja que modos e variantes já experimentou.",
+    },
+  },
+  {
+    id: "guided-discovery",
+    releasedAt: "2026-06-04T09:00:00Z",
+    type: "feature",
+    title: {
+      en: 'Guided Discovery — personalized "New challenge" suggestions, post-session prompts, and timed-session nudges.',
+      fr: "Découverte guidée — suggestions « Nouveau défi » personnalisées, invitations après chaque session et rappels de sessions chronométrées.",
+      es: "Descubrimiento guiado — sugerencias personalizadas de «Nuevo reto», avisos tras la sesión y recordatorios de sesiones cronometradas.",
+      de: "Geführte Entdeckung — personalisierte Vorschläge „Neue Herausforderung“, Hinweise nach der Sitzung und Tipps für Sitzungen auf Zeit.",
+      it: "Scoperta guidata — suggerimenti personalizzati «Nuova sfida», avvisi dopo la sessione e spunti per sessioni a tempo.",
+      nl: 'Begeleide ontdekking — gepersonaliseerde suggesties voor "Nieuwe uitdaging", meldingen na de sessie en tips voor sessies met tijdslimiet.',
+      pt: "Descoberta guiada — sugestões personalizadas de «Novo desafio», avisos pós-sessão e lembretes de sessões cronometradas.",
+    },
+  },
+  {
+    id: "a11y-reliability",
+    releasedAt: "2026-05-26T09:00:00Z",
+    type: "fix",
+    title: {
+      en: "Accessibility and reliability improvements across the app.",
+      fr: "Améliorations de l'accessibilité et de la fiabilité dans toute l'application.",
+      es: "Mejoras de accesibilidad y fiabilidad en toda la aplicación.",
+      de: "Verbesserungen bei Barrierefreiheit und Zuverlässigkeit in der gesamten App.",
+      it: "Miglioramenti di accessibilità e affidabilità in tutta l'app.",
+      nl: "Verbeteringen op het gebied van toegankelijkheid en betrouwbaarheid in de hele app.",
+      pt: "Melhorias de acessibilidade e fiabilidade em toda a aplicação.",
+    },
+  },
+  {
+    id: "intuitiva-santi",
+    releasedAt: "2026-05-25T14:00:00Z",
+    type: "stack",
+    title: {
+      en: "Added the Intuitiva Santi memorized deck.",
+      fr: "Ajout du jeu mémorisé Intuitiva Santi.",
+      es: "Añadida la baraja memorizada Intuitiva Santi.",
+      de: "Das memorierte Kartendeck Intuitiva Santi hinzugefügt.",
+      it: "Aggiunto il mazzo memorizzato Intuitiva Santi.",
+      nl: "Het gememoriseerde kaartspel Intuitiva Santi toegevoegd.",
+      pt: "Adicionado o baralho memorizado Intuitiva Santi.",
+    },
+  },
+  {
+    id: "card-names-spelled",
+    releasedAt: "2026-05-25T10:00:00Z",
+    type: "feature",
+    title: {
+      en: "Card names now spell out numeric ranks for clearer reading.",
+      fr: "Les noms des cartes affichent désormais les valeurs numériques en toutes lettres pour une lecture plus claire.",
+      es: "Los nombres de las cartas ahora escriben los valores numéricos con letras para leerlos mejor.",
+      de: "Kartennamen schreiben Zahlenwerte jetzt aus, damit sie leichter zu lesen sind.",
+      it: "I nomi delle carte ora indicano i valori numerici per esteso, per una lettura più chiara.",
+      nl: "Kaartnamen schrijven cijferwaarden nu voluit, zodat ze makkelijker te lezen zijn.",
+      pt: "Os nomes das cartas agora escrevem os valores numéricos por extenso para uma leitura mais clara.",
+    },
+  },
+  {
+    id: "offline-pwa",
+    releasedAt: "2026-05-08T12:00:00Z",
+    type: "feature",
+    title: {
+      en: "Install MemDeck as an app with full offline support.",
+      fr: "Installez MemDeck comme une application avec une prise en charge hors ligne complète.",
+      es: "Instala MemDeck como una app con soporte completo sin conexión.",
+      de: "Installiere MemDeck als App mit vollständiger Offline-Unterstützung.",
+      it: "Installa MemDeck come app con pieno supporto offline.",
+      nl: "Installeer MemDeck als app met volledige offline-ondersteuning.",
+      pt: "Instale o MemDeck como uma aplicação com suporte offline completo.",
+    },
+  },
+  {
+    id: "seven-languages",
+    releasedAt: "2026-05-07T12:00:00Z",
+    type: "feature",
+    title: {
+      en: "Train in seven languages — English, French, Spanish, German, Italian, Dutch, and Portuguese.",
+      fr: "Entraînez-vous en sept langues — anglais, français, espagnol, allemand, italien, néerlandais et portugais.",
+      es: "Entrena en siete idiomas — inglés, francés, español, alemán, italiano, neerlandés y portugués.",
+      de: "Trainiere in sieben Sprachen — Englisch, Französisch, Spanisch, Deutsch, Italienisch, Niederländisch und Portugiesisch.",
+      it: "Allenati in sette lingue — inglese, francese, spagnolo, tedesco, italiano, olandese e portoghese.",
+      nl: "Oefen in zeven talen — Engels, Frans, Spaans, Duits, Italiaans, Nederlands en Portugees.",
+      pt: "Treine em sete idiomas — inglês, francês, espanhol, alemão, italiano, neerlandês e português.",
+    },
+  },
+  {
+    id: "training-modes",
+    releasedAt: "2026-05-06T12:00:00Z",
+    type: "feature",
+    title: {
+      en: "Core training modes — Flashcard, Spot Check, ACAAN, Distance, and the Toolbox.",
+      fr: "Modes d'entraînement principaux — Flashcard, Spot Check, ACAAN, Distance et la Boîte à outils.",
+      es: "Modos de entrenamiento principales — Flashcard, Spot Check, ACAAN, Distancia y la Caja de herramientas.",
+      de: "Wichtigste Trainingsmodi — Flashcard, Spot Check, ACAAN, Distanzzahl und der Werkzeugkasten.",
+      it: "Modalità di allenamento principali — Flashcard, Spot Check, ACAAN, Distance e gli Strumenti.",
+      nl: "Belangrijkste oefenmodi — Flashcard, Spot Check, ACAAN, Afstand en het Gereedschap.",
+      pt: "Modos de treino principais — Flashcard, Spot Check, ACAAN, Distância e as Ferramentas.",
+    },
+  },
+  {
+    id: "launch-stacks",
+    releasedAt: "2026-05-05T12:00:00Z",
+    type: "stack",
+    title: {
+      en: "Launched with a collection of classic memorized deck systems to train and maintain.",
+      fr: "Lancement avec une collection de systèmes de jeu mémorisé classiques à travailler et entretenir.",
+      es: "Lanzado con una colección de sistemas clásicos de baraja memorizada para entrenar y mantener.",
+      de: "Start mit einer Sammlung klassischer memorierter Kartendeck-Systeme zum Trainieren und Aufrechterhalten.",
+      it: "Lancio con una raccolta di sistemi classici di mazzo memorizzato da allenare e mantenere.",
+      nl: "Gelanceerd met een verzameling klassieke gememoriseerde kaartsystemen om te oefenen en te onderhouden.",
+      pt: "Lançamento com uma coleção de sistemas clássicos de baralho memorizado para treinar e manter.",
+    },
+  },
+];

--- a/src/i18n/language.ts
+++ b/src/i18n/language.ts
@@ -13,7 +13,7 @@ export const SUPPORTED_LANGUAGES = [
   "nl",
   "pt",
 ] as const;
-type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
 
 export const LANGUAGE_LABELS = {
   en: "English",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -633,5 +633,15 @@
     "movingToNext": "Weiter zur nächsten Runde.",
     "answerCorrect": "Richtig",
     "answerIncorrect": "Falsch, die Antwort war {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Neuigkeiten",
+    "pageDescription": "Die neuesten MemDeck-Updates — neue Stacks, Funktionen und Korrekturen, die neuesten zuerst.",
+    "title": "Neuigkeiten",
+    "intro": "Aktuelle Updates für MemDeck — neue Stacks, Trainingsfunktionen und Korrekturen. Die neuesten zuerst.",
+    "typeStack": "Neuer Stack",
+    "typeFeature": "Funktion",
+    "typeFix": "Korrektur",
+    "badgeNew": "Neu"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -633,5 +633,15 @@
     "thumbEndLabel": "End position",
     "badgeFullAriaLabel": "Stack range: {{count}} cards. Tap to adjust.",
     "badgePartialAriaLabel": "Stack range: positions {{start}} to {{end}}. Tap to adjust."
+  },
+  "whatsNew": {
+    "pageTitle": "What's New",
+    "pageDescription": "The latest MemDeck updates — new stacks, features, and fixes, newest first.",
+    "title": "What's New",
+    "intro": "Recent updates to MemDeck — new stacks, training features, and fixes. Newest first.",
+    "typeStack": "New stack",
+    "typeFeature": "Feature",
+    "typeFix": "Fix",
+    "badgeNew": "New"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -633,5 +633,15 @@
     "movingToNext": "Pasando a la siguiente ronda.",
     "answerCorrect": "Correcto",
     "answerIncorrect": "Incorrecto, la respuesta era {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Novedades",
+    "pageDescription": "Las últimas actualizaciones de MemDeck — nuevos stacks, funciones y correcciones, las más recientes primero.",
+    "title": "Novedades",
+    "intro": "Actualizaciones recientes de MemDeck — nuevos stacks, funciones de entrenamiento y correcciones. Las más recientes primero.",
+    "typeStack": "Nuevo stack",
+    "typeFeature": "Función",
+    "typeFix": "Corrección",
+    "badgeNew": "Nuevo"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -633,5 +633,15 @@
     "movingToNext": "Passage à la manche suivante.",
     "answerCorrect": "Correct !",
     "answerIncorrect": "Faux. La réponse : {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Nouveautés",
+    "pageDescription": "Les dernières mises à jour de MemDeck — nouveaux stacks, fonctionnalités et corrections, les plus récentes d'abord.",
+    "title": "Nouveautés",
+    "intro": "Mises à jour récentes de MemDeck — nouveaux stacks, fonctionnalités d'entraînement et corrections. Les plus récentes d'abord.",
+    "typeStack": "Nouveau stack",
+    "typeFeature": "Fonctionnalité",
+    "typeFix": "Correction",
+    "badgeNew": "Nouveau"
   }
 }

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -633,5 +633,15 @@
     "movingToNext": "Passaggio al turno successivo.",
     "answerCorrect": "Corretto",
     "answerIncorrect": "Sbagliato, la risposta era {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Novità",
+    "pageDescription": "Gli ultimi aggiornamenti di MemDeck — nuovi stack, funzionalità e correzioni, dal più recente.",
+    "title": "Novità",
+    "intro": "Aggiornamenti recenti di MemDeck — nuovi stack, funzionalità di allenamento e correzioni. Dal più recente.",
+    "typeStack": "Nuovo stack",
+    "typeFeature": "Funzionalità",
+    "typeFix": "Correzione",
+    "badgeNew": "Nuovo"
   }
 }

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -633,5 +633,15 @@
     "movingToNext": "Door naar de volgende ronde.",
     "answerCorrect": "Goed",
     "answerIncorrect": "Fout, het antwoord was {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Wat is er nieuw",
+    "pageDescription": "De nieuwste MemDeck-updates — nieuwe stacks, functies en verbeteringen, nieuwste eerst.",
+    "title": "Wat is er nieuw",
+    "intro": "Recente updates voor MemDeck — nieuwe stacks, oefenfuncties en verbeteringen. Nieuwste eerst.",
+    "typeStack": "Nieuwe stack",
+    "typeFeature": "Functie",
+    "typeFix": "Verbetering",
+    "badgeNew": "Nieuw"
   }
 }

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -633,5 +633,15 @@
     "movingToNext": "A passar para a próxima ronda.",
     "answerCorrect": "Correto",
     "answerIncorrect": "Errado, a resposta era {{answer}}"
+  },
+  "whatsNew": {
+    "pageTitle": "Novidades",
+    "pageDescription": "As atualizações mais recentes do MemDeck — novos stacks, funcionalidades e correções, as mais recentes primeiro.",
+    "title": "Novidades",
+    "intro": "Atualizações recentes do MemDeck — novos stacks, funcionalidades de treino e correções. As mais recentes primeiro.",
+    "typeStack": "Novo stack",
+    "typeFeature": "Funcionalidade",
+    "typeFix": "Correção",
+    "badgeNew": "Novo"
   }
 }

--- a/src/pages/whats-new/whats-new-entry-card.test.tsx
+++ b/src/pages/whats-new/whats-new-entry-card.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { WhatsNewEntry } from "../../data/whats-new";
+import { render } from "../../test-utils";
+import { WhatsNewEntryCard } from "./whats-new-entry-card";
+
+const baseEntry: WhatsNewEntry = {
+  id: "test-entry",
+  releasedAt: "2026-06-05T13:30:00Z",
+  type: "feature",
+  title: {
+    en: "English title",
+    fr: "Titre français",
+    es: "Título español",
+    de: "Deutscher Titel",
+    it: "Titolo italiano",
+    nl: "Nederlandse titel",
+    pt: "Título português",
+  },
+};
+
+describe("WhatsNewEntryCard", () => {
+  it("renders the title in the requested language", () => {
+    render(<WhatsNewEntryCard entry={baseEntry} lang="fr" />);
+    expect(screen.getByText("Titre français")).toBeInTheDocument();
+  });
+
+  it("renders a <time> element carrying the ISO releasedAt", () => {
+    const { container } = render(
+      <WhatsNewEntryCard entry={baseEntry} lang="en" />
+    );
+    const time = container.querySelector<HTMLTimeElement>("time");
+    expect(time).not.toBeNull();
+    expect(time?.dateTime).toBe("2026-06-05T13:30:00Z");
+  });
+
+  it("renders the optional body when present", () => {
+    const withBody: WhatsNewEntry = {
+      ...baseEntry,
+      body: {
+        en: "Body text",
+        fr: "Corps",
+        es: "Cuerpo",
+        de: "Textkörper",
+        it: "Corpo",
+        nl: "Hoofdtekst",
+        pt: "Corpo",
+      },
+    };
+    render(<WhatsNewEntryCard entry={withBody} lang="en" />);
+    expect(screen.getByText("Body text")).toBeInTheDocument();
+  });
+
+  it("omits the body when absent", () => {
+    render(<WhatsNewEntryCard entry={baseEntry} lang="en" />);
+    expect(screen.queryByText("Body text")).not.toBeInTheDocument();
+  });
+
+  it("renders the localized type badge", () => {
+    const stackEntry: WhatsNewEntry = { ...baseEntry, type: "stack" };
+    render(<WhatsNewEntryCard entry={stackEntry} lang="en" />);
+    expect(screen.getByText("New stack")).toBeInTheDocument();
+  });
+});

--- a/src/pages/whats-new/whats-new-entry-card.tsx
+++ b/src/pages/whats-new/whats-new-entry-card.tsx
@@ -1,0 +1,48 @@
+import { Badge, Card, Group, Stack, Text, Title } from "@mantine/core";
+import { useTranslation } from "react-i18next";
+import type { WhatsNewEntry, WhatsNewType } from "../../data/whats-new";
+import type { SupportedLanguage } from "../../i18n/language";
+import { formatReleaseDate } from "../../utils/format-release-date";
+
+const TYPE_LABEL_KEYS = {
+  stack: "whatsNew.typeStack",
+  feature: "whatsNew.typeFeature",
+  fix: "whatsNew.typeFix",
+} as const satisfies Record<WhatsNewType, string>;
+
+const TYPE_COLORS = {
+  stack: "grape",
+  feature: "blue",
+  fix: "teal",
+} as const satisfies Record<WhatsNewType, string>;
+
+type WhatsNewEntryCardProps = {
+  entry: WhatsNewEntry;
+  lang: SupportedLanguage;
+};
+
+export const WhatsNewEntryCard = ({ entry, lang }: WhatsNewEntryCardProps) => {
+  const { t } = useTranslation();
+  const body = entry.body?.[lang];
+
+  return (
+    <Card component="article" padding="md" radius="md" withBorder>
+      <Stack gap="xs">
+        <Group gap="xs" justify="space-between" wrap="wrap">
+          <Badge color={TYPE_COLORS[entry.type]} variant="light">
+            {t(TYPE_LABEL_KEYS[entry.type])}
+          </Badge>
+          <Text c="dimmed" size="sm">
+            <time dateTime={entry.releasedAt}>
+              {formatReleaseDate(entry.releasedAt, lang)}
+            </time>
+          </Text>
+        </Group>
+        <Title order={2} size="h4">
+          {entry.title[lang]}
+        </Title>
+        {body ? <Text>{body}</Text> : null}
+      </Stack>
+    </Card>
+  );
+};

--- a/src/pages/whats-new/whats-new.test.tsx
+++ b/src/pages/whats-new/whats-new.test.tsx
@@ -1,0 +1,21 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WHATS_NEW_ENTRIES } from "../../data/whats-new";
+import { render } from "../../test-utils";
+import { WhatsNew } from "./whats-new";
+
+describe("WhatsNew", () => {
+  it("renders the page heading", () => {
+    render(<WhatsNew />);
+    expect(
+      screen.getByRole("heading", { level: 1, name: "What's New" })
+    ).toBeInTheDocument();
+  });
+
+  it("renders one entry per changelog item, newest first", () => {
+    render(<WhatsNew />);
+    const entryHeadings = screen.getAllByRole("heading", { level: 2 });
+    expect(entryHeadings).toHaveLength(WHATS_NEW_ENTRIES.length);
+    expect(entryHeadings[0]).toHaveTextContent(WHATS_NEW_ENTRIES[0].title.en);
+  });
+});

--- a/src/pages/whats-new/whats-new.tsx
+++ b/src/pages/whats-new/whats-new.tsx
@@ -1,0 +1,41 @@
+import { Stack, Text, Title } from "@mantine/core";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { buildBreadcrumbSchema, JsonLd } from "../../components/json-ld";
+import { ROUTES } from "../../constants";
+import { WHATS_NEW_ENTRIES } from "../../data/whats-new";
+import { useDocumentMeta } from "../../hooks/use-document-meta";
+import { isSupportedLanguage } from "../../i18n/language";
+import { WhatsNewEntryCard } from "./whats-new-entry-card";
+
+export const WhatsNew = () => {
+  const { t, i18n } = useTranslation();
+  const lang = isSupportedLanguage(i18n.language) ? i18n.language : "en";
+
+  useDocumentMeta({
+    title: t("whatsNew.pageTitle"),
+    description: t("whatsNew.pageDescription"),
+  });
+
+  const breadcrumbSchema = useMemo(
+    () => buildBreadcrumbSchema(t("whatsNew.title"), ROUTES.whatsNew),
+    [t]
+  );
+
+  return (
+    <article>
+      <JsonLd data={breadcrumbSchema} />
+      <Title mb="xs" order={1}>
+        {t("whatsNew.title")}
+      </Title>
+      <Text c="dimmed" mb="xl">
+        {t("whatsNew.intro")}
+      </Text>
+      <Stack gap="md">
+        {WHATS_NEW_ENTRIES.map((entry) => (
+          <WhatsNewEntryCard entry={entry} key={entry.id} lang={lang} />
+        ))}
+      </Stack>
+    </article>
+  );
+};

--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -21,7 +21,8 @@ type RoutesUsed =
   | "distance"
   | "toolbox"
   | "stats"
-  | "about";
+  | "about"
+  | "whatsNew";
 
 type AssertRoutesExhaustive = [
   Exclude<keyof typeof ROUTES, RoutesUsed>,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -44,6 +44,9 @@ const Stats = lazyWithReload(() =>
 const About = lazyWithReload(() =>
   import("./pages/about").then((m) => ({ default: m.About }))
 );
+const WhatsNew = lazyWithReload(() =>
+  import("./pages/whats-new/whats-new").then((m) => ({ default: m.WhatsNew }))
+);
 const PageLoader = () => (
   <Center h="100%">
     <Loader size="lg" />
@@ -153,6 +156,14 @@ export const Routes = () => (
         </LazyRoute>
       }
       path={ROUTES.about}
+    />
+    <RouterRoute
+      element={
+        <LazyRoute>
+          <WhatsNew />
+        </LazyRoute>
+      }
+      path={ROUTES.whatsNew}
     />
     <RouterRoute element={<Navigate replace to={ROUTES.home} />} path="*" />
   </RouterRoutes>

--- a/src/utils/format-release-date.test.ts
+++ b/src/utils/format-release-date.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { SUPPORTED_LANGUAGES } from "../i18n/language";
+import { formatReleaseDate } from "./format-release-date";
+
+// A fixed mid-year, mid-day instant. Assertions stay timezone-independent (no
+// exact ICU output is checked) so the test passes regardless of the machine's TZ.
+const ISO = "2026-06-05T13:30:00Z";
+const TIME_PATTERN = /\d{1,2}:\d{2}/;
+
+describe("formatReleaseDate", () => {
+  it("includes a time component (hours:minutes)", () => {
+    expect(formatReleaseDate(ISO, "en")).toMatch(TIME_PATTERN);
+  });
+
+  it("is locale-sensitive (English differs from German)", () => {
+    expect(formatReleaseDate(ISO, "en")).not.toBe(formatReleaseDate(ISO, "de"));
+  });
+
+  it("returns a non-empty, year-bearing string for every supported language", () => {
+    for (const lang of SUPPORTED_LANGUAGES) {
+      const formatted = formatReleaseDate(ISO, lang);
+      expect(formatted.length).toBeGreaterThan(0);
+      expect(formatted).toContain("2026");
+    }
+  });
+});

--- a/src/utils/format-release-date.ts
+++ b/src/utils/format-release-date.ts
@@ -1,0 +1,16 @@
+import type { SupportedLanguage } from "../i18n/language";
+
+/**
+ * Formats an ISO 8601 instant as a localized date + time string. No `timeZone`
+ * option is passed, so the result is rendered in the viewer's local timezone.
+ * Uses `dateStyle`/`timeStyle` so the exact format follows each locale's ICU
+ * conventions rather than a hand-rolled pattern.
+ */
+export const formatReleaseDate = (
+  iso: string,
+  lang: SupportedLanguage
+): string =>
+  new Date(iso).toLocaleString(lang, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });


### PR DESCRIPTION
## Summary

Foundational slice of the **What's New** epic (#717) — a dedicated, prerendered, translated `/whats-new/` changelog page listing curated entries newest-first, each with a localized type badge and its release date+time in the viewer's locale and local timezone.

- `src/data/whats-new.ts` — `WhatsNewType`, `WhatsNewEntry`, `WHATS_NEW_ENTRIES` (9 curated entries, all 7 languages enforced at compile time via `Record<SupportedLanguage, string>`). Contract for siblings #713–#716.
- `src/utils/format-release-date.ts` — pure `toLocaleString` formatter (viewer's local TZ, no `timeZone` override)
- `src/pages/whats-new/` — `WhatsNew` page + `WhatsNewEntryCard` component (mobile-first, `Group wrap`, `<time dateTime>`, type `<Badge>`)
- `whatsNew` i18n namespace across all 7 locales — native-reviewed by 6 language-specific translator subagents
- `ROUTES.whatsNew`, sitemap (`ROUTE_PRIORITIES` + `sourceMap`), `llms.txt`, `llms-full.txt`, `CLAUDE.md`, `README`

**What's automatic:** prerendered to `dist/whats-new/index.html` (9 `<time>` entries + BreadcrumbList JSON-LD), sitemap now at 12 URLs with a real `<lastmod>`, lazy chunk `whats-new-<hash>.js`.

## Test plan

- [x] `pnpm run typecheck` — compiler-enforced guards (sitemap exhaustive records, `RoutesUsed` union, i18n key types)
- [x] `rtk proxy pnpm run lint` — clean
- [x] `pnpm run knip` — no dead exports/files
- [x] `pnpm run fta` — new files score 8–14 (cap 90)
- [x] `pnpm run test:coverage` — 1984 tests pass, coverage ratchets held (`whats-new` dir 100% lines)
- [x] `pnpm run lint:e2e-no-wait` — no `waitForTimeout`
- [x] `pnpm run test:e2e` — 2 new specs pass (desktop + mobile reflow / no-overflow)
- [x] `pnpm run build` — prerendered HTML, sitemap, locale chunk confirmed

Closes #712
Part of #717