### PR TITLE
feat: What's New nav entry + automatic "New" badge (#713)

### DIFF
--- a/e2e/flashcard.e2e.ts
+++ b/e2e/flashcard.e2e.ts
@@ -27,7 +27,7 @@ test.describe("Flashcard Training", () => {
 
     // Verify score badges are displayed (thumbs up/down icons with numbers)
     // Score is shown as badges with "0" text initially
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges).toHaveCount(2);
 
     // Both badges should show 0 initially
@@ -105,7 +105,7 @@ test.describe("Flashcard Training", () => {
     await expect(page.locator(".cardSpreadCard").first()).toBeVisible();
 
     // Get initial score from badges
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     const initialSuccess = await scoreBadges.first().textContent();
     const initialFails = await scoreBadges.last().textContent();
 
@@ -134,7 +134,7 @@ test.describe("Flashcard Training", () => {
     page,
   }) => {
     // Verify initial score badges show 0
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges.first()).toContainText("0");
 
     // Make multiple selections to increase score
@@ -406,7 +406,7 @@ test.describe("Flashcard Training", () => {
     await expect(page.getByRole("img", { name: "Card after" })).toHaveCount(0);
 
     // Score should be reset to 0/0
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges.first()).toContainText("0");
     await expect(scoreBadges.last()).toContainText("0");
 
@@ -436,7 +436,7 @@ test.describe("Flashcard Training", () => {
     await page.locator(".cardSpreadCard").last().click({ force: true });
 
     // Score should be non-zero
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(async () => {
       const successText = await scoreBadges.first().textContent();
       const failsText = await scoreBadges.last().textContent();
@@ -477,7 +477,7 @@ test.describe("Flashcard Training", () => {
     await page.waitForLoadState("networkidle");
 
     // Page should load correctly with score badges and flashcard content
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges).toHaveCount(2);
 
     // Flashcard title should be visible (use heading role to be specific)

--- a/e2e/user-journeys.e2e.ts
+++ b/e2e/user-journeys.e2e.ts
@@ -68,7 +68,7 @@ test.describe("User Journeys", () => {
       page.getByRole("heading", { name: "Flashcard" })
     ).toBeVisible();
     // Score is shown as badges, verify they exist
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges).toHaveCount(2);
 
     // User practices by clicking answers
@@ -146,7 +146,7 @@ test.describe("User Journeys", () => {
     await page.waitForLoadState("networkidle");
 
     // Flashcard page should load with score badges
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges).toHaveCount(2);
     await expect(
       page.getByRole("heading", { name: "Flashcard" })
@@ -278,7 +278,7 @@ test.describe("User Journeys", () => {
     expect(itemCount).toBeGreaterThan(0);
 
     // Score badges should be visible
-    const scoreBadges = page.locator(".mantine-Badge-root");
+    const scoreBadges = page.locator("main .mantine-Badge-root");
     await expect(scoreBadges).toHaveCount(2);
   });
 

--- a/e2e/whats-new.e2e.ts
+++ b/e2e/whats-new.e2e.ts
@@ -45,4 +45,32 @@ test.describe("What's New page", () => {
     });
     expect(hasHorizontalOverflow).toBe(false);
   });
+
+  test("nav 'New' badge shows on a fresh profile and clears after opening the page", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const whatsNewNav = page
+      .locator("#main-nav")
+      .getByRole("link", { name: WHATS_NEW_HEADING });
+    await expect(whatsNewNav).toBeVisible();
+    // Visible "New" badge (UX) ...
+    await expect(whatsNewNav.getByText("New", { exact: true })).toBeVisible();
+    // ... and the screen-reader-only label (the a11y acceptance gate).
+    await expect(whatsNewNav.getByText("Unseen updates")).toBeAttached();
+
+    await whatsNewNav.click();
+    await expect(page).toHaveURL(WHATS_NEW_URL_PATTERN);
+
+    // Cleared live in the persistent navbar — no reload (same-tab dispatch).
+    const navAfter = page
+      .locator("#main-nav")
+      .getByRole("link", { name: WHATS_NEW_HEADING });
+    await expect(navAfter.getByText("New", { exact: true })).toHaveCount(0);
+    await expect(
+      page.locator("#main-nav").getByText("Unseen updates")
+    ).toHaveCount(0);
+  });
 });

--- a/src/components/nav-links.tsx
+++ b/src/components/nav-links.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "@mantine/core";
+import { Badge, NavLink, VisuallyHidden } from "@mantine/core";
 import {
   IconArrowsLeftRight,
   IconBook2,
@@ -9,12 +9,14 @@ import {
   IconInfoCircle,
   IconNumber,
   IconPlayCardStar,
+  IconSparkles,
   IconTools,
 } from "@tabler/icons-react";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router";
 import { ROUTES } from "../constants";
+import { useUnseenWhatsNew } from "../hooks/use-unseen-whats-new";
 
 export const NavLinks = memo(function NavLinks({
   onClick,
@@ -23,6 +25,7 @@ export const NavLinks = memo(function NavLinks({
 }) {
   const location = useLocation();
   const { t } = useTranslation();
+  const { hasUnseen } = useUnseenWhatsNew();
 
   return (
     <>
@@ -63,6 +66,27 @@ export const NavLinks = memo(function NavLinks({
         leftSection={<IconChartBar size={16} stroke={1.5} />}
         onClick={onClick}
         to={ROUTES.stats}
+      />
+      <NavLink
+        active={location.pathname === ROUTES.whatsNew}
+        aria-current={
+          location.pathname === ROUTES.whatsNew ? "page" : undefined
+        }
+        component={Link}
+        label={t("nav.whatsNew")}
+        leftSection={<IconSparkles aria-hidden="true" size={16} stroke={1.5} />}
+        onClick={onClick}
+        rightSection={
+          hasUnseen ? (
+            <>
+              <Badge aria-hidden="true" size="xs" variant="filled">
+                {t("whatsNew.badgeNew")}
+              </Badge>
+              <VisuallyHidden>{t("nav.whatsNewUnseen")}</VisuallyHidden>
+            </>
+          ) : undefined
+        }
+        to={ROUTES.whatsNew}
       />
 
       <NavLink

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,6 +79,9 @@ export const PWA_INSTALL_PERMANENTLY_DISMISSED_LSK =
   "memdeck-app-pwa-install-permanently-dismissed";
 export const PWA_INSTALL_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
 
+/** localStorage key for the newest What's New entry id the user has seen (nav badge) */
+export const WHATS_NEW_LAST_SEEN_LSK = "memdeck-app-whats-new-last-seen";
+
 export const SITE_NAME = "MemDeck";
 export const SITE_URL = "https://memdeck.org";
 

--- a/src/hooks/use-unseen-whats-new.test.ts
+++ b/src/hooks/use-unseen-whats-new.test.ts
@@ -1,0 +1,129 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WHATS_NEW_LAST_SEEN_LSK } from "../constants";
+import { WHATS_NEW_ENTRIES } from "../data/whats-new";
+import { useUnseenWhatsNew } from "./use-unseen-whats-new";
+
+vi.mock("../utils/localstorage-telemetry", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/localstorage-telemetry")>()),
+  handleLocalDbWriteFailed: vi.fn(),
+  reportLocalDbCorruption: vi.fn(),
+}));
+const { handleLocalDbWriteFailed, reportLocalDbCorruption } = await import(
+  "../utils/localstorage-telemetry"
+);
+const mockHandleWriteFailed = vi.mocked(handleLocalDbWriteFailed);
+const mockReportCorruption = vi.mocked(reportLocalDbCorruption);
+
+// Non-empty by construction (see whats-new.test.ts); derive rather than
+// hardcode so this suite survives every new changelog entry.
+const latestId = WHATS_NEW_ENTRIES[0]?.id ?? "";
+const staleId = `${latestId}-stale`;
+
+// happy-dom@20 + vitest@4 expose `window.localStorage` as a plain object
+// without the Storage API, so install a hand-rolled in-memory mock — mirrors
+// `src/utils/localstorage.test.ts`. Write-failure tests override `setItemMock`.
+describe("useUnseenWhatsNew", () => {
+  let store: Record<string, string>;
+  let setItemMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    store = {};
+    setItemMock = vi.fn((k: string, v: string) => {
+      store[k] = String(v);
+    });
+    vi.stubGlobal("localStorage", {
+      get length() {
+        return Object.keys(store).length;
+      },
+      getItem: vi.fn((k: string) => (k in store ? store[k] : null)),
+      setItem: setItemMock,
+      removeItem: vi.fn((k: string) => {
+        delete store[k];
+      }),
+      clear: () => {
+        for (const k of Object.keys(store)) {
+          delete store[k];
+        }
+      },
+      key: (i: number) => Object.keys(store)[i] ?? null,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("flags unseen on a fresh profile (no stored id)", () => {
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(true);
+  });
+
+  it("flags unseen when the stored id is stale", () => {
+    window.localStorage.setItem(
+      WHATS_NEW_LAST_SEEN_LSK,
+      JSON.stringify(staleId)
+    );
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(true);
+  });
+
+  it("is not unseen when the stored id matches the newest entry", () => {
+    window.localStorage.setItem(
+      WHATS_NEW_LAST_SEEN_LSK,
+      JSON.stringify(latestId)
+    );
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(false);
+  });
+
+  it("markLatestSeen persists the newest id and clears hasUnseen live", () => {
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(true);
+
+    act(() => {
+      result.current.markLatestSeen();
+    });
+
+    expect(store[WHATS_NEW_LAST_SEEN_LSK]).toBe(JSON.stringify(latestId));
+    expect(result.current.hasUnseen).toBe(false);
+  });
+
+  it("markLatestSeen does not write when the newest id is already seen", () => {
+    window.localStorage.setItem(
+      WHATS_NEW_LAST_SEEN_LSK,
+      JSON.stringify(latestId)
+    );
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(false);
+
+    setItemMock.mockClear();
+    act(() => {
+      result.current.markLatestSeen();
+    });
+
+    expect(setItemMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to unseen and reports corruption for a guard-failing value", () => {
+    window.localStorage.setItem(WHATS_NEW_LAST_SEEN_LSK, JSON.stringify(42));
+    const { result } = renderHook(() => useUnseenWhatsNew());
+    expect(result.current.hasUnseen).toBe(true);
+    expect(mockReportCorruption).toHaveBeenCalled();
+  });
+
+  it("reports a write failure without throwing when persistence fails", () => {
+    setItemMock.mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+    const { result } = renderHook(() => useUnseenWhatsNew());
+
+    expect(() => {
+      act(() => {
+        result.current.markLatestSeen();
+      });
+    }).not.toThrow();
+    expect(mockHandleWriteFailed).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-unseen-whats-new.ts
+++ b/src/hooks/use-unseen-whats-new.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+import { WHATS_NEW_LAST_SEEN_LSK } from "../constants";
+import { WHATS_NEW_ENTRIES } from "../data/whats-new";
+import { useLocalDb } from "../utils/localstorage";
+import {
+  handleLocalDbWriteFailed,
+  reportLocalDbCorruption,
+} from "../utils/localstorage-telemetry";
+
+// Mirrors `isBoolean` in share-nudge.tsx — module-scoped, not exported.
+const isStringOrNull = (value: unknown): value is string | null =>
+  typeof value === "string" || value === null;
+
+/**
+ * Tracks whether the user has seen the newest What's New entry, keyed on the
+ * entry **id** (not its date) so the nav badge re-arms only when a genuinely
+ * new entry is published. `markLatestSeen` persists the newest id; because
+ * `useLocalDb` dispatches a same-tab change event on write, the persistent
+ * navbar's separate hook instance clears its badge live (no reload).
+ */
+export const useUnseenWhatsNew = (): {
+  hasUnseen: boolean;
+  markLatestSeen: () => void;
+} => {
+  const [lastSeen, setLastSeen] = useLocalDb<string | null>(
+    WHATS_NEW_LAST_SEEN_LSK,
+    null,
+    isStringOrNull,
+    {
+      onCorrupt: reportLocalDbCorruption,
+      onWriteFailed: handleLocalDbWriteFailed,
+    }
+  );
+
+  const latestId = WHATS_NEW_ENTRIES[0]?.id ?? null;
+  const hasUnseen = latestId !== null && latestId !== lastSeen;
+
+  const markLatestSeen = useCallback(() => {
+    if (hasUnseen) {
+      setLastSeen(latestId);
+    }
+  }, [hasUnseen, setLastSeen, latestId]);
+
+  return { hasUnseen, markLatestSeen };
+};

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -69,6 +69,8 @@
     "name": "{{suit}} {{rank}}"
   },
   "nav": {
+    "whatsNew": "Neuigkeiten",
+    "whatsNewUnseen": "Ungelesene Updates",
     "home": "Start",
     "guide": "Anleitung",
     "resources": "Ressourcen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} of {{suit}}"
   },
   "nav": {
+    "whatsNew": "What's New",
+    "whatsNewUnseen": "Unseen updates",
     "home": "Home",
     "guide": "Guide",
     "resources": "Resources",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} de {{suit}}"
   },
   "nav": {
+    "whatsNew": "Novedades",
+    "whatsNewUnseen": "Actualizaciones sin ver",
     "home": "Inicio",
     "guide": "Guía",
     "resources": "Recursos",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} de {{suit}}"
   },
   "nav": {
+    "whatsNew": "Nouveautés",
+    "whatsNewUnseen": "Mises à jour non vues",
     "home": "Accueil",
     "guide": "Guide",
     "resources": "Ressources",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} di {{suit}}"
   },
   "nav": {
+    "whatsNew": "Novità",
+    "whatsNewUnseen": "Aggiornamenti non letti",
     "home": "Home",
     "guide": "Guida",
     "resources": "Risorse",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} van {{suit}}"
   },
   "nav": {
+    "whatsNew": "Wat is er nieuw",
+    "whatsNewUnseen": "Ongelezen updates",
     "home": "Home",
     "guide": "Gids",
     "resources": "Bronnen",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -69,6 +69,8 @@
     "name": "{{rank}} de {{suit}}"
   },
   "nav": {
+    "whatsNew": "Novidades",
+    "whatsNewUnseen": "Atualizações não vistas",
     "home": "Início",
     "guide": "Guia",
     "resources": "Recursos",

--- a/src/pages/whats-new/whats-new.tsx
+++ b/src/pages/whats-new/whats-new.tsx
@@ -1,21 +1,28 @@
 import { Stack, Text, Title } from "@mantine/core";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { buildBreadcrumbSchema, JsonLd } from "../../components/json-ld";
 import { ROUTES } from "../../constants";
 import { WHATS_NEW_ENTRIES } from "../../data/whats-new";
 import { useDocumentMeta } from "../../hooks/use-document-meta";
+import { useUnseenWhatsNew } from "../../hooks/use-unseen-whats-new";
 import { isSupportedLanguage } from "../../i18n/language";
 import { WhatsNewEntryCard } from "./whats-new-entry-card";
 
 export const WhatsNew = () => {
   const { t, i18n } = useTranslation();
   const lang = isSupportedLanguage(i18n.language) ? i18n.language : "en";
+  const { markLatestSeen } = useUnseenWhatsNew();
 
   useDocumentMeta({
     title: t("whatsNew.pageTitle"),
     description: t("whatsNew.pageDescription"),
   });
+
+  // Opening the page clears the nav "New" badge (marks the newest id seen).
+  useEffect(() => {
+    markLatestSeen();
+  }, [markLatestSeen]);
 
   const breadcrumbSchema = useMemo(
     () => buildBreadcrumbSchema(t("whatsNew.title"), ROUTES.whatsNew),


### PR DESCRIPTION
## Summary

- Adds a top-level **What's New** nav entry (after Stats, `IconSparkles`) linking to `/whats-new/`
- An automatic **"New" badge** appears when there are unseen changelog entries and clears live — without a reload — the moment the user opens the page
- Badge clearing propagates same-tab via `useLocalDb`'s custom-event dispatch, so the persistent `NavLinks` instance re-renders without a remount
- Screen-reader accessible: visible `<Badge aria-hidden>` paired with a `<VisuallyHidden>` label ("Unseen updates") — explicit `aria-current` per the Mantine `active=` gotcha rule
- SR label reframed from "New updates" to an "unseen/unread" framing across all 7 locales, confirmed by a native-speaker review per language
- e2e score-badge locators scoped to `main .mantine-Badge-root` to exclude the new nav badge from existing count assertions

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — clean (353 files)
- [x] `pnpm run knip` — clean
- [x] `pnpm run fta` — clean
- [x] `pnpm run test:coverage` — 1990/1990 (hook test 7/7, ratchets held)
- [x] `pnpm run lint:e2e-no-wait` — clean
- [x] `pnpm run test:e2e` — **195/195** (new badge show→clear test passes)
- [x] Two rounds of `/jr-review` — both clean (react/a11y, typescript/testing, security reviewers)
- [x] Per-language native-speaker translation audit (7 locales) via dedicated subagents

Closes #713
Part of #717