### PR TITLE
feat: What's New gated PWA update toast + "See What's New" link

### DIFF
--- a/src/components/pwa-update-notifier.test.tsx
+++ b/src/components/pwa-update-notifier.test.tsx
@@ -1,5 +1,6 @@
 import { notifications } from "@mantine/notifications";
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { RegisterSWOptions } from "vite-plugin-pwa/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -7,11 +8,22 @@ import {
   PWA_UPDATE_COOLDOWN_MS,
   PWA_UPDATE_TOAST_TIMEOUT,
   UPDATE_NOTIFIED_AT_LSK,
+  WHATS_NEW_LAST_ANNOUNCED_LSK,
 } from "../constants";
+import { WHATS_NEW_ENTRIES } from "../data/whats-new";
+import { render as renderWithProviders } from "../test-utils";
 import { createMockLocalStorage } from "../test-utils/mock-local-storage";
 import { PwaUpdateNotifier } from "./pwa-update-notifier";
 
 vi.stubGlobal("__COMMIT_HASH__", "abc1234");
+
+// The gating tests use the real data module's newest entry id. Narrow here so
+// the assumption (the changelog is non-empty) is explicit and typed.
+const latestEntry = WHATS_NEW_ENTRIES[0];
+if (!latestEntry) {
+  throw new Error("WHATS_NEW_ENTRIES must be non-empty for these tests");
+}
+const latestEntryId = latestEntry.id;
 
 const mockUseRegisterSW = vi.fn((_options?: RegisterSWOptions) => ({}));
 
@@ -20,7 +32,7 @@ vi.mock("virtual:pwa-register/react", () => ({
 }));
 
 vi.mock("@mantine/notifications", () => ({
-  notifications: { show: vi.fn() },
+  notifications: { show: vi.fn(), hide: vi.fn() },
 }));
 
 const mockTrackFeatureUsed = vi.fn();
@@ -69,17 +81,17 @@ describe("PwaUpdateNotifier", () => {
     expect(notifications.show).not.toHaveBeenCalled();
   });
 
-  it("shows a teal auto-closing toast when hash differs and cooldown expired", () => {
+  it("shows a teal auto-closing toast when hash differs and a new entry is unannounced", () => {
     mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
     render(<PwaUpdateNotifier />);
 
     expect(notifications.show).toHaveBeenCalledOnce();
     expect(notifications.show).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: "pwa-update",
         color: "teal",
         autoClose: PWA_UPDATE_TOAST_TIMEOUT,
         title: "Updated",
-        message: "MemDeck has been updated.",
         withCloseButton: true,
       })
     );
@@ -130,6 +142,61 @@ describe("PwaUpdateNotifier", () => {
     render(<PwaUpdateNotifier />);
 
     expect(mockTrackFeatureUsed).toHaveBeenCalledWith("PWA Update Applied");
+  });
+
+  it("is silent when the latest entry was already announced (noise deploy)", () => {
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
+    mockLocalStorage.setItem(WHATS_NEW_LAST_ANNOUNCED_LSK, latestEntryId);
+
+    render(<PwaUpdateNotifier />);
+
+    expect(notifications.show).not.toHaveBeenCalled();
+  });
+
+  it("still tracks telemetry when the toast is gated silent", () => {
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
+    mockLocalStorage.setItem(WHATS_NEW_LAST_ANNOUNCED_LSK, latestEntryId);
+
+    render(<PwaUpdateNotifier />);
+
+    expect(mockTrackFeatureUsed).toHaveBeenCalledWith("PWA Update Applied");
+    expect(notifications.show).not.toHaveBeenCalled();
+  });
+
+  it("records the announced entry id when the toast shows", () => {
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
+
+    render(<PwaUpdateNotifier />);
+
+    expect(notifications.show).toHaveBeenCalledOnce();
+    expect(mockLocalStorage.getItem(WHATS_NEW_LAST_ANNOUNCED_LSK)).toBe(
+      latestEntryId
+    );
+  });
+
+  it("seeds the announced marker on first visit so new users aren't toasted", () => {
+    render(<PwaUpdateNotifier />);
+
+    expect(notifications.show).not.toHaveBeenCalled();
+    expect(mockLocalStorage.getItem(COMMIT_HASH_LSK)).toBe("abc1234");
+    expect(mockLocalStorage.getItem(WHATS_NEW_LAST_ANNOUNCED_LSK)).toBe(
+      latestEntryId
+    );
+  });
+
+  it("renders a 'See What's New' link to /whats-new/ that dismisses the toast", async () => {
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
+    render(<PwaUpdateNotifier />);
+
+    const call = vi.mocked(notifications.show).mock.calls[0]?.[0];
+    expect(call).toBeDefined();
+    renderWithProviders(<div>{call?.message}</div>);
+
+    const link = screen.getByRole("link", { name: "See What's New" });
+    expect(link).toHaveAttribute("href", "/whats-new/");
+
+    await userEvent.click(link);
+    expect(notifications.hide).toHaveBeenCalledWith("pwa-update");
   });
 
   it("registers the service worker with immediate option and onRegisteredSW", () => {

--- a/src/components/pwa-update-notifier.tsx
+++ b/src/components/pwa-update-notifier.tsx
@@ -1,13 +1,18 @@
 import { useRegisterSW } from "virtual:pwa-register/react";
+import { Anchor } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { Link } from "react-router";
 import {
   COMMIT_HASH_LSK,
   PWA_UPDATE_COOLDOWN_MS,
   PWA_UPDATE_TOAST_TIMEOUT,
+  ROUTES,
   UPDATE_NOTIFIED_AT_LSK,
+  WHATS_NEW_LAST_ANNOUNCED_LSK,
 } from "../constants";
+import { WHATS_NEW_ENTRIES } from "../data/whats-new";
 import { analytics } from "../services/analytics";
 import {
   handleLocalDbWriteFailed,
@@ -15,6 +20,11 @@ import {
 } from "../utils/localstorage-telemetry";
 
 const UPDATE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Fixed notification id so the in-message link can dismiss the toast it lives in. */
+const PWA_UPDATE_TOAST_ID = "pwa-update";
+
+const dismissPwaUpdateToast = () => notifications.hide(PWA_UPDATE_TOAST_ID);
 
 const safeGetItem = (key: string): string | null => {
   try {
@@ -36,9 +46,10 @@ const safeSetItem = (key: string, value: string): void => {
 };
 
 /**
- * Silently auto-updates the service worker and shows a brief "Updated" toast
- * on the user's next visit when a new version has been applied.
- * At most one toast per 24 hours. Renders nothing.
+ * Silently auto-updates the service worker. On the user's next visit after a new
+ * version is applied, shows a brief "Updated" toast — but only when there's a
+ * genuinely new, unannounced What's New entry to point at (silent on
+ * dependency-bump / noise deploys). At most once per entry. Renders nothing.
  */
 export const PwaUpdateNotifier = () => {
   const { t } = useTranslation();
@@ -80,10 +91,16 @@ export const PwaUpdateNotifier = () => {
   );
 
   useEffect(() => {
+    const latestEntryId = WHATS_NEW_ENTRIES[0]?.id;
     const storedHash = safeGetItem(COMMIT_HASH_LSK);
 
     if (!storedHash) {
       safeSetItem(COMMIT_HASH_LSK, __COMMIT_HASH__);
+      // Seed the announced marker so brand-new users aren't toasted on their
+      // next update for an entry that predates their first visit.
+      if (latestEntryId) {
+        safeSetItem(WHATS_NEW_LAST_ANNOUNCED_LSK, latestEntryId);
+      }
       return;
     }
 
@@ -102,13 +119,36 @@ export const PwaUpdateNotifier = () => {
     }
 
     safeSetItem(UPDATE_NOTIFIED_AT_LSK, String(Date.now()));
+    // Telemetry stays above the What's New gate below: every applied update is
+    // tracked, even when the toast stays silent because nothing new shipped.
     analytics.trackFeatureUsed("PWA Update Applied");
 
+    // Gate the toast on a genuinely new, unannounced changelog entry. Silent on
+    // dependency-bump / noise deploys that ship no What's New entry.
+    const lastAnnounced = safeGetItem(WHATS_NEW_LAST_ANNOUNCED_LSK);
+    if (!latestEntryId || latestEntryId === lastAnnounced) {
+      return;
+    }
+
+    safeSetItem(WHATS_NEW_LAST_ANNOUNCED_LSK, latestEntryId);
+
     notifications.show({
+      id: PWA_UPDATE_TOAST_ID,
       color: "teal",
       autoClose: PWA_UPDATE_TOAST_TIMEOUT,
       title: t("pwaUpdate.title"),
-      message: t("pwaUpdate.message"),
+      message: (
+        <>
+          {t("pwaUpdate.message")}{" "}
+          <Anchor
+            component={Link}
+            onClick={dismissPwaUpdateToast}
+            to={ROUTES.whatsNew}
+          >
+            {t("pwaUpdate.seeWhatsNew")}
+          </Anchor>
+        </>
+      ),
       withCloseButton: true,
     });
   }, [t]);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,12 @@ export const LAST_SAVE_FAILED_SHOWN_SSK = "memdeck-app-last-save-failed-shown";
 export const COMMIT_HASH_LSK = "memdeck-app-commit-hash";
 export const UPDATE_NOTIFIED_AT_LSK = "memdeck-app-update-notified-at";
 export const PWA_UPDATE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-export const PWA_UPDATE_TOAST_TIMEOUT = 5000;
+/**
+ * Toast visible duration. 10s (not 5s) so keyboard and screen-reader users have
+ * time to reach the toast's "See What's New" link before it auto-closes — Mantine
+ * pauses autoClose on hover but not on focus.
+ */
+export const PWA_UPDATE_TOAST_TIMEOUT = 10_000;
 
 export const PWA_INSTALL_DISMISSED_AT_LSK =
   "memdeck-app-pwa-install-dismissed-at";
@@ -81,6 +86,14 @@ export const PWA_INSTALL_COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** localStorage key for the newest What's New entry id the user has seen (nav badge) */
 export const WHATS_NEW_LAST_SEEN_LSK = "memdeck-app-whats-new-last-seen";
+
+/**
+ * localStorage key for the newest What's New entry id announced via the PWA update toast.
+ * Distinct from WHATS_NEW_LAST_SEEN_LSK (nav badge) so each entry is toast-announced at most
+ * once, regardless of later dependency-bump / noise deploys.
+ */
+export const WHATS_NEW_LAST_ANNOUNCED_LSK =
+  "memdeck-app-whats-new-last-announced";
 
 export const SITE_NAME = "MemDeck";
 export const SITE_URL = "https://memdeck.org";

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Aktualisiert",
-    "message": "MemDeck wurde aktualisiert."
+    "message": "MemDeck wurde aktualisiert.",
+    "seeWhatsNew": "Neuigkeiten ansehen"
   },
   "errors": {
     "somethingWentWrong": "Etwas ist schiefgelaufen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -369,7 +369,8 @@
   },
   "pwaUpdate": {
     "title": "Updated",
-    "message": "MemDeck has been updated."
+    "message": "MemDeck has been updated.",
+    "seeWhatsNew": "See What's New"
   },
   "errors": {
     "somethingWentWrong": "Something went wrong",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Actualizado",
-    "message": "MemDeck se ha actualizado."
+    "message": "MemDeck se ha actualizado.",
+    "seeWhatsNew": "Ver novedades"
   },
   "errors": {
     "somethingWentWrong": "Algo salió mal",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Mis à jour",
-    "message": "MemDeck a été mis à jour."
+    "message": "MemDeck a été mis à jour.",
+    "seeWhatsNew": "Voir les nouveautés"
   },
   "errors": {
     "somethingWentWrong": "Une erreur est survenue",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Aggiornato",
-    "message": "MemDeck è stato aggiornato."
+    "message": "MemDeck è stato aggiornato.",
+    "seeWhatsNew": "Scopri le novità"
   },
   "errors": {
     "somethingWentWrong": "Qualcosa è andato storto",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Bijgewerkt",
-    "message": "MemDeck is bijgewerkt."
+    "message": "MemDeck is bijgewerkt.",
+    "seeWhatsNew": "Bekijk wat er nieuw is"
   },
   "errors": {
     "somethingWentWrong": "Er is iets misgegaan",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -337,7 +337,8 @@
   },
   "pwaUpdate": {
     "title": "Atualizado",
-    "message": "O MemDeck foi atualizado."
+    "message": "O MemDeck foi atualizado.",
+    "seeWhatsNew": "Ver novidades"
   },
   "errors": {
     "somethingWentWrong": "Algo correu mal",

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -157,10 +157,13 @@ export const Provider = () => (
         FallbackComponent={RootErrorFallback}
         onError={handleRootError}
       >
-        <Notifications />
         <LanguageLoadNotifier />
         <PwaUpdateNotifier />
         <BrowserRouter>
+          {/* Inside the router so toast messages can render react-router <Link>s
+              (e.g. the PWA update toast's "See What's New" link). Mantine portals
+              to a fixed DOM target regardless of React-tree position. */}
+          <Notifications />
           <FocusOnNavigate />
           <App />
         </BrowserRouter>


### PR DESCRIPTION
## Summary

- Re-gates the PWA "Updated" toast so it fires only when there's a genuinely new, unannounced What's New entry — silent on dependency-bump / noise deploys, at most once per entry.
- Adds a "See What's New" client-side link in the toast body that navigates to `/whats-new/` and dismisses the toast on click.
- Moves `<Notifications />` inside `<BrowserRouter>` so the toast's react-router `<Link>` has router context (Mantine portals to a fixed DOM target — safe, no regression).
- Bumps `PWA_UPDATE_TOAST_TIMEOUT` 5 s → 10 s: Mantine only pauses `autoClose` on hover, not keyboard focus; the longer window gives keyboard/SR users time to reach the link.
- Adds `pwaUpdate.seeWhatsNew` to all 7 locales (en, fr, es, de, it, nl, pt) — native-expert reviewed.
- Adds `WHATS_NEW_LAST_ANNOUNCED_LSK` (distinct from the nav-badge `WHATS_NEW_LAST_SEEN_LSK`) and seeds it on first-run so brand-new users aren't toasted for entries that predate their first visit.
- Test coverage: gate-shows, gate-silent (noise deploy), telemetry-on-silent, marker-set, first-run-seed, link target + dismiss-on-click.

## Test plan

- [x] `pnpm run typecheck` — clean
- [x] `rtk proxy pnpm run lint` — clean (353 files checked)
- [x] `pnpm run knip` — clean
- [x] `pnpm run fta` — clean
- [x] `pnpm run test:coverage` — 1996 tests / 119 files passed; notifier suite 21/21; per-directory coverage ratchets held
- [x] `pnpm run lint:e2e-no-wait` — clean
- [x] `pnpm run test:e2e` — 195 passed (incl. `whats-new.e2e.ts` + write-failure toast)
- [x] 7-language native-expert i18n review — all KEEP
- [x] Two-pass `/jr-review` — 3 findings found, 2 applied (a11y timing + dismiss test), 1 kept as Option A (cooldown, deliberate)

**Feature-correctness note:** The toast fires only on a real SW hash change + cooldown pass — not exercisable in local `pnpm run dev`. Gate logic is covered by unit tests; link target and dismiss are covered by the render-the-message test. End-to-end toast firing in a live browser is not locally reproducible.

**Rollout note:** Existing users have a stored commit hash but no `WHATS_NEW_LAST_ANNOUNCED` marker — the first post-deploy visit will toast them once for the current newest entry (self-limiting, intended as a one-time "here's what changed" nudge). The nav "New" badge (#713) covers the same entry independently as a durable fallback.

Closes #714
Part of #717