### PR TITLE
feat: What's New dev draft helper (whats-new:draft)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,7 +248,7 @@ All user-facing English text must follow these principles:
 ## Adding a New Locale
 
 1. Copy `src/i18n/locales/en.json` to `src/i18n/locales/<code>.json` and translate values. Keys must stay identical — they're typed off `en` via `src/i18n/types.ts`, so any drift is a type error.
-2. Register the locale in `src/i18n/language.ts` — add `<code>` to `SUPPORTED_LANGUAGES`, `LANGUAGE_LABELS`, `LANGUAGE_CODES`, and `languageLoaders` (all four must stay in sync; they share a `satisfies Record<SupportedLanguage, …>` constraint).
+2. Register the locale: add `<code>` to `SUPPORTED_LANGUAGES` in `src/i18n/supported-languages.ts` (the dependency-free leaf that owns the list/type), then to `LANGUAGE_LABELS`, `LANGUAGE_CODES`, and `languageLoaders` in `src/i18n/language.ts` (all four must stay in sync; `LANGUAGE_LABELS`/`LANGUAGE_CODES` share a `satisfies Record<SupportedLanguage, …>` constraint).
 3. The filename must match `vite.config.ts`'s `LOCALE_CHUNK_RE` (`/i18n/locales/(?!en)(\w+)\.json$/`) — use a plain `<code>.json`, not `<code>-<region>.json`, or the chunk won't be split correctly.
 4. Run `pnpm run build` — a new `dist/assets/locale-<code>-<hash>.js` chunk should appear and be excluded from precaching (see `globIgnores` in `vite.config.ts`).
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lighthouse": "lhci autorun",
     "generate:splash": "node scripts/generate-splash-images.ts",
     "generate:screenshots": "node scripts/generate-screenshots.ts",
+    "whats-new:draft": "node scripts/draft-whats-new.ts",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/scripts/draft-whats-new.ts
+++ b/scripts/draft-whats-new.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from "node:child_process";
+
+const { WHATS_NEW_ENTRIES } = await import("../src/data/whats-new.ts");
+const { cleanCommitSubject } = await import("../src/utils/whats-new-draft.ts");
+const { SUPPORTED_LANGUAGES } = await import(
+  "../src/i18n/supported-languages.ts"
+);
+
+// Used only when there are no entries yet (no `releasedAt` boundary to derive keys from).
+// Derived from the canonical language set so it can't drift when a locale is added.
+const FALLBACK_LANGS = [...SUPPORTED_LANGUAGES];
+
+const latest = WHATS_NEW_ENTRIES.at(0); // entries are newest-first
+
+const gitArgs = ["log", "--format=%H|%cI|%s"];
+gitArgs.push(latest ? `--since=${latest.releasedAt}` : "--max-count=40");
+
+let raw = "";
+try {
+  raw = execFileSync("git", gitArgs, { encoding: "utf-8" }).trim();
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`[draft-whats-new] git log failed: ${message}\n`);
+  process.exit(1);
+}
+
+type Candidate = {
+  hash: string;
+  date: string;
+  type: "feature" | "fix";
+  text: string;
+};
+
+const candidates: Candidate[] = [];
+let skipped = 0;
+for (const line of raw ? raw.split("\n") : []) {
+  // %H and %cI never contain `|`; rejoin the rest so a `|` in a subject can't corrupt the parse.
+  const [hash, date, ...rest] = line.split("|");
+  if (hash === undefined || date === undefined || rest.length === 0) {
+    continue;
+  }
+  const parsed = cleanCommitSubject(rest.join("|"));
+  if (!parsed) {
+    skipped++;
+    continue;
+  }
+  candidates.push({ hash: hash.slice(0, 7), date, ...parsed });
+}
+
+const boundary = latest
+  ? `last entry "${latest.id}" (${latest.releasedAt})`
+  : "(no entries yet — scanning the last 40 commits)";
+
+console.log(`\nWhat's New draft — candidates since ${boundary}`);
+console.log(
+  `${candidates.length} candidate(s), ${skipped} non-feat/fix commit(s) skipped.\n`
+);
+
+for (const candidate of candidates) {
+  console.log(`  [${candidate.type}] ${candidate.hash} ${candidate.date}`);
+  console.log(`    ${candidate.text}\n`);
+}
+
+const top = candidates.at(0);
+if (top) {
+  const langs = latest ? Object.keys(latest.title) : FALLBACK_LANGS;
+  const titleLines = langs
+    .map(
+      (lang) =>
+        `    ${lang}: ${lang === "en" ? JSON.stringify(top.text) : '"TODO"'},`
+    )
+    .join("\n");
+  console.log(
+    "Paste-ready skeleton — compose/squash by hand, then translate the TODOs:\n"
+  );
+  console.log("{");
+  console.log('  id: "TODO-slug",');
+  console.log(`  releasedAt: ${JSON.stringify(top.date)},`);
+  console.log(`  type: ${JSON.stringify(top.type)},`);
+  console.log("  title: {");
+  console.log(titleLines);
+  console.log("  },");
+  console.log("},\n");
+} else {
+  console.log(
+    "No feat/fix candidates since the last entry. Nothing to draft.\n"
+  );
+}

--- a/src/components/language-picker.tsx
+++ b/src/components/language-picker.tsx
@@ -6,8 +6,8 @@ import {
   changeLanguage,
   isSupportedLanguage,
   LANGUAGE_LABELS,
-  SUPPORTED_LANGUAGES,
 } from "../i18n/language";
+import { SUPPORTED_LANGUAGES } from "../i18n/supported-languages";
 import { analytics } from "../services/analytics";
 
 const LANGUAGE_OPTIONS = SUPPORTED_LANGUAGES.map((lang) => ({

--- a/src/data/whats-new.test.ts
+++ b/src/data/whats-new.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SUPPORTED_LANGUAGES } from "../i18n/language";
+import { SUPPORTED_LANGUAGES } from "../i18n/supported-languages";
 import { WHATS_NEW_ENTRIES } from "./whats-new";
 
 describe("WHATS_NEW_ENTRIES", () => {

--- a/src/data/whats-new.ts
+++ b/src/data/whats-new.ts
@@ -1,4 +1,4 @@
-import type { SupportedLanguage } from "../i18n/language";
+import type { SupportedLanguage } from "../i18n/supported-languages";
 
 /** Category of a changelog entry; surfaced as a localized badge on the page. */
 export type WhatsNewType = "stack" | "feature" | "fix";

--- a/src/i18n/language.test.ts
+++ b/src/i18n/language.test.ts
@@ -6,8 +6,8 @@ import {
   detectLanguage,
   isSupportedLanguage,
   LANGUAGE_CODES,
-  SUPPORTED_LANGUAGES,
 } from "./language";
+import { SUPPORTED_LANGUAGES } from "./supported-languages";
 
 vi.mock("i18next", () => ({
   default: {

--- a/src/i18n/language.ts
+++ b/src/i18n/language.ts
@@ -3,17 +3,10 @@ import { LANGUAGE_LSK, LOCALE_RELOAD_SSK } from "../constants";
 import { analytics } from "../services/analytics";
 import { includes } from "../utils/includes";
 import { isStaleChunkError } from "../utils/stale-chunk";
-
-export const SUPPORTED_LANGUAGES = [
-  "en",
-  "fr",
-  "es",
-  "de",
-  "it",
-  "nl",
-  "pt",
-] as const;
-export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+import {
+  SUPPORTED_LANGUAGES,
+  type SupportedLanguage,
+} from "./supported-languages";
 
 export const LANGUAGE_LABELS = {
   en: "English",

--- a/src/i18n/supported-languages.ts
+++ b/src/i18n/supported-languages.ts
@@ -1,0 +1,19 @@
+/**
+ * Canonical list of supported language codes and the type derived from it.
+ *
+ * This is a dependency-free leaf module: it imports nothing, so it can be pulled
+ * into a Node context (e.g. the `whats-new:draft` script, via the type chain
+ * `whats-new.ts` → here) without dragging in i18next, analytics, or any other
+ * browser-coupled runtime. `language.ts` imports both names; app consumers import them directly from this leaf.
+ */
+export const SUPPORTED_LANGUAGES = [
+  "en",
+  "fr",
+  "es",
+  "de",
+  "it",
+  "nl",
+  "pt",
+] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];

--- a/src/pages/whats-new/whats-new-entry-card.tsx
+++ b/src/pages/whats-new/whats-new-entry-card.tsx
@@ -1,7 +1,7 @@
 import { Badge, Card, Group, Stack, Text, Title } from "@mantine/core";
 import { useTranslation } from "react-i18next";
 import type { WhatsNewEntry, WhatsNewType } from "../../data/whats-new";
-import type { SupportedLanguage } from "../../i18n/language";
+import type { SupportedLanguage } from "../../i18n/supported-languages";
 import { formatReleaseDate } from "../../utils/format-release-date";
 
 const TYPE_LABEL_KEYS = {

--- a/src/utils/format-release-date.test.ts
+++ b/src/utils/format-release-date.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { SUPPORTED_LANGUAGES } from "../i18n/language";
+import { SUPPORTED_LANGUAGES } from "../i18n/supported-languages";
 import { formatReleaseDate } from "./format-release-date";
 
 // A fixed mid-year, mid-day instant. Assertions stay timezone-independent (no

--- a/src/utils/format-release-date.ts
+++ b/src/utils/format-release-date.ts
@@ -1,4 +1,4 @@
-import type { SupportedLanguage } from "../i18n/language";
+import type { SupportedLanguage } from "../i18n/supported-languages";
 
 /**
  * Formats an ISO 8601 instant as a localized date + time string. No `timeZone`

--- a/src/utils/whats-new-draft.test.ts
+++ b/src/utils/whats-new-draft.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { cleanCommitSubject } from "./whats-new-draft";
+
+describe("cleanCommitSubject", () => {
+  it("maps a feat commit to the feature badge and strips the prefix and PR ref", () => {
+    expect(cleanCommitSubject("feat: add neighbor mode (#5)")).toEqual({
+      type: "feature",
+      text: "add neighbor mode",
+    });
+  });
+
+  it("maps a fix commit to the fix badge", () => {
+    expect(
+      cleanCommitSubject(
+        "fix: deep-linked discovery sessions now record the preselected mode (#706)"
+      )
+    ).toEqual({
+      type: "fix",
+      text: "deep-linked discovery sessions now record the preselected mode",
+    });
+  });
+
+  it("parses a subject with no PR ref and trims trailing whitespace", () => {
+    expect(cleanCommitSubject("feat: add a thing  ")).toEqual({
+      type: "feature",
+      text: "add a thing",
+    });
+  });
+
+  it("strips a trailing PR ref followed by whitespace", () => {
+    expect(cleanCommitSubject("feat: a thing (#5) ")).toEqual({
+      type: "feature",
+      text: "a thing",
+    });
+  });
+
+  it("strips a scope from the prefix", () => {
+    expect(
+      cleanCommitSubject(
+        "feat(nav): add llms.txt footer link with i18n accessible label (#675)"
+      )
+    ).toEqual({
+      type: "feature",
+      text: "add llms.txt footer link with i18n accessible label",
+    });
+  });
+
+  it("strips doubled squash-merge PR suffixes", () => {
+    expect(
+      cleanCommitSubject(
+        'feat: What\'s New nav entry + automatic "New" badge (#713) (#719)'
+      )
+    ).toEqual({
+      type: "feature",
+      text: 'What\'s New nav entry + automatic "New" badge',
+    });
+  });
+
+  it("preserves non-issue parentheticals such as (foundation)", () => {
+    expect(
+      cleanCommitSubject(
+        "feat: What's New /whats-new/ changelog page (foundation) (#718)"
+      )
+    ).toEqual({
+      type: "feature",
+      text: "What's New /whats-new/ changelog page (foundation)",
+    });
+  });
+
+  it("tolerates a conventional-commit breaking-change marker", () => {
+    expect(cleanCommitSubject("feat!: drop the legacy API (#9)")).toEqual({
+      type: "feature",
+      text: "drop the legacy API",
+    });
+  });
+
+  it("strips a scope and breaking-change marker together", () => {
+    expect(cleanCommitSubject("fix(core)!: boom (#9)")).toEqual({
+      type: "fix",
+      text: "boom",
+    });
+  });
+
+  it("returns null for commit types other than feat/fix", () => {
+    expect(cleanCommitSubject("chore: bump knip to 6.16.0 (#711)")).toBeNull();
+    expect(
+      cleanCommitSubject("refactor(localstorage): tidy callbacks (#674)")
+    ).toBeNull();
+    expect(cleanCommitSubject("feature: x")).toBeNull();
+    expect(cleanCommitSubject("fixup: y")).toBeNull();
+  });
+
+  it("returns null when nothing meaningful remains after stripping", () => {
+    expect(cleanCommitSubject("feat: (#5)")).toBeNull();
+  });
+});

--- a/src/utils/whats-new-draft.ts
+++ b/src/utils/whats-new-draft.ts
@@ -1,0 +1,31 @@
+import type { WhatsNewType } from "../data/whats-new";
+
+// `feat`/`fix` with optional `(scope)` and `!`, then `:` and any following space.
+const PREFIX_RE = /^(feat|fix)(?:\([^)]*\))?!?:\s*/;
+// One or more trailing ` (#NNN)` issue/PR refs (incl. doubled squash suffixes like `(#713) (#719)`).
+const TRAILING_REFS_RE = /(?:\s*\(#\d+\))+\s*$/;
+
+/**
+ * Parses a conventional-commit subject into a draft "What's New" candidate. Strips the
+ * `feat`/`fix` prefix (with optional scope and `!`) plus any trailing `(#NNN)` issue/PR refs,
+ * then maps the kind to a `WhatsNewType` badge. Returns `null` for any other commit type, or
+ * when nothing meaningful remains after stripping. The output is a raw candidate — clean,
+ * translated prose is still composed by hand (entries are decoupled from commits).
+ */
+export const cleanCommitSubject = (
+  subject: string
+): { type: Exclude<WhatsNewType, "stack">; text: string } | null => {
+  const match = subject.match(PREFIX_RE);
+  if (!match) {
+    return null;
+  }
+  const type = match[1] === "feat" ? "feature" : "fix";
+  const text = subject
+    .slice(match[0].length)
+    .replace(TRAILING_REFS_RE, "")
+    .trim();
+  if (!text) {
+    return null;
+  }
+  return { type, text };
+};


### PR DESCRIPTION
## Summary

Adds `pnpm run whats-new:draft` — a **dev-only** helper that proposes clean draft changelog entries from `feat:`/`fix:` commits since the last entry, plus a paste-ready 7-language skeleton. It prints to stdout only; it never writes source and never ships untranslated text. The What's New epic (#717) keeps a curated, translated changelog in `src/data/whats-new.ts`; this removes the tedium of hand-finding and de-noising the relevant commits.

- **`src/utils/whats-new-draft.ts`** — pure `cleanCommitSubject()` parser (+ colocated tests). Strips the `feat`/`fix` prefix (optional scope and `!`) and trailing `(#NNN)` refs *including doubled squash suffixes* (`(#713) (#719)`); preserves non-issue parens like `(foundation)`. Returns `{ type: Exclude<WhatsNewType,"stack">, text } | null`.
- **`scripts/draft-whats-new.ts`** — `git log --since=<latest releasedAt>` → clean candidates + a paste-ready `WhatsNewEntry` skeleton (`releasedAt` from `%cI`, all 7 language keys, `en` prefilled).
- **`package.json`** — `"whats-new:draft": "node scripts/draft-whats-new.ts"`.

### Why the i18n changes (10 of the files)

Importing the changelog data into a **Node** context exposed a latent coupling: `src/data/whats-new.ts` type-imported `SupportedLanguage` from `src/i18n/language.ts`, which value-imports `analytics` (uses `import.meta.env`). That dragged `analytics`/`event-bus` into the node tsconfig project and broke `tsc -b`. Fix: `SUPPORTED_LANGUAGES` / `SupportedLanguage` are extracted into a **dependency-free leaf** `src/i18n/supported-languages.ts`; consumers import from it directly (a re-export from `language.ts` was rejected by Biome's `noBarrelFile`). Pure import-path moves — zero behavior change.

## Test plan

- Full DoD green: `typecheck`, `lint`, `knip`, `fta`, `test:coverage` (120 files / 2007 tests, per-dir ratchets enforced), `lint:e2e-no-wait`.
- `pnpm run test:e2e` — passes (one pre-existing flaky test in `error-scenarios.e2e.ts`, unrelated to this change, re-verified passing in isolation).
- `pnpm run whats-new:draft` exercised end-to-end: doubled `(#NNN)` suffixes stripped, `(foundation)` preserved, 7-language skeleton emitted.
- New util has 11 colocated unit tests covering both prefix arms, scope, doubled refs, `!` marker, near-miss-prefix rejection, and empty-after-strip → null.

Closes #715
Part of #717