### PR TITLE
fix: address audit findings — a11y, error-handling, types, and test coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ All memorized decks are centralized in `src/types/stacks.ts`:
 - **Pages**: Self-contained in `src/pages/` — each training mode is its own page. Stack-dependent pages are wrapped in `RequireStack`
 - **Components**: Reusable UI in `src/components/` (e.g., `CardSpread`, `StackPicker`, `NumberCard`, `ShareButton`, `ShareNudge`, `NavFooter`, `JsonLd`)
 - **Hooks**: Custom hooks in `src/hooks/` (e.g., `useSelectedStack`, `usePwaInstall`, `useDocumentMeta`)
-- **Utils**: Pure utility functions in `src/utils/` (e.g., `card-selection`, `card-formatting`, `format-release-date`, `localstorage`, `share`, `is-pwa`)
+- **Utils**: Utility functions in `src/utils/` (e.g., `card-selection`, `card-formatting`, `format-release-date`, `localstorage`, `share`, `is-pwa`) — mostly pure, though a few modules carry deliberate side effects (telemetry, persistence, notifications), e.g. `localstorage-telemetry`, `session-persistence`, `lazy-with-reload`
 - **Data**: Typed content modules in `src/data/` (e.g., `whats-new.ts` — the curated changelog; all 7 languages enforced at compile time via `Record<SupportedLanguage, string>`)
 - **Services**: `src/services/analytics.ts` — Google Analytics 4 integration with event tracking. Only initialized when `window.location.hostname === "memdeck.org"` — local dev, preview deployments, and e2e runs are **silent** (no GA events fired). Don't treat "GA didn't log locally" as a bug. Tracks flashcard/spot-check/ACAAN/distance answers, session completions, share actions, web vitals, and errors
 - **i18n**: `src/i18n/` — 7 languages (en, fr, es, de, it, nl, pt) using `react-i18next`. Locale files are lazy-loaded as separate chunks. Type-safe keys derived from the English locale

--- a/scripts/prerender.ts
+++ b/scripts/prerender.ts
@@ -83,47 +83,53 @@ try {
     // Update meta name="title"
     html = html.replace(
       /(<meta\s+name="title"\s+content=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.title}${p2}`
+      (_: string, p1: string, p2: string) => `${p1}${extracted.title}${p2}`
     );
 
     // Update meta name="description"
     html = html.replace(
       /(<meta\s+name="description"\s+content=")[\s\S]*?(")/,
-      (_, p1, p2) => `${p1}${extracted.description}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.description}${p2}`
     );
 
     // Update canonical link
     html = html.replace(
       /(<link\s+rel="canonical"\s+href=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.canonicalUrl}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.canonicalUrl}${p2}`
     );
 
     // Update OG tags
     html = html.replace(
       /(<meta\s+property="og:title"\s+content=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.title}${p2}`
+      (_: string, p1: string, p2: string) => `${p1}${extracted.title}${p2}`
     );
     html = html.replace(
       /(<meta\s+property="og:description"\s+content=")[\s\S]*?(")/,
-      (_, p1, p2) => `${p1}${extracted.description}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.description}${p2}`
     );
     html = html.replace(
       /(<meta\s+property="og:url"\s+content=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.canonicalUrl}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.canonicalUrl}${p2}`
     );
 
     // Update Twitter tags
     html = html.replace(
       /(<meta\s+name="twitter:title"\s+content=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.title}${p2}`
+      (_: string, p1: string, p2: string) => `${p1}${extracted.title}${p2}`
     );
     html = html.replace(
       /(<meta\s+name="twitter:description"\s+content=")[\s\S]*?(")/,
-      (_, p1, p2) => `${p1}${extracted.description}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.description}${p2}`
     );
     html = html.replace(
       /(<meta\s+name="twitter:url"\s+content=")[^"]*(")/,
-      (_, p1, p2) => `${p1}${extracted.canonicalUrl}${p2}`
+      (_: string, p1: string, p2: string) =>
+        `${p1}${extracted.canonicalUrl}${p2}`
     );
 
     // Write the pre-rendered HTML to the appropriate path

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -72,7 +72,7 @@ export const App = () => {
         <Header opened={opened} toggle={toggle} />
       </AppShell.Header>
 
-      <AppShell.Navbar id="main-nav" p="md">
+      <AppShell.Navbar id="main-nav" inert={!opened || undefined} p="md">
         <AppShell.Section component={ScrollArea} grow>
           <NavLinks onClick={closeMobile} />
         </AppShell.Section>

--- a/src/components/card-spread/card-spread.test.tsx
+++ b/src/components/card-spread/card-spread.test.tsx
@@ -144,13 +144,14 @@ describe("CardSpread", () => {
 
   describe("Keyboard navigation", () => {
     // The component tracks an `offset` value that shifts all cards visually.
-    // Each card receives a CSS custom property `--i` computed as:
-    //   index + 1 - (items.length / 2) + offset
+    // The offset is applied as a `--offset` CSS custom property on the
+    // CONTAINER (so each drag/keyboard step re-renders one node instead of
+    // all 52 buttons), while each card keeps a static `--i` computed as:
+    //   index + 1 - (items.length / 2)
+    // styles.css combines them: calc((var(--i) + var(--offset)) * ...).
     // ArrowRight increases offset by KEYBOARD_STEP (3), ArrowLeft decreases it.
     // maxOffset = items.length / 2. Using 6 cards: maxOffset = 3, KEYBOARD_STEP = 3.
-    // Initial offset = 0, so card[0] --i = 0 + 1 - 3 + 0 = -2.
-    // After ArrowRight: offset = 3, card[0] --i = 1.
-    // After ArrowLeft: offset = -3, card[0] --i = -5.
+    // Initial --offset = 0; card[0] --i = 0 + 1 - 3 = -2 and never changes.
 
     const sixUniqueCards = [
       AceOfHearts,
@@ -173,111 +174,109 @@ describe("CardSpread", () => {
     const getCssVar = (el: HTMLElement, name: string) =>
       el.style.getPropertyValue(name);
 
-    it("ArrowRight increases the offset, shifting card CSS positions forward", () => {
+    it("ArrowRight increases the container offset, leaving per-card --i static", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
       const firstCard = getFirstButton();
 
+      expect(getCssVar(group, "--offset")).toBe("0");
       expect(getCssVar(firstCard, "--i")).toBe("-2");
 
       fireEvent.keyDown(group, { key: "ArrowRight" });
 
-      expect(getCssVar(firstCard, "--i")).toBe("1");
+      expect(getCssVar(group, "--offset")).toBe("3");
+      expect(getCssVar(firstCard, "--i")).toBe("-2");
     });
 
-    it("ArrowLeft decreases the offset, shifting card CSS positions backward", () => {
+    it("ArrowLeft decreases the container offset, leaving per-card --i static", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
       const firstCard = getFirstButton();
 
+      expect(getCssVar(group, "--offset")).toBe("0");
       expect(getCssVar(firstCard, "--i")).toBe("-2");
 
       fireEvent.keyDown(group, { key: "ArrowLeft" });
 
-      expect(getCssVar(firstCard, "--i")).toBe("-5");
+      expect(getCssVar(group, "--offset")).toBe("-3");
+      expect(getCssVar(firstCard, "--i")).toBe("-2");
     });
 
     it("ArrowRight clamps at the maximum offset and stops changing", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
 
       // One press reaches maxOffset (3 === KEYBOARD_STEP for 6 cards).
       fireEvent.keyDown(group, { key: "ArrowRight" });
-      expect(getCssVar(firstCard, "--i")).toBe("1");
+      expect(getCssVar(group, "--offset")).toBe("3");
 
       // Additional presses should not change the value beyond the boundary.
       fireEvent.keyDown(group, { key: "ArrowRight" });
-      expect(getCssVar(firstCard, "--i")).toBe("1");
+      expect(getCssVar(group, "--offset")).toBe("3");
     });
 
     it("ArrowLeft clamps at the minimum offset and stops changing", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
 
       // One press reaches -maxOffset (-3 === -KEYBOARD_STEP for 6 cards).
       fireEvent.keyDown(group, { key: "ArrowLeft" });
-      expect(getCssVar(firstCard, "--i")).toBe("-5");
+      expect(getCssVar(group, "--offset")).toBe("-3");
 
       // Additional presses should not change the value beyond the boundary.
       fireEvent.keyDown(group, { key: "ArrowLeft" });
-      expect(getCssVar(firstCard, "--i")).toBe("-5");
+      expect(getCssVar(group, "--offset")).toBe("-3");
     });
 
     it("ArrowRight then ArrowLeft returns cards to their original positions", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
-      const initialValue = getCssVar(firstCard, "--i");
+      const initialValue = getCssVar(group, "--offset");
 
       fireEvent.keyDown(group, { key: "ArrowRight" });
       fireEvent.keyDown(group, { key: "ArrowLeft" });
 
-      expect(getCssVar(firstCard, "--i")).toBe(initialValue);
+      expect(getCssVar(group, "--offset")).toBe(initialValue);
     });
 
     it("when canMove=false, ArrowRight does not change card positions", () => {
       render(<CardSpread canMove={false} items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
-      const initialValue = getCssVar(firstCard, "--i");
+      const initialValue = getCssVar(group, "--offset");
 
       fireEvent.keyDown(group, { key: "ArrowRight" });
 
-      expect(getCssVar(firstCard, "--i")).toBe(initialValue);
+      expect(getCssVar(group, "--offset")).toBe(initialValue);
     });
 
     it("when canMove=false, ArrowLeft does not change card positions", () => {
       render(<CardSpread canMove={false} items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
-      const initialValue = getCssVar(firstCard, "--i");
+      const initialValue = getCssVar(group, "--offset");
 
       fireEvent.keyDown(group, { key: "ArrowLeft" });
 
-      expect(getCssVar(firstCard, "--i")).toBe(initialValue);
+      expect(getCssVar(group, "--offset")).toBe(initialValue);
     });
 
     it("unhandled keys such as Enter, Escape, and Tab do not change card positions", () => {
       render(<CardSpread items={cardItems(sixUniqueCards)} />);
 
       const group = screen.getByRole("group");
-      const firstCard = getFirstButton();
-      const initialValue = getCssVar(firstCard, "--i");
+      const initialValue = getCssVar(group, "--offset");
 
       fireEvent.keyDown(group, { key: "Enter" });
       fireEvent.keyDown(group, { key: "Escape" });
       fireEvent.keyDown(group, { key: "Tab" });
 
-      expect(getCssVar(firstCard, "--i")).toBe(initialValue);
+      expect(getCssVar(group, "--offset")).toBe(initialValue);
     });
   });
 

--- a/src/components/card-spread/card-spread.tsx
+++ b/src/components/card-spread/card-spread.tsx
@@ -1,6 +1,6 @@
 import { Flex, Image } from "@mantine/core";
 import type { KeyboardEvent } from "react";
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { SPREAD_CARD_HEIGHT, SPREAD_CARD_WIDTH } from "../../constants";
 import { useFormatCardName } from "../../hooks/use-format-card-name";
@@ -166,49 +166,62 @@ export const CardSpread = memo(function CardSpread(props: CardSpreadProps) {
 
   // Keys are position-based (not data-based) so that DOM buttons are reused
   // when switching between card and number items, preventing flicker.
-  const renderedItems =
-    items.type === "cards"
-      ? items.data.map((item, index) => (
-          <button
-            aria-label={formatCardName(item)}
-            className="cardSpreadCard"
-            data-card-index={index}
-            // biome-ignore lint/suspicious/noArrayIndexKey: Position-based keys prevent DOM flicker when switching card/number items
-            key={`spread_${index}`}
-            onClick={handleCardButtonClick}
-            style={{
-              cursor: hasCursor ? "pointer" : "default",
-              ...cssVarCounterStyle(index, items.data.length / 2, offset),
-            }}
-            type="button"
-          >
-            <Image
-              alt=""
-              h={SPREAD_CARD_HEIGHT}
-              src={item.image}
-              w={SPREAD_CARD_WIDTH}
-            />
-          </button>
-        ))
-      : items.data.map((item, index) => (
-          <button
-            aria-label={t("cardSpread.selectPositionAriaLabel", {
-              position: item,
-            })}
-            className="cardSpreadCard"
-            data-number-index={index}
-            // biome-ignore lint/suspicious/noArrayIndexKey: Position-based keys prevent DOM flicker when switching card/number items
-            key={`spread_${index}`}
-            onClick={handleNumberButtonClick}
-            style={{
-              cursor: hasCursor ? "pointer" : "default",
-              ...cssVarCounterStyle(index, items.data.length / 2, offset),
-            }}
-            type="button"
-          >
-            <NumberCard number={item} />
-          </button>
-        ));
+  // The drag/keyboard offset is applied as a container-level CSS variable
+  // (--offset, below), so per-item styles stay static and this memo keeps
+  // drag updates from re-rendering all 52 buttons.
+  const renderedItems = useMemo(
+    () =>
+      items.type === "cards"
+        ? items.data.map((item, index) => (
+            <button
+              aria-label={formatCardName(item)}
+              className="cardSpreadCard"
+              data-card-index={index}
+              // biome-ignore lint/suspicious/noArrayIndexKey: Position-based keys prevent DOM flicker when switching card/number items
+              key={`spread_${index}`}
+              onClick={handleCardButtonClick}
+              style={{
+                cursor: hasCursor ? "pointer" : "default",
+                ...cssVarCounterStyle(index, items.data.length / 2, 0),
+              }}
+              type="button"
+            >
+              <Image
+                alt=""
+                h={SPREAD_CARD_HEIGHT}
+                src={item.image}
+                w={SPREAD_CARD_WIDTH}
+              />
+            </button>
+          ))
+        : items.data.map((item, index) => (
+            <button
+              aria-label={t("cardSpread.selectPositionAriaLabel", {
+                position: item,
+              })}
+              className="cardSpreadCard"
+              data-number-index={index}
+              // biome-ignore lint/suspicious/noArrayIndexKey: Position-based keys prevent DOM flicker when switching card/number items
+              key={`spread_${index}`}
+              onClick={handleNumberButtonClick}
+              style={{
+                cursor: hasCursor ? "pointer" : "default",
+                ...cssVarCounterStyle(index, items.data.length / 2, 0),
+              }}
+              type="button"
+            >
+              <NumberCard number={item} />
+            </button>
+          )),
+    [
+      items,
+      hasCursor,
+      formatCardName,
+      t,
+      handleCardButtonClick,
+      handleNumberButtonClick,
+    ]
+  );
 
   return (
     <Flex
@@ -221,7 +234,7 @@ export const CardSpread = memo(function CardSpread(props: CardSpreadProps) {
       onMouseMove={handleMouseMove}
       onTouchMove={handleTouchMove}
       role="group"
-      style={{ "--degree": `${degree}deg` }}
+      style={{ "--degree": `${degree}deg`, "--offset": offset }}
     >
       {renderedItems}
     </Flex>

--- a/src/components/error-boundary.test.tsx
+++ b/src/components/error-boundary.test.tsx
@@ -1,0 +1,125 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type MockInstance,
+  vi,
+} from "vitest";
+import { render } from "../test-utils";
+import { ErrorBoundary } from "./error-boundary";
+
+const mockTrackError = vi.fn();
+vi.mock("../services/analytics", () => ({
+  analytics: {
+    trackError: (...args: unknown[]) => mockTrackError(...args),
+  },
+}));
+
+const Bomb = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error("boom");
+  }
+  return <div>recovered</div>;
+};
+
+const nonErrorValue: unknown = "string failure";
+
+const StringBomb = () => {
+  throw nonErrorValue;
+};
+
+describe("ErrorBoundary", () => {
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(() => {
+    mockTrackError.mockClear();
+    // React logs every caught render error; silence it to keep test output clean.
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {
+      // Intentionally empty
+    });
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders the fallback when a child throws an Error", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Something went wrong" })
+    ).toBeInTheDocument();
+  });
+
+  it("reports the thrown Error to analytics with the component stack", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(mockTrackError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.any(String)
+    );
+    const [errorArg] = mockTrackError.mock.calls[0];
+    expect(errorArg).toBeInstanceOf(Error);
+    if (errorArg instanceof Error) {
+      expect(errorArg.message).toBe("boom");
+    }
+  });
+
+  it("wraps a non-Error thrown value in an Error before reporting it", () => {
+    render(
+      <ErrorBoundary>
+        <StringBomb />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Something went wrong" })
+    ).toBeInTheDocument();
+    expect(mockTrackError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.any(String)
+    );
+    const [errorArg] = mockTrackError.mock.calls[0];
+    expect(errorArg).toBeInstanceOf(Error);
+    if (errorArg instanceof Error) {
+      expect(errorArg.message).toBe("string failure");
+    }
+  });
+
+  it("re-renders children when Try again is clicked", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Something went wrong" })
+    ).toBeInTheDocument();
+
+    rerender(
+      <ErrorBoundary>
+        <Bomb shouldThrow={false} />
+      </ErrorBoundary>
+    );
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("recovered")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Something went wrong" })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -18,7 +18,10 @@ type JsonLdData = Record<string, unknown> & {
  */
 export const JsonLd = ({ data }: { data: JsonLdData }) => {
   const ref = useRef<HTMLDivElement>(null);
-  const serialized = JSON.stringify(data);
+  // Escape "<" so prerendered HTML (which embeds this via innerHTML) cannot
+  // break out of the <script> element (e.g. a "</script>" inside a string).
+  // \u003c is a valid JSON escape, so parsers are unaffected.
+  const serialized = JSON.stringify(data).replaceAll("<", "\\u003c");
 
   useEffect(() => {
     const container = ref.current;

--- a/src/components/nav-links.tsx
+++ b/src/components/nav-links.tsx
@@ -12,7 +12,7 @@ import {
   IconSparkles,
   IconTools,
 } from "@tabler/icons-react";
-import { memo } from "react";
+import { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router";
 import { ROUTES } from "../constants";
@@ -26,6 +26,9 @@ export const NavLinks = memo(function NavLinks({
   const location = useLocation();
   const { t } = useTranslation();
   const { hasUnseen } = useUnseenWhatsNew();
+  // Controlled so aria-expanded can be set: Mantine NavLink only emits
+  // data-expanded, which screen readers don't announce.
+  const [toolsOpened, setToolsOpened] = useState(true);
 
   return (
     <>
@@ -90,10 +93,12 @@ export const NavLinks = memo(function NavLinks({
       />
 
       <NavLink
+        aria-expanded={toolsOpened}
         component="button"
-        defaultOpened
         label={t("nav.tools")}
         leftSection={<IconTools size={16} stroke={1.5} />}
+        onChange={setToolsOpened}
+        opened={toolsOpened}
       >
         <NavLink
           active={location.pathname === ROUTES.flashcard}

--- a/src/components/pwa-update-notifier.test.tsx
+++ b/src/components/pwa-update-notifier.test.tsx
@@ -3,13 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { RegisterSWOptions } from "vite-plugin-pwa/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  COMMIT_HASH_LSK,
-  PWA_UPDATE_COOLDOWN_MS,
-  PWA_UPDATE_TOAST_TIMEOUT,
-  UPDATE_NOTIFIED_AT_LSK,
-  WHATS_NEW_LAST_ANNOUNCED_LSK,
-} from "../constants";
+import { COMMIT_HASH_LSK, WHATS_NEW_LAST_ANNOUNCED_LSK } from "../constants";
 import { WHATS_NEW_ENTRIES } from "../data/whats-new";
 import { render as renderWithProviders } from "../test-utils";
 import { createMockLocalStorage } from "../test-utils/mock-local-storage";
@@ -81,7 +75,7 @@ describe("PwaUpdateNotifier", () => {
     expect(notifications.show).not.toHaveBeenCalled();
   });
 
-  it("shows a teal auto-closing toast when hash differs and a new entry is unannounced", () => {
+  it("shows a teal persistent toast when hash differs and a new entry is unannounced", () => {
     mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
     render(<PwaUpdateNotifier />);
 
@@ -90,51 +84,36 @@ describe("PwaUpdateNotifier", () => {
       expect.objectContaining({
         id: "pwa-update",
         color: "teal",
-        autoClose: PWA_UPDATE_TOAST_TIMEOUT,
+        autoClose: false,
         title: "Updated",
         withCloseButton: true,
       })
     );
   });
 
-  it("updates stored hash and timestamp after showing toast", () => {
-    const now = 1_700_000_000_000;
-    vi.spyOn(Date, "now").mockReturnValue(now);
+  it("updates the stored hash after showing the toast", () => {
     mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
 
     render(<PwaUpdateNotifier />);
 
     expect(mockLocalStorage.getItem(COMMIT_HASH_LSK)).toBe("abc1234");
-    expect(mockLocalStorage.getItem(UPDATE_NOTIFIED_AT_LSK)).toBe(String(now));
   });
 
-  it("does not show a toast when within 24h cooldown", () => {
-    const now = 1_700_000_000_000;
-    vi.spyOn(Date, "now").mockReturnValue(now);
-    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
-    mockLocalStorage.setItem(
-      UPDATE_NOTIFIED_AT_LSK,
-      String(now - PWA_UPDATE_COOLDOWN_MS + 1000)
-    );
+  it("announces and tracks back-to-back updates without a cooldown", () => {
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash_1");
+    const { unmount } = render(<PwaUpdateNotifier />);
 
+    expect(notifications.show).toHaveBeenCalledTimes(1);
+    expect(mockTrackFeatureUsed).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // A second update applied right after: telemetry fires again, but the gate
+    // keeps the toast silent because the latest entry is already announced.
+    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash_2");
     render(<PwaUpdateNotifier />);
 
-    expect(notifications.show).not.toHaveBeenCalled();
-    expect(mockLocalStorage.getItem(COMMIT_HASH_LSK)).toBe("abc1234");
-  });
-
-  it("shows a toast when cooldown has expired (25h ago)", () => {
-    const now = 1_700_000_000_000;
-    vi.spyOn(Date, "now").mockReturnValue(now);
-    mockLocalStorage.setItem(COMMIT_HASH_LSK, "old_hash");
-    mockLocalStorage.setItem(
-      UPDATE_NOTIFIED_AT_LSK,
-      String(now - PWA_UPDATE_COOLDOWN_MS - 3_600_000)
-    );
-
-    render(<PwaUpdateNotifier />);
-
-    expect(notifications.show).toHaveBeenCalledOnce();
+    expect(mockTrackFeatureUsed).toHaveBeenCalledTimes(2);
+    expect(notifications.show).toHaveBeenCalledTimes(1);
   });
 
   it("tracks 'PWA Update Applied' analytics event", () => {

--- a/src/components/pwa-update-notifier.tsx
+++ b/src/components/pwa-update-notifier.tsx
@@ -6,10 +6,7 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router";
 import {
   COMMIT_HASH_LSK,
-  PWA_UPDATE_COOLDOWN_MS,
-  PWA_UPDATE_TOAST_TIMEOUT,
   ROUTES,
-  UPDATE_NOTIFIED_AT_LSK,
   WHATS_NEW_LAST_ANNOUNCED_LSK,
 } from "../constants";
 import { WHATS_NEW_ENTRIES } from "../data/whats-new";
@@ -110,16 +107,7 @@ export const PwaUpdateNotifier = () => {
 
     safeSetItem(COMMIT_HASH_LSK, __COMMIT_HASH__);
 
-    const lastNotified = safeGetItem(UPDATE_NOTIFIED_AT_LSK);
-    if (lastNotified) {
-      const elapsed = Date.now() - Number(lastNotified);
-      if (elapsed < PWA_UPDATE_COOLDOWN_MS) {
-        return;
-      }
-    }
-
-    safeSetItem(UPDATE_NOTIFIED_AT_LSK, String(Date.now()));
-    // Telemetry stays above the What's New gate below: every applied update is
+    // Telemetry stays above the What's New gate: every applied update is
     // tracked, even when the toast stays silent because nothing new shipped.
     analytics.trackFeatureUsed("PWA Update Applied");
 
@@ -135,7 +123,9 @@ export const PwaUpdateNotifier = () => {
     notifications.show({
       id: PWA_UPDATE_TOAST_ID,
       color: "teal",
-      autoClose: PWA_UPDATE_TOAST_TIMEOUT,
+      // Persistent (WCAG 2.2.1): the toast holds a link keyboard/SR users may
+      // not reach within an auto-close window; the close button dismisses it.
+      autoClose: false,
       title: t("pwaUpdate.title"),
       message: (
         <>

--- a/src/components/require-stack.test.tsx
+++ b/src/components/require-stack.test.tsx
@@ -1,0 +1,57 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ROUTES } from "../constants";
+import { render } from "../test-utils";
+import { RequireStack } from "./require-stack";
+
+const mockUseSelectedStack = vi.fn();
+vi.mock("../hooks/use-selected-stack", () => ({
+  useSelectedStack: () => mockUseSelectedStack(),
+}));
+
+const DESCRIPTION_KEY = "flashcard.pageDescription";
+const DESCRIPTION_TEXT =
+  "Practice your memorized deck with interactive flashcard drills. Train card-to-number, number-to-card, or both.";
+const NO_STACK_TEXT = "Pick a stack on the homepage to get started.";
+
+describe("RequireStack", () => {
+  it("renders children when a stack is selected", () => {
+    mockUseSelectedStack.mockReturnValue({ stackKey: "mnemonica" });
+
+    render(
+      <RequireStack descriptionKey={DESCRIPTION_KEY}>
+        <div>protected content</div>
+      </RequireStack>
+    );
+
+    expect(screen.getByText("protected content")).toBeInTheDocument();
+    expect(screen.queryByText(NO_STACK_TEXT)).not.toBeInTheDocument();
+  });
+
+  it("renders the no-stack message instead of children when no stack is selected", () => {
+    mockUseSelectedStack.mockReturnValue({ stackKey: "" });
+
+    render(
+      <RequireStack descriptionKey={DESCRIPTION_KEY}>
+        <div>protected content</div>
+      </RequireStack>
+    );
+
+    expect(screen.queryByText("protected content")).not.toBeInTheDocument();
+    expect(screen.getByText(NO_STACK_TEXT)).toBeInTheDocument();
+    expect(screen.getByText(DESCRIPTION_TEXT)).toBeInTheDocument();
+  });
+
+  it("links to the homepage when no stack is selected", () => {
+    mockUseSelectedStack.mockReturnValue({ stackKey: "" });
+
+    render(
+      <RequireStack descriptionKey={DESCRIPTION_KEY}>
+        <div>protected content</div>
+      </RequireStack>
+    );
+
+    const link = screen.getByRole("link", { name: "Go to homepage" });
+    expect(link).toHaveAttribute("href", ROUTES.home);
+  });
+});

--- a/src/components/timer-display.tsx
+++ b/src/components/timer-display.tsx
@@ -5,6 +5,15 @@ import { calculateTimerProgress, getTimerColor } from "../utils/timer";
 
 const TIMER_MAX_WIDTH = 300;
 
+// Darker text shades for the urgent states: the default yellow-6/red-6 fail
+// WCAG 1.4.3 contrast on a light background exactly when time is short.
+const TIMER_TEXT_COLORS: Record<string, string> = {
+  // No Mantine yellow shade reaches 4.5:1 on white (yellow-9 is ~3:1), so the
+  // light side uses a custom dark amber (#996300 ≈ 4.9:1 on white).
+  yellow: "light-dark(#996300, var(--mantine-color-yellow-4))",
+  red: "light-dark(var(--mantine-color-red-9), var(--mantine-color-red-4))",
+};
+
 type TimerDisplayProps = {
   timeRemaining: number;
   timerDuration: number;
@@ -21,6 +30,7 @@ export const TimerDisplay = memo(function TimerDisplay({
 }: TimerDisplayProps) {
   const timerProgress = calculateTimerProgress(timeRemaining, timerDuration);
   const timerColor = getTimerColor(timeRemaining);
+  const timerTextColor = TIMER_TEXT_COLORS[timerColor] ?? timerColor;
   const { t } = useTranslation();
   const isUrgent = timeRemaining === 5 || timeRemaining === 1;
 
@@ -29,10 +39,10 @@ export const TimerDisplay = memo(function TimerDisplay({
       <Center>
         <div style={{ width: "100%", maxWidth: TIMER_MAX_WIDTH }}>
           <Group gap="xs" justify="space-between">
-            <Text c={timerColor} fw={500} size="sm">
+            <Text c={timerTextColor} fw={500} size="sm">
               {t("timer.timeRemaining")}
             </Text>
-            <Text c={timerColor} fw={700} size="lg">
+            <Text c={timerTextColor} fw={700} size="lg">
               {timeRemaining}s
             </Text>
           </Group>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,15 +69,6 @@ export const LOCALE_RELOAD_SSK = "memdeck-locale-reload";
 export const LAST_SAVE_FAILED_SHOWN_SSK = "memdeck-app-last-save-failed-shown";
 
 export const COMMIT_HASH_LSK = "memdeck-app-commit-hash";
-export const UPDATE_NOTIFIED_AT_LSK = "memdeck-app-update-notified-at";
-export const PWA_UPDATE_COOLDOWN_MS = 24 * 60 * 60 * 1000;
-/**
- * Toast visible duration. 10s (not 5s) so keyboard and screen-reader users have
- * time to reach the toast's "See What's New" link before it auto-closes — Mantine
- * pauses autoClose on hover but not on focus.
- */
-export const PWA_UPDATE_TOAST_TIMEOUT = 10_000;
-
 export const PWA_INSTALL_DISMISSED_AT_LSK =
   "memdeck-app-pwa-install-dismissed-at";
 export const PWA_INSTALL_PERMANENTLY_DISMISSED_LSK =

--- a/src/hooks/use-card-image-preload.test.ts
+++ b/src/hooks/use-card-image-preload.test.ts
@@ -1,0 +1,109 @@
+import { cleanup, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ALL_CARDS } from "../types/playingcard";
+import { useCardImagePreload } from "./use-card-image-preload";
+
+// Instances created by the hook's `new Image()` calls, in creation order.
+let createdImages: FakeImage[] = [];
+
+class FakeImage {
+  src = "";
+  constructor() {
+    createdImages.push(this);
+  }
+}
+
+let capturedIdleCallback: (() => void) | null = null;
+
+const requestIdleCallbackMock = vi.fn((callback: () => void): number => {
+  capturedIdleCallback = callback;
+  return 42;
+});
+
+const cancelIdleCallbackMock = vi.fn();
+
+const stubIdleCallbacks = (): void => {
+  vi.stubGlobal("requestIdleCallback", requestIdleCallbackMock);
+  vi.stubGlobal("cancelIdleCallback", cancelIdleCallbackMock);
+};
+
+// Drive the hook's setTimeout fallback branch. `stubGlobal` first so
+// `unstubAllGlobals` restores any native happy-dom implementation, then
+// delete the property so the hook's `"requestIdleCallback" in window`
+// check is false (a stubbed `undefined` value would still pass `in`).
+const removeRequestIdleCallback = (): void => {
+  vi.stubGlobal("requestIdleCallback", undefined);
+  Reflect.deleteProperty(window, "requestIdleCallback");
+};
+
+afterEach(() => {
+  // Unmount before unstubbing so the hook's effect cleanup still sees the
+  // stubbed cancelIdleCallback/clearTimeout globals it captured.
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  createdImages = [];
+  capturedIdleCallback = null;
+});
+
+describe("useCardImagePreload", () => {
+  it("preloads all 52 card images when the idle callback runs", () => {
+    stubIdleCallbacks();
+    vi.stubGlobal("Image", FakeImage);
+
+    renderHook(() => useCardImagePreload());
+
+    expect(requestIdleCallbackMock).toHaveBeenCalledTimes(1);
+    // Nothing is fetched until the browser grants idle time.
+    expect(createdImages).toHaveLength(0);
+
+    capturedIdleCallback?.();
+
+    expect(createdImages).toHaveLength(52);
+    expect(createdImages.map((img) => img.src)).toEqual(
+      ALL_CARDS.map((card) => card.image)
+    );
+  });
+
+  it("falls back to setTimeout when requestIdleCallback is unavailable", () => {
+    removeRequestIdleCallback();
+    vi.stubGlobal("Image", FakeImage);
+    vi.useFakeTimers();
+
+    renderHook(() => useCardImagePreload());
+
+    expect(createdImages).toHaveLength(0);
+
+    vi.advanceTimersByTime(1);
+
+    expect(createdImages).toHaveLength(52);
+    expect(createdImages.map((img) => img.src)).toEqual(
+      ALL_CARDS.map((card) => card.image)
+    );
+  });
+
+  it("cancels the pending idle callback on unmount before preload runs", () => {
+    stubIdleCallbacks();
+    vi.stubGlobal("Image", FakeImage);
+
+    const { unmount } = renderHook(() => useCardImagePreload());
+    unmount();
+
+    expect(cancelIdleCallbackMock).toHaveBeenCalledWith(42);
+    expect(createdImages).toHaveLength(0);
+  });
+
+  it("clears the pending timeout on unmount before preload runs", () => {
+    removeRequestIdleCallback();
+    vi.stubGlobal("Image", FakeImage);
+    vi.useFakeTimers();
+
+    const { unmount } = renderHook(() => useCardImagePreload());
+    unmount();
+
+    vi.advanceTimersByTime(10);
+
+    expect(createdImages).toHaveLength(0);
+  });
+});

--- a/src/hooks/use-pwa-install.test.ts
+++ b/src/hooks/use-pwa-install.test.ts
@@ -125,14 +125,11 @@ describe("usePwaInstall", () => {
     expect(nativeUsed).toBe(false);
   });
 
-  it("install rejection re-enables eligibility and restores deferredPromptRef so a second install attempt can succeed", async () => {
+  it("install rejection does not restore the consumed prompt — prompt() may only be called once per event", async () => {
     withSession();
     const { result } = renderHook(() => usePwaInstall());
 
-    const firstPrompt = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("User cancelled"))
-      .mockResolvedValueOnce(undefined);
+    const firstPrompt = vi.fn().mockRejectedValue(new Error("User cancelled"));
     const event = new Event("beforeinstallprompt", { cancelable: true });
     Object.defineProperty(event, "prompt", { value: firstPrompt });
     window.dispatchEvent(event);
@@ -145,16 +142,15 @@ describe("usePwaInstall", () => {
       await Promise.resolve();
     });
     expect(firstCall).toBe(true);
-    expect(result.current.eligible).toBe(true);
+    expect(result.current.eligible).toBe(false);
 
-    let secondCall = false;
+    let secondCall = true;
     await act(async () => {
       secondCall = result.current.install();
       await Promise.resolve();
     });
-    expect(secondCall).toBe(true);
-    expect(firstPrompt).toHaveBeenCalledTimes(2);
-    expect(result.current.eligible).toBe(false);
+    expect(secondCall).toBe(false);
+    expect(firstPrompt).toHaveBeenCalledTimes(1);
   });
 
   it("install rejection forwards a wrapped error with name PwaInstallPromptRejected to analytics.trackError", async () => {
@@ -192,6 +188,16 @@ describe("usePwaInstall", () => {
     expect(mockLocalStorage.getItem(PWA_INSTALL_DISMISSED_AT_LSK)).toBe(
       String(now)
     );
+    expect(result.current.eligible).toBe(false);
+  });
+
+  it("resets eligibility when the viewport leaves the mobile breakpoint", () => {
+    withSession();
+    const { result, rerender } = renderHook(() => usePwaInstall());
+    expect(result.current.eligible).toBe(true);
+
+    mockIsMobile = false;
+    rerender();
     expect(result.current.eligible).toBe(false);
   });
 

--- a/src/hooks/use-pwa-install.ts
+++ b/src/hooks/use-pwa-install.ts
@@ -79,22 +79,16 @@ export const usePwaInstall = (): UsePwaInstallResult => {
   }, []);
 
   useEffect(() => {
-    if (runningAsPwa || !isMobile) {
-      return;
-    }
-    if (!hasCompletedSession()) {
-      return;
-    }
-    if (permanentlyDismissed) {
-      return;
-    }
-    if (
+    const cooldownActive =
       dismissedAt !== null &&
-      Date.now() - dismissedAt < PWA_INSTALL_COOLDOWN_MS
-    ) {
-      return;
-    }
-    setEligible(true);
+      Date.now() - dismissedAt < PWA_INSTALL_COOLDOWN_MS;
+    const isEligible =
+      !runningAsPwa &&
+      isMobile === true &&
+      hasCompletedSession() &&
+      !permanentlyDismissed &&
+      !cooldownActive;
+    setEligible(isEligible);
   }, [runningAsPwa, isMobile, permanentlyDismissed, dismissedAt]);
 
   const install = useCallback((): boolean => {
@@ -104,14 +98,15 @@ export const usePwaInstall = (): UsePwaInstallResult => {
     }
     deferredPromptRef.current = null;
     setEligible(false);
-    // Handle rejection without changing the sync return signature: restore
-    // the ref + eligibility so the user can retry, and emit telemetry. The
-    // returned promise from prompt() is intentionally fire-and-forget after
-    // the catch handler — callers only care whether the native flow was
-    // *initiated* synchronously.
+    // Handle rejection without changing the sync return signature: emit
+    // telemetry once and leave the ref empty — prompt() may only be called
+    // once per BeforeInstallPromptEvent, so restoring the consumed event
+    // would make every retry reject again. A fresh beforeinstallprompt
+    // event (captured by the listener above) re-enables the native flow.
+    // The returned promise from prompt() is intentionally fire-and-forget
+    // after the catch handler — callers only care whether the native flow
+    // was *initiated* synchronously.
     event.prompt().catch((error: unknown) => {
-      deferredPromptRef.current = event;
-      setEligible(true);
       const wrapped =
         error instanceof Error
           ? new Error(error.message, { cause: error })

--- a/src/hooks/use-session.test.ts
+++ b/src/hooks/use-session.test.ts
@@ -1038,6 +1038,102 @@ describe("useSession hook", () => {
   });
 
   // -----------------------------------------------------------------------
+  // startSession — prior-session auto-save failure surfacing
+  // -----------------------------------------------------------------------
+
+  describe("startSession — prior-session auto-save failure surfacing", () => {
+    /** Start an open session and answer 3 questions so it meets the save threshold. */
+    const runSessionPastSaveThreshold = (result: {
+      current: ReturnType<typeof useSession>;
+    }) => {
+      act(() => {
+        result.current.startSession({ type: "open" });
+      });
+      for (let i = 0; i < 3; i++) {
+        act(() => {
+          result.current.handleAnswer({
+            correct: true,
+            questionAdvanced: true,
+          });
+        });
+      }
+    };
+
+    it("shows the yellow save-failed notification and reports analytics when auto-saving the prior session fails with write-failed", () => {
+      const { result } = renderHook(() =>
+        useSession({ mode: "flashcard", stackKey: "mnemonica" })
+      );
+
+      runSessionPastSaveThreshold(result);
+
+      // The SECOND startSession auto-saves the prior active session; force
+      // that finalize to fail.
+      mockFinalizeSession.mockReturnValueOnce({
+        ok: false,
+        reason: "write-failed",
+      });
+      act(() => {
+        result.current.startSession({ type: "open" });
+      });
+
+      expect(mockTrackError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "LocalDbWriteFailed",
+          message: "reason=write-failed",
+        }),
+        "useSession:startSession"
+      );
+      // Unlike the flush effect's red toast, the auto-save path uses yellow
+      // for recoverable reasons — the prior session is dropped either way
+      // (the new one replaces it), so there is no retry to invite.
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: "yellow",
+          title: "errors.sessionSaveFailed.title",
+          message: "errors.sessionSaveFailed.message",
+        })
+      );
+      // The failure must not block the new session from starting.
+      const { status } = result.current;
+      assertPhase(status, "active");
+      expect(status.session.questionsCompleted).toBe(0);
+    });
+
+    it("shows the red corrupt-storage notification when auto-saving the prior session fails with corrupt", () => {
+      const { result } = renderHook(() =>
+        useSession({ mode: "flashcard", stackKey: "mnemonica" })
+      );
+
+      runSessionPastSaveThreshold(result);
+
+      mockFinalizeSession.mockReturnValueOnce({
+        ok: false,
+        reason: "corrupt",
+      });
+      act(() => {
+        result.current.startSession({ type: "open" });
+      });
+
+      // corrupt = two failed writes (stats write + history rollback), so it
+      // lands in the LocalDbWriteFailed bucket — same as the flush path.
+      expect(mockTrackError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "LocalDbWriteFailed",
+          message: "reason=corrupt",
+        }),
+        "useSession:startSession"
+      );
+      expect(mockNotificationsShow).toHaveBeenCalledWith(
+        expect.objectContaining({
+          color: "red",
+          title: "errors.sessionStorageCorrupt.title",
+          message: "errors.sessionStorageCorrupt.message",
+        })
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
   // last-save-failed breadcrumb on mount
   // -----------------------------------------------------------------------
 

--- a/src/hooks/use-session.ts
+++ b/src/hooks/use-session.ts
@@ -37,6 +37,32 @@ import { useSessionRecording } from "./use-session-recording";
 
 export type { SessionPhase } from "../types/session";
 
+// Surface a write failure when auto-saving the previous session: the prior
+// session is dropped either way (the new one replaces it), so a silent failure
+// here skipped both telemetry and the toast. Extracted to keep startSession
+// under the cognitive-complexity ceiling.
+const reportPriorSessionFinalizeFailure = (
+  reason: FinalizeFailureReason,
+  t: ReturnType<typeof useTranslation>["t"]
+) => {
+  reportSessionPersistenceFailed(reason, "useSession:startSession");
+  const isUnrecoverable =
+    reason === "corrupt" || reason === "corrupt-prior-state";
+  notifications.show({
+    color: isUnrecoverable ? "red" : "yellow",
+    title: t(
+      isUnrecoverable
+        ? "errors.sessionStorageCorrupt.title"
+        : "errors.sessionSaveFailed.title"
+    ),
+    message: t(
+      isUnrecoverable
+        ? "errors.sessionStorageCorrupt.message"
+        : "errors.sessionSaveFailed.message"
+    ),
+  });
+};
+
 type UseSessionOptionsBase = {
   stackKey: StackKey;
   autoStart?: boolean;
@@ -339,11 +365,18 @@ export const useSession = (options: UseSessionOptions): UseSessionResult => {
 
   const startSession = useCallback(
     (config: SessionConfig) => {
-      // Auto-save current active session if it meets minimum threshold
+      // Auto-save current active session if it meets minimum threshold.
+      // The previous session is dropped either way (the new one replaces it),
+      // so a write failure must be surfaced here — mirrors the reporting +
+      // toast pattern of the flush effect and useSessionAutoSave's cleanup
+      // path; silently discarding the result skipped both.
       if (statusRef.current.phase === "active") {
         const { session } = statusRef.current;
         if (meetsMinimumSaveThreshold(session)) {
-          tryFinalizeSession(session);
+          const result = tryFinalizeSession(session);
+          if (result.status === "write-failed") {
+            reportPriorSessionFinalizeFailure(result.reason, tRef.current);
+          }
         }
       }
 

--- a/src/hooks/use-stack-limits.test.ts
+++ b/src/hooks/use-stack-limits.test.ts
@@ -26,6 +26,13 @@ const mockSetValue = vi.fn(
 );
 const mockProbeStoredValue = vi.fn();
 const mockEmitStackLimitsChanged = vi.fn();
+const mockNotificationsShow = vi.fn();
+
+vi.mock("@mantine/notifications", () => ({
+  notifications: {
+    show: (...args: unknown[]) => mockNotificationsShow(...args),
+  },
+}));
 
 vi.mock("../utils/localstorage", () => ({
   useLocalDb: vi.fn((_, defaultValue) => [defaultValue, mockSetValue, vi.fn()]),
@@ -257,6 +264,45 @@ describe("useStackLimits", () => {
       rangeSize: 21,
       stackName: stacks[stackKey].name,
     });
+  });
+
+  it("re-shows the id-deduped corruption notice when the corrupt-lock refuses a write", () => {
+    mockProbeStoredValue.mockReturnValue({
+      status: "corrupt",
+      raw: "garbage",
+    });
+
+    const { result } = renderHook(() => useStackLimits("mnemonica"));
+
+    // The mount effect shows the notice once with the dedupe id.
+    expect(mockNotificationsShow).toHaveBeenCalledTimes(1);
+    expect(mockNotificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "stack-limits-corrupt" })
+    );
+    mockNotificationsShow.mockClear();
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockNotificationsShow).toHaveBeenCalledTimes(1);
+    expect(mockNotificationsShow).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "stack-limits-corrupt" })
+    );
+  });
+
+  it("does not show the corruption notice when the stored blob is valid or absent", () => {
+    mockProbeStoredValue.mockReturnValue({ status: "absent" });
+
+    const { result } = renderHook(() => useStackLimits("mnemonica"));
+
+    result.current.setLimits({
+      start: createDeckPosition(5),
+      end: createDeckPosition(25),
+    });
+
+    expect(mockNotificationsShow).not.toHaveBeenCalled();
   });
 
   it("does not emit STACK_LIMITS_CHANGED when the corrupt-lock blocks the write", () => {

--- a/src/hooks/use-stack-limits.ts
+++ b/src/hooks/use-stack-limits.ts
@@ -32,6 +32,7 @@ type UseStackLimitsResult = {
 // and the next `setLimits` call would merge into `{}`, silently destroying
 // every other stack's saved range. Splitting into per-stack keys would
 // require a migration touching consumers outside this hook's ownership.
+const STACK_LIMITS_CORRUPT_NOTIFICATION_ID = "stack-limits-corrupt";
 export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
   const { t } = useTranslation();
   const tRef = useRef(t);
@@ -49,31 +50,29 @@ export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
 
   // Probe once on mount; if the stored blob is corrupt, lock writes for the
   // lifetime of this hook instance so we don't overwrite recoverable data.
+  // The probe (localStorage I/O), analytics emit, and Mantine notification
+  // are side effects, so they run in a mount-only effect rather than during
+  // render — `handleSetLimits` only fires from event handlers, which can't
+  // run before mount effects, so the lock is always set before any possible
+  // write. The null-latch keeps the effect idempotent under StrictMode
+  // double-invoke.
   const corruptRef = useRef<boolean | null>(null);
-  if (corruptRef.current === null) {
+  useEffect(() => {
+    if (corruptRef.current !== null) {
+      return;
+    }
     const probe = probeStoredValue(STACK_LIMITS_LSK, isStackLimitsRecord);
     const corrupt = probe.status === "corrupt" || probe.status === "read-error";
     corruptRef.current = corrupt;
     if (corrupt) {
       analytics.trackError(new Error("stackLimits-corrupt"));
+      notifications.show({
+        id: STACK_LIMITS_CORRUPT_NOTIFICATION_ID,
+        color: "red",
+        title: tRef.current("errors.stackLimitsCorrupt.title"),
+        message: tRef.current("errors.stackLimitsCorrupt.message"),
+      });
     }
-  }
-
-  // Surface the corruption to the user via a Mantine notification once on
-  // mount. Side-effects can't run during render, so the visual notice is
-  // deferred to a mount-only effect. The latch ref also keeps it idempotent
-  // under StrictMode double-invoke.
-  const corruptNoticeShownRef = useRef(false);
-  useEffect(() => {
-    if (corruptRef.current !== true || corruptNoticeShownRef.current) {
-      return;
-    }
-    corruptNoticeShownRef.current = true;
-    notifications.show({
-      color: "red",
-      title: tRef.current("errors.stackLimitsCorrupt.title"),
-      message: tRef.current("errors.stackLimitsCorrupt.message"),
-    });
   }, []);
 
   const rawStart = record[stackKey]?.start;
@@ -92,9 +91,16 @@ export const useStackLimits = (stackKey: StackKey): UseStackLimitsResult => {
   const handleSetLimits = useCallback(
     (newLimits: StackLimits): void => {
       // Refuse to overwrite a corrupt blob — preserves any other stacks'
-      // ranges that may still be recoverable manually. The user has already
-      // been notified of the corruption via the mount-effect toast.
+      // ranges that may still be recoverable manually. Re-show the
+      // corruption notice (id-deduped by Mantine) so each refused write
+      // reminds the user why the control is inert.
       if (corruptRef.current === true) {
+        notifications.show({
+          id: STACK_LIMITS_CORRUPT_NOTIFICATION_ID,
+          color: "red",
+          title: tRef.current("errors.stackLimitsCorrupt.title"),
+          message: tRef.current("errors.stackLimitsCorrupt.message"),
+        });
         return;
       }
       setRecord(

--- a/src/pages/acaan/acaan.test.tsx
+++ b/src/pages/acaan/acaan.test.tsx
@@ -1,0 +1,191 @@
+import { MantineProvider } from "@mantine/core";
+import { render, waitFor } from "@testing-library/react";
+import { type ReactNode, useEffect, useState } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ROUTES } from "../../constants";
+import { stacks } from "../../types/stacks";
+
+// Capture every useSession invocation so tests can assert how the page gates
+// autoStart while a deep-link param is pending.
+type CapturedSessionOpts = { autoStart: boolean };
+let capturedSessionCalls: CapturedSessionOpts[] = [];
+
+vi.mock("../../hooks/use-session", () => ({
+  useSession: (options: CapturedSessionOpts) => {
+    capturedSessionCalls.push(options);
+    return {
+      status: { phase: "idle" },
+      startSession: vi.fn(),
+      handleAnswer: vi.fn(),
+      startNewSession: vi.fn(),
+      isStructuredSession: false,
+      activeSession: null,
+      stopSession: vi.fn(),
+      dismissSummary: vi.fn(),
+    };
+  },
+}));
+
+// Captured settings setter — ACAAN has no ?try variants, so ?timed=1 applying
+// through this existing setter is the page's whole deep-link surface.
+const handleTimerEnabledChange = vi.fn();
+
+vi.mock("./use-acaan-settings", () => ({
+  useAcaanSettings: () => ({
+    timerSettings: { enabled: false, duration: 15 },
+    setTimerDuration: vi.fn(),
+    handleTimerEnabledChange,
+  }),
+}));
+
+vi.mock("./use-acaan-game", () => ({
+  useAcaanGame: () => ({
+    scenario: {
+      card: stacks.mnemonica.order[0],
+      targetPosition: 10,
+      cutDepth: 6,
+    },
+    score: { successes: 0, fails: 0 },
+    timeRemaining: 15,
+    timerDuration: 15,
+    submitAnswer: vi.fn(),
+    revealAnswer: vi.fn(),
+  }),
+}));
+
+vi.mock("./use-cut-depth-input", () => ({
+  useCutDepthInput: () => ({
+    cutDepth: "",
+    maxCutDepth: 51,
+    handleCutDepthChange: vi.fn(),
+    handleCheckAnswer: vi.fn(),
+    handleKeyDown: vi.fn(),
+  }),
+}));
+
+vi.mock("@mantine/notifications", () => ({
+  notifications: { show: vi.fn() },
+}));
+
+vi.mock("../../services/event-bus", () => ({
+  eventBus: {
+    emit: {
+      ACAAN_ANSWER: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../services/analytics", () => ({
+  analytics: {
+    trackEvent: vi.fn(),
+    trackFeatureUsed: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks/use-document-meta", () => ({
+  useDocumentMeta: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-card-image-preload", () => ({
+  useCardImagePreload: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-selected-stack", () => ({
+  useRequiredStack: () => ({
+    stackKey: "mnemonica",
+    stack: stacks.mnemonica,
+    stackOrder: stacks.mnemonica.order,
+    stackName: stacks.mnemonica.name,
+  }),
+}));
+
+// Stub the heavy children so the tests only exercise the page's deep-link
+// wiring.
+vi.mock("../../components/training-header", () => ({
+  TrainingHeader: () => null,
+}));
+vi.mock("../../components/session-summary-modal", () => ({
+  SessionSummaryModal: () => null,
+}));
+vi.mock("../../components/reveal-button", () => ({
+  RevealButton: () => null,
+}));
+vi.mock("../../components/json-ld", () => ({
+  JsonLd: () => null,
+  buildBreadcrumbSchema: () => ({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [],
+  }),
+}));
+
+// Mount the page one commit AFTER the Router so the Router's history listener
+// is attached before useSuggestionDeepLink's layout-effect navigate() fires —
+// same rationale as DeferredMount in use-suggestion-deep-link.test.tsx.
+function DeferredMount({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted ? children : null;
+}
+
+const renderPage = async (initialEntry: string) => {
+  // Lazy import after mocks are set up.
+  const { Acaan } = await import("./acaan");
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <MantineProvider>
+        <DeferredMount>
+          <Acaan />
+        </DeferredMount>
+      </MantineProvider>
+    </MemoryRouter>
+  );
+};
+
+beforeEach(() => {
+  capturedSessionCalls = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Acaan — deep-link preselect", () => {
+  it("applies ?timed=1 through the timer setter and gates autoStart until the param is consumed", async () => {
+    await renderPage(`${ROUTES.acaan}?timed=1`);
+
+    await waitFor(() => {
+      expect(handleTimerEnabledChange).toHaveBeenCalledWith(true);
+    });
+    // While the param was pending, the session must not auto-start.
+    expect(capturedSessionCalls[0]?.autoStart).toBe(false);
+    // Once the layout effect strips the param, auto-start is released.
+    await waitFor(() => {
+      expect(capturedSessionCalls.at(-1)?.autoStart).toBe(true);
+    });
+  });
+
+  it("ignores a ?try value (ACAAN has no try handlers) but still strips it and releases autoStart", async () => {
+    await renderPage(`${ROUTES.acaan}?try=anything`);
+
+    await waitFor(() => {
+      expect(capturedSessionCalls.at(-1)?.autoStart).toBe(true);
+    });
+    expect(handleTimerEnabledChange).not.toHaveBeenCalled();
+    // The pending param still gated the initial auto-start.
+    expect(capturedSessionCalls[0]?.autoStart).toBe(false);
+  });
+
+  it("auto-starts immediately when no deep-link params are present", async () => {
+    await renderPage(ROUTES.acaan);
+
+    await waitFor(() => {
+      expect(capturedSessionCalls.length).toBeGreaterThan(0);
+    });
+    expect(capturedSessionCalls[0]?.autoStart).toBe(true);
+    expect(handleTimerEnabledChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/distance/distance-active-round.test.tsx
+++ b/src/pages/distance/distance-active-round.test.tsx
@@ -13,7 +13,7 @@ import { TwoOfHearts } from "../../types/suits/hearts";
 import { AceOfSpades, FiveOfSpades } from "../../types/suits/spades";
 import type { TimerSettings } from "../../types/timer";
 import { DistanceActiveRound } from "./distance-active-round";
-import type { DistanceRound } from "./distance-game-reducer";
+import type { PlayableDistanceRound } from "./distance-game-reducer";
 
 const promptCard: PlayingCardPosition = {
   index: createDeckPosition(1),
@@ -38,7 +38,7 @@ const cardChoiceC: PlayingCardPosition = {
   card: FiveOfSpades,
 };
 
-const computeRound: DistanceRound = {
+const computeRound: PlayableDistanceRound = {
   display: "compute",
   expectedDistance: 3,
   offset: null,
@@ -46,7 +46,7 @@ const computeRound: DistanceRound = {
   choices: { kind: "numbers", data: [1, 2, 3, 4, 5] },
 };
 
-const applyRound: DistanceRound = {
+const applyRound: PlayableDistanceRound = {
   display: "apply",
   expectedDistance: null,
   offset: 5,

--- a/src/pages/distance/distance-active-round.tsx
+++ b/src/pages/distance/distance-active-round.tsx
@@ -9,12 +9,15 @@ import type { PlayingCard } from "../../types/playingcard";
 import type { PlayingCardPosition } from "../../types/stacks";
 import type { TimerSettings } from "../../types/timer";
 import { cardItems, numberItems } from "../../types/typeguards";
-import type { DistanceAnswer, DistanceRound } from "./distance-game-reducer";
+import type {
+  DistanceAnswer,
+  PlayableDistanceRound,
+} from "./distance-game-reducer";
 import { DistancePromptDisplay } from "./distance-prompt-display";
 
 type DistanceActiveRoundProps = {
   card: PlayingCardPosition;
-  round: DistanceRound;
+  round: PlayableDistanceRound;
   roundConvention: DistanceConvention;
   submitAnswer: (answer: DistanceAnswer) => void;
   timerSettings: TimerSettings;

--- a/src/pages/distance/distance-game-reducer.test.ts
+++ b/src/pages/distance/distance-game-reducer.test.ts
@@ -229,19 +229,15 @@ describe("generateNextDistanceRound", () => {
       expect(payload.newChoices.data.length).toBeGreaterThan(0);
       expect(payload.newExpectedDistance).not.toBeNull();
       expect(payload.newExpectedDistance).not.toBe(0);
+      expect(payload.newAnswerCard.index).toBeGreaterThanOrEqual(1);
+      expect(payload.newAnswerCard.index).toBeLessThanOrEqual(6);
+      expect(payload.newCard.index).not.toBe(payload.newAnswerCard.index);
     }
     expect(payload.newCard.index).toBeGreaterThanOrEqual(1);
     expect(payload.newCard.index).toBeLessThanOrEqual(6);
-    expect(payload.newAnswerCard.index).toBeGreaterThanOrEqual(1);
-    expect(payload.newAnswerCard.index).toBeLessThanOrEqual(6);
-    expect(payload.newCard.index).not.toBe(payload.newAnswerCard.index);
   });
 
-  it("returns a mode-independent placeholder payload (no throw) when cycleSize < MIN_DISTANCE_RANGE", () => {
-    // The placeholder is intentionally compute-shaped regardless of the
-    // requested mode — the page short-circuits to a rangeTooSmall banner
-    // and never reads choices/prompt data, so the placeholder shape is
-    // load-bearing only for "no throw across all mode inputs".
+  it("returns a mode-independent range-too-small payload (no throw) when cycleSize < MIN_DISTANCE_RANGE", () => {
     const tooSmall = {
       start: createDeckPosition(1),
       end: createDeckPosition(5),
@@ -253,14 +249,8 @@ describe("generateNextDistanceRound", () => {
         "cyclic",
         tooSmall
       );
-      expect(payload.newDisplay).toBe("compute");
-      if (payload.newDisplay === "compute") {
-        expect(payload.newOffset).toBeNull();
-        expect(payload.newChoices.kind).toBe("numbers");
-        expect(payload.newChoices.data).toEqual([]);
-      }
+      expect(payload.newDisplay).toBe("range-too-small");
       expect(payload.newCard.index).toBe(tooSmall.start);
-      expect(payload.newAnswerCard.index).toBe(tooSmall.start);
     }
   });
 });
@@ -294,41 +284,15 @@ describe("isCorrectAnswer", () => {
     expect(isCorrectAnswer({ kind: "compute", value: 5 }, round)).toBe(false);
   });
 
-  it("rejects every answer (including 0) when round is the rangeTooSmall placeholder", () => {
-    // The placeholder produced by buildRangeTooSmallPayload has empty
-    // choices and `expectedDistance: 0`. Without the defensive guard, an
-    // answer of `{kind:'compute', value:0}` would silently match and
-    // pollute session stats. This test pins that guard.
-    const tooSmall = {
-      start: createDeckPosition(1),
-      end: createDeckPosition(5),
-    };
-    const placeholderPayload = generateNextDistanceRound(
-      stackOrder,
-      "compute",
-      "cyclic",
-      tooSmall
+  it("rejects every answer (including 0) when the round is range-too-small", () => {
+    // Without this guard an answer could silently score against an
+    // unplayable round and pollute session stats. This test pins it.
+    const round: DistanceRound = { display: "range-too-small" };
+    expect(isCorrectAnswer({ kind: "compute", value: 0 }, round)).toBe(false);
+    expect(isCorrectAnswer({ kind: "compute", value: 1 }, round)).toBe(false);
+    expect(isCorrectAnswer({ kind: "apply", value: TwoOfHearts }, round)).toBe(
+      false
     );
-    if (placeholderPayload.newDisplay !== "compute") {
-      throw new Error("expected placeholder to be compute-shaped");
-    }
-    const placeholderRound: DistanceRound = {
-      display: "compute",
-      expectedDistance: placeholderPayload.newExpectedDistance,
-      offset: null,
-      answerCard: placeholderPayload.newAnswerCard,
-      choices: placeholderPayload.newChoices,
-    };
-    expect(placeholderRound.choices.data).toEqual([]);
-    expect(
-      isCorrectAnswer({ kind: "compute", value: 0 }, placeholderRound)
-    ).toBe(false);
-    expect(
-      isCorrectAnswer({ kind: "compute", value: 1 }, placeholderRound)
-    ).toBe(false);
-    expect(
-      isCorrectAnswer({ kind: "apply", value: TwoOfHearts }, placeholderRound)
-    ).toBe(false);
   });
 });
 
@@ -361,7 +325,7 @@ describe("createInitialState", () => {
     expect(state.card.index).toBeLessThanOrEqual(52);
   });
 
-  it("returns a placeholder state without throwing when cycleSize < MIN_DISTANCE_RANGE", () => {
+  it("returns a range-too-small state without throwing when cycleSize < MIN_DISTANCE_RANGE", () => {
     const tooSmall = {
       start: createDeckPosition(1),
       end: createDeckPosition(5),
@@ -375,14 +339,8 @@ describe("createInitialState", () => {
     });
     expect(state.successes).toBe(0);
     expect(state.fails).toBe(0);
-    expect(state.display).toBe("compute");
-    if (state.display === "compute") {
-      expect(state.offset).toBeNull();
-      expect(state.choices.kind).toBe("numbers");
-      expect(state.choices.data).toEqual([]);
-    }
+    expect(state.display).toBe("range-too-small");
     expect(state.card.index).toBe(tooSmall.start);
-    expect(state.answerCard.index).toBe(tooSmall.start);
   });
 });
 

--- a/src/pages/distance/distance-game-reducer.ts
+++ b/src/pages/distance/distance-game-reducer.ts
@@ -32,7 +32,7 @@ import {
  * a non-null `offset` and card choices. This makes the impossible states
  * (e.g., display="apply" with offset=null) unrepresentable.
  */
-export type DistanceRound =
+export type PlayableDistanceRound =
   | {
       display: "compute";
       expectedDistance: number;
@@ -47,6 +47,16 @@ export type DistanceRound =
       answerCard: PlayingCardPosition;
       choices: { kind: "cards"; data: PlayingCardPosition[] };
     };
+
+/**
+ * A playable round, or the `range-too-small` state produced when
+ * `cycleSize < MIN_DISTANCE_RANGE`. The latter carries no prompt data —
+ * consumers must narrow on `display` before reading round fields, which makes
+ * reading prompt data from an unplayable round a compile-time error.
+ */
+export type DistanceRound =
+  | PlayableDistanceRound
+  | { display: "range-too-small" };
 
 /**
  * The user's submitted answer, discriminated to match the current round kind.
@@ -88,7 +98,8 @@ type AdvanceRound =
       newOffset: number;
       newAnswerCard: PlayingCardPosition;
       newChoices: { kind: "cards"; data: PlayingCardPosition[] };
-    };
+    }
+  | { newDisplay: "range-too-small" };
 
 export type AdvancePayload = AdvancePayloadBase & AdvanceRound;
 
@@ -199,45 +210,29 @@ const pickPromptKind = (mode: DistanceMode): DistancePromptKind => {
 };
 
 /**
- * Builds the rangeTooSmall placeholder payload. See SAFETY note on the
- * call site — these values are inert because the page guards on
- * `rangeTooSmall` and never reads them.
+ * Builds the `range-too-small` payload. The prompt card is a stable
+ * placeholder (the first card in range) so `GameState.card` stays populated;
+ * the round itself carries no prompt data — consumers must narrow on
+ * `display` before reading it.
  */
 const buildRangeTooSmallPayload = (
   stackOrder: Stack,
   convention: DistanceConvention,
   limits: StackLimits
-): AdvancePayload => {
-  const placeholder: PlayingCardPosition = {
+): AdvancePayload => ({
+  newCard: {
     index: limits.start,
     card: getCardAt(stackOrder, limits.start - 1),
-  };
-  // Placeholder for rangeTooSmall — consumers must guard on
-  // choices.data.length === 0 before reading expectedDistance. The
-  // expectedDistance: 0 violates the discriminated-union invariant for a
-  // real compute round but is inert because the page-level rangeTooSmall
-  // guard prevents it from ever reaching the user, and `isCorrectAnswer`
-  // short-circuits on the empty choices array.
-  return {
-    newCard: placeholder,
-    newAnswerCard: placeholder,
-    newChoices: { kind: "numbers", data: [] },
-    newDisplay: "compute",
-    newExpectedDistance: 0,
-    newOffset: null,
-    newConvention: convention,
-  };
-};
+  },
+  newDisplay: "range-too-small",
+  newConvention: convention,
+});
 
 /**
  * Build the next-round payload, used by both initial state and every
  * post-answer transition. When `rangeSize < MIN_DISTANCE_RANGE` (the
- * minimum needed to pick 5 unique choices), returns a placeholder payload —
- * the page renders the rangeTooSmall banner in that case and never reads
- * choices/prompt data, so the placeholder is harmless. The placeholder is
- * always compute-shaped (with `expectedDistance: 0`) since the discriminated
- * union requires a non-null distance for compute branches; the page never
- * surfaces this value.
+ * minimum needed to pick 5 unique choices), returns a `range-too-small`
+ * payload — the page renders the rangeTooSmall banner in that case.
  */
 export const generateNextDistanceRound = (
   stackOrder: Stack,
@@ -247,12 +242,6 @@ export const generateNextDistanceRound = (
 ): AdvancePayload => {
   const cycleSize = limits.end - limits.start + 1;
   if (cycleSize < MIN_DISTANCE_RANGE) {
-    // SAFETY: this placeholder is only reached when the page-level
-    // `rangeTooSmall` guard is bypassed (e.g., a unit test). The page
-    // short-circuits to `DistanceRangeTooSmallAlert` and never reads these
-    // values, so `expectedDistance: 0` (an invariant violation for a real
-    // compute round) and the empty `data` array are inert. Do not rely on
-    // these values from any consumer that bypasses the guard.
     return buildRangeTooSmallPayload(stackOrder, convention, limits);
   }
   const kind = pickPromptKind(mode);
@@ -284,20 +273,13 @@ export const generateNextDistanceRound = (
  * Compares a user's discriminated answer against the active round.
  * Compute: numeric value must match `expectedDistance`.
  * Apply: card must match `answerCard.card` by suit and rank.
- *
- * Defensive guard: if the round has no choices (i.e. it's the
- * `buildRangeTooSmallPayload` placeholder served when `cycleSize <
- * MIN_DISTANCE_RANGE`), every answer is wrong. The page-level rangeTooSmall
- * alert prevents the user from ever submitting against this placeholder, but
- * if a routing or test regression bypasses that guard, an answer of `0`
- * would otherwise score correct against the placeholder's
- * `expectedDistance: 0` and silently pollute session stats.
+ * A `range-too-small` round has no answer, so every submission is wrong.
  */
 export const isCorrectAnswer = (
   answer: DistanceAnswer,
   round: DistanceRound
 ): boolean => {
-  if (round.choices.data.length === 0) {
+  if (round.display === "range-too-small") {
     return false;
   }
   if (answer.kind === "compute") {
@@ -318,6 +300,14 @@ const buildStateFromPayload = (
   base: GameStateBase,
   payload: AdvancePayload
 ): GameState => {
+  if (payload.newDisplay === "range-too-small") {
+    return {
+      ...base,
+      card: payload.newCard,
+      convention: payload.newConvention,
+      display: "range-too-small",
+    };
+  }
   if (payload.newDisplay === "compute") {
     return {
       ...base,

--- a/src/pages/distance/distance.tsx
+++ b/src/pages/distance/distance.tsx
@@ -1,7 +1,6 @@
 import { Grid, Text } from "@mantine/core";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { ErrorBoundary } from "../../components/error-boundary";
 import { buildBreadcrumbSchema, JsonLd } from "../../components/json-ld";
 import { RevealButton } from "../../components/reveal-button";
 import { SessionSummaryModal } from "../../components/session-summary-modal";
@@ -95,9 +94,9 @@ export const Distance = () => {
   );
 
   // Safe to invoke unconditionally even when rangeTooSmall: the reducer's
-  // generateNextDistanceRound short-circuits to a placeholder payload (see
-  // buildRangeTooSmallPayload) when cycleSize < MIN_DISTANCE_RANGE, the
-  // timer is force-disabled above, and the page hides the prompt UI.
+  // generateNextDistanceRound short-circuits to a `range-too-small` round
+  // when cycleSize < MIN_DISTANCE_RANGE, the timer is force-disabled above,
+  // and the page renders the alert instead of the prompt UI.
   const {
     score,
     card,
@@ -120,71 +119,69 @@ export const Distance = () => {
   const activeModeLabel = t(ACTIVE_MODE_KEYS[mode]);
 
   return (
-    <ErrorBoundary>
-      <div className="fullMantineContainerHeight">
-        <JsonLd data={breadcrumbSchema} />
-        <Grid
-          gap={0}
-          overflow="hidden"
-          style={{ display: "grid", height: "100%" }}
-        >
-          <Grid.Col span={12}>
-            <TrainingHeader
-              activeSession={activeSession}
-              isStructuredSession={isStructuredSession}
-              onStartSession={startSession}
-              onStopSession={stopSession}
-              rangeSize={rangeSize}
-              score={score}
-              sessionTooltip={t("session.startSessionTooltip")}
-              settingsContent={
-                <DistanceSettingsContent
-                  convention={convention}
-                  mode={mode}
-                  onConventionChange={handleConventionChange}
-                  onDurationChange={setTimerDuration}
-                  onModeChange={handleModeChange}
-                  onTimerEnabledChange={handleTimerEnabledChange}
-                  timerSettings={timerSettings}
-                />
-              }
-              settingsTooltip={t("distance.settingsAriaLabel")}
-              subtitle={activeModeLabel}
-              title={t("distance.title")}
-            />
-            <Text c="dimmed" mb="xs" size="sm">
-              {t("distance.pageDescription")}
-            </Text>
-            <span aria-hidden="true" className="sr-only">
-              {t("distance.seoIntro")}
-            </span>
-          </Grid.Col>
+    <div className="fullMantineContainerHeight">
+      <JsonLd data={breadcrumbSchema} />
+      <Grid
+        gap={0}
+        overflow="hidden"
+        style={{ display: "grid", height: "100%" }}
+      >
+        <Grid.Col span={12}>
+          <TrainingHeader
+            activeSession={activeSession}
+            isStructuredSession={isStructuredSession}
+            onStartSession={startSession}
+            onStopSession={stopSession}
+            rangeSize={rangeSize}
+            score={score}
+            sessionTooltip={t("session.startSessionTooltip")}
+            settingsContent={
+              <DistanceSettingsContent
+                convention={convention}
+                mode={mode}
+                onConventionChange={handleConventionChange}
+                onDurationChange={setTimerDuration}
+                onModeChange={handleModeChange}
+                onTimerEnabledChange={handleTimerEnabledChange}
+                timerSettings={timerSettings}
+              />
+            }
+            settingsTooltip={t("distance.settingsAriaLabel")}
+            subtitle={activeModeLabel}
+            title={t("distance.title")}
+          />
+          <Text c="dimmed" mb="xs" size="sm">
+            {t("distance.pageDescription")}
+          </Text>
+          <span aria-hidden="true" className="sr-only">
+            {t("distance.seoIntro")}
+          </span>
+        </Grid.Col>
 
-          {rangeTooSmall ? (
-            <DistanceRangeTooSmallAlert />
-          ) : (
-            <DistanceActiveRound
-              card={card}
-              round={round}
-              roundConvention={roundConvention}
-              submitAnswer={submitAnswer}
-              timeRemaining={timeRemaining}
-              timerDuration={timerDuration}
-              timerSettings={timerSettings}
-            />
-          )}
-        </Grid>
-        {status.phase === "summary" && (
-          <SessionSummaryModal
-            onDismiss={dismissSummary}
-            onNewSession={startNewSession}
-            summary={status.summary}
+        {round.display === "range-too-small" ? (
+          <DistanceRangeTooSmallAlert />
+        ) : (
+          <DistanceActiveRound
+            card={card}
+            round={round}
+            roundConvention={roundConvention}
+            submitAnswer={submitAnswer}
+            timeRemaining={timeRemaining}
+            timerDuration={timerDuration}
+            timerSettings={timerSettings}
           />
         )}
-        {status.phase !== "summary" && !rangeTooSmall && (
-          <RevealButton onReveal={revealAnswer} />
-        )}
-      </div>
-    </ErrorBoundary>
+      </Grid>
+      {status.phase === "summary" && (
+        <SessionSummaryModal
+          onDismiss={dismissSummary}
+          onNewSession={startNewSession}
+          summary={status.summary}
+        />
+      )}
+      {status.phase !== "summary" && !rangeTooSmall && (
+        <RevealButton onReveal={revealAnswer} />
+      )}
+    </div>
   );
 };

--- a/src/pages/distance/use-distance-game.test.ts
+++ b/src/pages/distance/use-distance-game.test.ts
@@ -101,8 +101,11 @@ describe("useDistanceGame initial state", () => {
         DEFAULT_STACK_LIMITS
       )
     );
-    expect(result.current.round.display).toBe("compute");
-    expect(result.current.round.choices.kind).toBe("numbers");
+    const round = result.current.round;
+    expect(round.display).toBe("compute");
+    if (round.display === "compute") {
+      expect(round.choices.kind).toBe("numbers");
+    }
   });
 
   it("starts in apply display when mode is apply", () => {
@@ -116,10 +119,11 @@ describe("useDistanceGame initial state", () => {
         DEFAULT_STACK_LIMITS
       )
     );
-    expect(result.current.round.display).toBe("apply");
-    expect(result.current.round.choices.kind).toBe("cards");
-    if (result.current.round.display === "apply") {
-      expect(result.current.round.offset).not.toBeNull();
+    const round = result.current.round;
+    expect(round.display).toBe("apply");
+    if (round.display === "apply") {
+      expect(round.choices.kind).toBe("cards");
+      expect(round.offset).not.toBeNull();
     }
   });
 });
@@ -141,13 +145,14 @@ describe("useDistanceGame submitAnswer", () => {
       )
     );
 
-    if (result.current.round.choices.kind !== "numbers") {
-      throw new Error("expected numbers choices in compute mode");
+    const round = result.current.round;
+    if (round.display !== "compute") {
+      throw new Error("expected a compute round in compute mode");
     }
     const cardBefore = result.current.card;
     const expectedDistance = computeDistance(
       result.current.card.index - 1,
-      result.current.round.answerCard.index - 1,
+      round.answerCard.index - 1,
       "cyclic",
       DEFAULT_STACK_LIMITS
     );
@@ -184,8 +189,8 @@ describe("useDistanceGame submitAnswer", () => {
         DEFAULT_STACK_LIMITS
       )
     );
-    if (result.current.round.choices.kind !== "numbers") {
-      throw new Error("expected numbers choices");
+    if (result.current.round.display !== "compute") {
+      throw new Error("expected a compute round");
     }
     const cardBefore = result.current.card;
     // Submit a value far outside the distance set: 9999 is never a valid distance
@@ -217,11 +222,12 @@ describe("useDistanceGame submitAnswer", () => {
       )
     );
 
-    if (result.current.round.choices.kind !== "cards") {
-      throw new Error("expected cards choices in apply mode");
+    const round = result.current.round;
+    if (round.display !== "apply") {
+      throw new Error("expected an apply round in apply mode");
     }
     const cardBefore = result.current.card;
-    const correctCard = result.current.round.answerCard.card;
+    const correctCard = round.answerCard.card;
 
     act(() => {
       result.current.submitAnswer({ kind: "apply", value: correctCard });
@@ -256,16 +262,17 @@ describe("useDistanceGame submitAnswer", () => {
       )
     );
 
-    if (result.current.round.choices.kind !== "cards") {
-      throw new Error("expected cards choices in apply mode");
+    const round = result.current.round;
+    if (round.display !== "apply") {
+      throw new Error("expected an apply round in apply mode");
     }
     // Round generation requires MIN_DISTANCE_RANGE (6) cards in scope, so
     // distinct distractors are guaranteed by construction. Assert it
     // explicitly so this test fails loudly if that invariant breaks.
-    expect(result.current.round.choices.data.length).toBeGreaterThanOrEqual(2);
+    expect(round.choices.data.length).toBeGreaterThanOrEqual(2);
     const cardBefore = result.current.card;
-    const correctCard = result.current.round.answerCard.card;
-    const wrongCard = result.current.round.choices.data.find(
+    const correctCard = round.answerCard.card;
+    const wrongCard = round.choices.data.find(
       (c) =>
         c.card.suit !== correctCard.suit || c.card.rank !== correctCard.rank
     );
@@ -304,9 +311,13 @@ describe("useDistanceGame revealAnswer", () => {
         DEFAULT_STACK_LIMITS
       )
     );
+    const round = result.current.round;
+    if (round.display !== "compute") {
+      throw new Error("expected a compute round in compute mode");
+    }
     const expectedDistance = computeDistance(
       result.current.card.index - 1,
-      result.current.round.answerCard.index - 1,
+      round.answerCard.index - 1,
       "cyclic",
       DEFAULT_STACK_LIMITS
     );
@@ -333,7 +344,11 @@ describe("useDistanceGame revealAnswer", () => {
         DEFAULT_STACK_LIMITS
       )
     );
-    const expectedName = formatCardName(result.current.round.answerCard.card);
+    const round = result.current.round;
+    if (round.display !== "apply") {
+      throw new Error("expected an apply round in apply mode");
+    }
+    const expectedName = formatCardName(round.answerCard.card);
     act(() => {
       result.current.revealAnswer();
     });
@@ -458,8 +473,9 @@ describe("useDistanceGame reset on prop change", () => {
     // Cyclic convention only generates positive distances (1..N-1) — sample
     // a handful of cyclic rounds to anchor the invariant.
     for (let i = 0; i < 20; i++) {
-      if (result.current.round.choices.kind === "numbers") {
-        for (const v of result.current.round.choices.data) {
+      const round = result.current.round;
+      if (round.display === "compute") {
+        for (const v of round.choices.data) {
           expect(v).toBeGreaterThanOrEqual(1);
         }
       }
@@ -474,9 +490,10 @@ describe("useDistanceGame reset on prop change", () => {
     // round must surface a negative value in its numeric choices.
     let sawNegative = false;
     for (let i = 0; i < 30; i++) {
+      const round = result.current.round;
       if (
-        result.current.round.choices.kind === "numbers" &&
-        result.current.round.choices.data.some((v) => v < 0)
+        round.display === "compute" &&
+        round.choices.data.some((v) => v < 0)
       ) {
         sawNegative = true;
         break;

--- a/src/pages/distance/use-distance-game.ts
+++ b/src/pages/distance/use-distance-game.ts
@@ -16,7 +16,7 @@ import type {
   StackValue,
 } from "../../types/stacks";
 import type { TimerSettings } from "../../types/timer";
-import { buildWrongAnswerNotification } from "../flashcard/utils";
+import { buildWrongAnswerNotification } from "../../utils/notifications";
 import {
   type AdvancePayload,
   createInitialState,
@@ -37,7 +37,7 @@ type UseDistanceGameResult = {
   /**
    * The round-shaped fields, discriminated by `display`. Compute rounds carry
    * `expectedDistance` and numeric choices; Apply rounds carry `offset` and
-   * card choices.
+   * card choices; a `range-too-small` round carries no prompt data.
    */
   round: DistanceRound;
   convention: DistanceConvention;
@@ -185,6 +185,11 @@ export const useDistanceGame = (
 
   const revealAnswer = useCallback(() => {
     const round = roundRef.current;
+    // A range-too-small round has no answer to reveal (the page hides the
+    // reveal button in that state).
+    if (round.display === "range-too-small") {
+      return;
+    }
     const revealMessage =
       round.display === "apply"
         ? formatCardName(round.answerCard.card)

--- a/src/pages/flashcard/flashcard.test.tsx
+++ b/src/pages/flashcard/flashcard.test.tsx
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "../../test-utils";
+import type { FlashcardMode, NeighborDirection } from "../../types/flashcard";
+import {
+  createDeckPosition,
+  type PlayingCardPosition,
+  stacks,
+} from "../../types/stacks";
+import type { ResolvedDirection } from "../../utils/neighbor";
+
+// Mock the timer hook so useFlashcardGame mounts without a real interval.
+vi.mock("../../hooks/use-game-timer", () => ({
+  timerReducerCases: {
+    TICK: (s: { timeRemaining: number }) => ({
+      ...s,
+      timeRemaining: Math.max(0, s.timeRemaining - 1),
+    }),
+    RESET_TIMER: (
+      s: { timeRemaining: number; timerDuration: number },
+      duration: number
+    ) => ({ ...s, timeRemaining: duration, timerDuration: duration }),
+  },
+  useGameTimer: vi.fn(),
+}));
+
+vi.mock("@mantine/notifications", () => ({
+  notifications: { show: vi.fn() },
+}));
+
+vi.mock("../../services/event-bus", () => ({
+  eventBus: {
+    emit: {
+      FLASHCARD_ANSWER: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../services/analytics", () => ({
+  analytics: {
+    trackEvent: vi.fn(),
+    trackFeatureUsed: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks/use-document-meta", () => ({
+  useDocumentMeta: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-selected-stack", () => ({
+  useRequiredStack: () => ({
+    stackKey: "mnemonica",
+    stack: stacks.mnemonica,
+    stackOrder: stacks.mnemonica.order,
+    stackName: stacks.mnemonica.name,
+  }),
+}));
+
+const fullLimits = {
+  start: createDeckPosition(1),
+  end: createDeckPosition(52),
+};
+
+type StackLimitsResult = {
+  limits: typeof fullLimits;
+  setLimits: ReturnType<typeof vi.fn>;
+  rangeSize: number;
+  isFullDeck: boolean;
+};
+
+const limitsResult = (start: number, end: number): StackLimitsResult => ({
+  limits: { start: createDeckPosition(start), end: createDeckPosition(end) },
+  setLimits: vi.fn(),
+  rangeSize: end - start + 1,
+  isFullDeck: start === 1 && end === 52,
+});
+
+const mockUseStackLimits = vi.fn<() => StackLimitsResult>();
+
+vi.mock("../../hooks/use-stack-limits", () => ({
+  useStackLimits: () => mockUseStackLimits(),
+}));
+
+type FlashcardSettingsResult = {
+  mode: FlashcardMode;
+  neighborDirection: NeighborDirection;
+  timerSettings: { enabled: boolean; duration: number };
+  setTimerDuration: ReturnType<typeof vi.fn>;
+  handleModeChange: ReturnType<typeof vi.fn>;
+  handleDirectionChange: ReturnType<typeof vi.fn>;
+  handleTimerEnabledChange: ReturnType<typeof vi.fn>;
+};
+
+const settingsResult = (
+  mode: FlashcardMode,
+  neighborDirection: NeighborDirection
+): FlashcardSettingsResult => ({
+  mode,
+  neighborDirection,
+  timerSettings: { enabled: false, duration: 15 },
+  setTimerDuration: vi.fn(),
+  handleModeChange: vi.fn(),
+  handleDirectionChange: vi.fn(),
+  handleTimerEnabledChange: vi.fn(),
+});
+
+const mockUseFlashcardSettings = vi.fn<() => FlashcardSettingsResult>();
+
+vi.mock("./use-flashcard-settings", () => ({
+  useFlashcardSettings: () => mockUseFlashcardSettings(),
+}));
+
+// Controls whether the page believes a ?try= deep link is pending.
+let mockDeepLinkPending = false;
+
+vi.mock("../../hooks/use-suggestion-deep-link", () => ({
+  useSuggestionDeepLink: () => mockDeepLinkPending,
+  tryHandler: () => () => false,
+}));
+
+type CapturedSessionOpts = { autoStart: boolean };
+let capturedSessionOpts: CapturedSessionOpts[] = [];
+
+vi.mock("../../hooks/use-session", () => ({
+  useSession: (opts: CapturedSessionOpts) => {
+    capturedSessionOpts.push(opts);
+    return {
+      status: { phase: "idle" },
+      startSession: vi.fn(),
+      handleAnswer: vi.fn(),
+      startNewSession: vi.fn(),
+      isStructuredSession: false,
+      activeSession: null,
+      stopSession: vi.fn(),
+      dismissSummary: vi.fn(),
+    };
+  },
+}));
+
+// Capture the props the page wires into the active round so we can assert
+// the answer card it surfaces, without rendering the heavy card spread.
+type CapturedRoundProps = {
+  card: PlayingCardPosition;
+  answerCard: PlayingCardPosition;
+  resolvedDirection: ResolvedDirection | null;
+};
+let capturedRoundProps: CapturedRoundProps[] = [];
+
+vi.mock("./flashcard-active-round", () => ({
+  FlashcardActiveRound: (props: CapturedRoundProps) => {
+    capturedRoundProps.push(props);
+    return null;
+  },
+}));
+
+// Stub the heavy children so the test only exercises the Flashcard page logic.
+vi.mock("../../components/training-header", () => ({
+  TrainingHeader: () => null,
+}));
+vi.mock("../../components/session-summary-modal", () => ({
+  SessionSummaryModal: () => null,
+}));
+vi.mock("../../components/reveal-button", () => ({
+  RevealButton: () => null,
+}));
+vi.mock("../../components/json-ld", () => ({
+  JsonLd: () => null,
+  buildBreadcrumbSchema: () => ({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [],
+  }),
+}));
+
+const lastRoundProps = (): CapturedRoundProps => {
+  const props = capturedRoundProps.at(-1);
+  if (!props) {
+    throw new Error("FlashcardActiveRound was not rendered");
+  }
+  return props;
+};
+
+beforeEach(() => {
+  capturedRoundProps = [];
+  capturedSessionOpts = [];
+  mockDeepLinkPending = false;
+  mockUseFlashcardSettings.mockReturnValue(settingsResult("neighbor", "after"));
+  mockUseStackLimits.mockReturnValue(limitsResult(1, 52));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Flashcard — neighbor mode answer card", () => {
+  it("passes the neighbor (not the prompt card) as the answer card", async () => {
+    const { Flashcard } = await import("./flashcard");
+    render(<Flashcard />);
+
+    const { card, answerCard, resolvedDirection } = lastRoundProps();
+    expect(resolvedDirection).toBe("after");
+    // Direction "after" with full limits: position + 1, wrapping 52 → 1.
+    const expectedIndex = card.index === 52 ? 1 : card.index + 1;
+    expect(answerCard.index).toBe(expectedIndex);
+    expect(answerCard.index).not.toBe(card.index);
+    expect(stacks.mnemonica.order[answerCard.index - 1]).toBe(answerCard.card);
+  });
+
+  it("does not crash when limits narrow past the on-screen card (F5 regression)", async () => {
+    // Start with a range high in the deck so the drawn card is guaranteed
+    // to fall outside the narrowed range below.
+    mockUseStackLimits.mockReturnValue(limitsResult(40, 52));
+    const { Flashcard } = await import("./flashcard");
+    const { rerender } = render(<Flashcard />);
+
+    const before = lastRoundProps();
+    expect(before.card.index).toBeGreaterThanOrEqual(40);
+
+    mockUseStackLimits.mockReturnValue(limitsResult(1, 10));
+    expect(() => rerender(<Flashcard />)).not.toThrow();
+
+    // The committed round is drawn entirely from the new range.
+    const after = lastRoundProps();
+    expect(after.card.index).toBeGreaterThanOrEqual(1);
+    expect(after.card.index).toBeLessThanOrEqual(10);
+    expect(after.answerCard.index).toBeGreaterThanOrEqual(1);
+    expect(after.answerCard.index).toBeLessThanOrEqual(10);
+  });
+});
+
+describe("Flashcard — session auto-start vs deep link", () => {
+  it("passes autoStart=false to useSession while a ?try= deep link is pending", async () => {
+    mockDeepLinkPending = true;
+    const { Flashcard } = await import("./flashcard");
+    render(<Flashcard />);
+
+    expect(capturedSessionOpts.length).toBeGreaterThan(0);
+    for (const opts of capturedSessionOpts) {
+      expect(opts.autoStart).toBe(false);
+    }
+  });
+
+  it("passes autoStart=true to useSession when no deep link is pending", async () => {
+    const { Flashcard } = await import("./flashcard");
+    render(<Flashcard />);
+
+    expect(capturedSessionOpts.length).toBeGreaterThan(0);
+    for (const opts of capturedSessionOpts) {
+      expect(opts.autoStart).toBe(true);
+    }
+  });
+});

--- a/src/pages/flashcard/flashcard.tsx
+++ b/src/pages/flashcard/flashcard.tsx
@@ -17,7 +17,6 @@ import {
 } from "../../hooks/use-suggestion-deep-link";
 import { isFlashcardMode } from "../../types/flashcard";
 import { cardItems, numberItems } from "../../types/typeguards";
-import { getNeighborCard } from "../../utils/neighbor";
 import { FlashcardActiveRound } from "./flashcard-active-round";
 import { FlashcardSettingsContent } from "./flashcard-settings-content";
 import { useFlashcardGame } from "./use-flashcard-game";
@@ -72,6 +71,7 @@ export const Flashcard = () => {
   const {
     score,
     card,
+    answerCard,
     choices,
     shouldShowCard,
     timeRemaining,
@@ -98,13 +98,6 @@ export const Flashcard = () => {
     () => cardItems(choices.map((c) => c.card)),
     [choices]
   );
-  const answerCard = useMemo(() => {
-    if (isNeighborMode && resolvedDirection !== null) {
-      return getNeighborCard(stackOrder, card, resolvedDirection, limits);
-    }
-    return card;
-  }, [isNeighborMode, resolvedDirection, stackOrder, card, limits]);
-
   return (
     <div className="fullMantineContainerHeight">
       <JsonLd data={breadcrumbSchema} />

--- a/src/pages/flashcard/use-flashcard-game.ts
+++ b/src/pages/flashcard/use-flashcard-game.ts
@@ -18,6 +18,7 @@ import type {
 } from "../../types/stacks";
 import type { TimerSettings } from "../../types/timer";
 import type { ResolvedDirection } from "../../utils/neighbor";
+import { buildWrongAnswerNotification } from "../../utils/notifications";
 import type { AdvancePayload } from "./flashcard-game-reducer";
 import {
   createInitialState,
@@ -26,7 +27,7 @@ import {
   generateNewCardAndChoices,
   isCorrectAnswer,
 } from "./flashcard-game-reducer";
-import { buildWrongAnswerNotification, getRandomDisplayMode } from "./utils";
+import { getRandomDisplayMode } from "./utils";
 
 // --- Hook ---
 
@@ -37,6 +38,8 @@ type UseFlashcardGameOptions = {
 type UseFlashcardGameResult = {
   score: GameScore;
   card: PlayingCardPosition;
+  /** The card the user must select as the answer. Same as `card` for standard modes. */
+  answerCard: PlayingCardPosition;
   choices: PlayingCardPosition[];
   shouldShowCard: boolean;
   timeRemaining: number;
@@ -270,6 +273,7 @@ export const useFlashcardGame = (
   return {
     score: { successes: state.successes, fails: state.fails },
     card: state.card,
+    answerCard: state.answerCard,
     choices: state.choices,
     shouldShowCard,
     timeRemaining: state.timeRemaining,

--- a/src/pages/flashcard/utils.test.ts
+++ b/src/pages/flashcard/utils.test.ts
@@ -1,11 +1,5 @@
-import type { TFunction } from "i18next";
 import { describe, expect, it } from "vitest";
-import { NOTIFICATION_CLOSE_TIMEOUT } from "../../constants";
-import {
-  buildWrongAnswerNotification,
-  type DisplayMode,
-  getRandomDisplayMode,
-} from "./utils";
+import { type DisplayMode, getRandomDisplayMode } from "./utils";
 
 describe("getRandomDisplayMode", () => {
   it("returns a valid display mode", () => {
@@ -20,21 +14,5 @@ describe("getRandomDisplayMode", () => {
     }
     expect(results.has("card")).toBe(true);
     expect(results.has("index")).toBe(true);
-  });
-});
-
-describe("buildWrongAnswerNotification", () => {
-  it("returns a notification with translated title and message", () => {
-    // Mock t to return the key so we can verify which keys are looked up.
-    // `TFunction` is heavily overloaded and bound to the typed locale shape via
-    // `CustomTypeOptions`; satisfying that surface for a test mock would require
-    // duplicating its overload signatures. Test-only cast — justified.
-    const mockT = ((key: string) => key) as unknown as TFunction;
-    expect(buildWrongAnswerNotification(mockT)).toEqual({
-      color: "red",
-      title: "common.wrongAnswerTitle",
-      message: "common.wrongAnswerMessage",
-      autoClose: NOTIFICATION_CLOSE_TIMEOUT,
-    });
   });
 });

--- a/src/pages/flashcard/utils.ts
+++ b/src/pages/flashcard/utils.ts
@@ -1,6 +1,3 @@
-import type { TFunction } from "i18next";
-import { NOTIFICATION_CLOSE_TIMEOUT } from "../../constants";
-
 const DISPLAY_MODES = ["card", "index"] as const;
 
 export type DisplayMode = (typeof DISPLAY_MODES)[number];
@@ -14,10 +11,3 @@ export const getRandomDisplayMode = (): DisplayMode => {
   }
   return mode;
 };
-
-export const buildWrongAnswerNotification = (t: TFunction) => ({
-  color: "red" as const,
-  title: t("common.wrongAnswerTitle"),
-  message: t("common.wrongAnswerMessage"),
-  autoClose: NOTIFICATION_CLOSE_TIMEOUT,
-});

--- a/src/pages/spot-check/spot-check.test.tsx
+++ b/src/pages/spot-check/spot-check.test.tsx
@@ -1,0 +1,194 @@
+import { MantineProvider } from "@mantine/core";
+import { render, waitFor } from "@testing-library/react";
+import { type ReactNode, useEffect, useState } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ROUTES } from "../../constants";
+import { createDeckPosition, stacks } from "../../types/stacks";
+
+// Capture every useSession invocation so tests can assert how the page gates
+// autoStart while a deep-link param is pending.
+type CapturedSessionOpts = { autoStart: boolean };
+let capturedSessionCalls: CapturedSessionOpts[] = [];
+
+vi.mock("../../hooks/use-session", () => ({
+  useSession: (options: CapturedSessionOpts) => {
+    capturedSessionCalls.push(options);
+    return {
+      status: { phase: "idle" },
+      startSession: vi.fn(),
+      handleAnswer: vi.fn(),
+      startNewSession: vi.fn(),
+      isStructuredSession: false,
+      activeSession: null,
+      stopSession: vi.fn(),
+      dismissSummary: vi.fn(),
+    };
+  },
+}));
+
+// Captured settings setters — the deep link must apply the variant through
+// these (the page's existing setters), not through some parallel path.
+const handleModeChange = vi.fn();
+const handleTimerEnabledChange = vi.fn();
+
+vi.mock("./use-spot-check-settings", () => ({
+  useSpotCheckSettings: () => ({
+    mode: "missing",
+    timerSettings: { enabled: false, duration: 15 },
+    setTimerDuration: vi.fn(),
+    handleModeChange,
+    handleTimerEnabledChange,
+  }),
+}));
+
+vi.mock("./use-spot-check-game", () => ({
+  useSpotCheckGame: () => ({
+    score: { successes: 0, fails: 0 },
+    puzzleCards: [],
+    puzzleState: {
+      mode: "missing",
+      puzzle: { cards: [], missingIndex: 0, missingCard: null },
+    },
+    timeRemaining: 15,
+    timerDuration: 15,
+    submitAnswer: vi.fn(),
+    revealAnswer: vi.fn(),
+  }),
+}));
+
+vi.mock("@mantine/notifications", () => ({
+  notifications: { show: vi.fn() },
+}));
+
+vi.mock("../../services/event-bus", () => ({
+  eventBus: {
+    emit: {
+      SPOT_CHECK_ANSWER: vi.fn(),
+      SPOT_CHECK_MODE_CHANGED: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../../services/analytics", () => ({
+  analytics: {
+    trackEvent: vi.fn(),
+    trackFeatureUsed: vi.fn(),
+  },
+}));
+
+vi.mock("../../hooks/use-document-meta", () => ({
+  useDocumentMeta: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-card-image-preload", () => ({
+  useCardImagePreload: vi.fn(),
+}));
+
+vi.mock("../../hooks/use-selected-stack", () => ({
+  useRequiredStack: () => ({
+    stackKey: "mnemonica",
+    stack: stacks.mnemonica,
+    stackOrder: stacks.mnemonica.order,
+    stackName: stacks.mnemonica.name,
+  }),
+}));
+
+vi.mock("../../hooks/use-stack-limits", () => ({
+  useStackLimits: () => ({
+    limits: { start: createDeckPosition(1), end: createDeckPosition(52) },
+    setLimits: vi.fn(),
+    rangeSize: 52,
+    isFullDeck: true,
+  }),
+}));
+
+// Stub the heavy children so the tests only exercise the page's deep-link
+// wiring.
+vi.mock("../../components/training-header", () => ({
+  TrainingHeader: () => null,
+}));
+vi.mock("../../components/session-summary-modal", () => ({
+  SessionSummaryModal: () => null,
+}));
+vi.mock("../../components/reveal-button", () => ({
+  RevealButton: () => null,
+}));
+vi.mock("../../components/json-ld", () => ({
+  JsonLd: () => null,
+  buildBreadcrumbSchema: () => ({
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [],
+  }),
+}));
+
+// Mount the page one commit AFTER the Router so the Router's history listener
+// is attached before useSuggestionDeepLink's layout-effect navigate() fires —
+// same rationale as DeferredMount in use-suggestion-deep-link.test.tsx.
+function DeferredMount({ children }: { children: ReactNode }) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+  return mounted ? children : null;
+}
+
+const renderPage = async (initialEntry: string) => {
+  // Lazy import after mocks are set up.
+  const { SpotCheck } = await import("./spot-check");
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <MantineProvider>
+        <DeferredMount>
+          <SpotCheck />
+        </DeferredMount>
+      </MantineProvider>
+    </MemoryRouter>
+  );
+};
+
+beforeEach(() => {
+  capturedSessionCalls = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SpotCheck — ?try deep-link preselect", () => {
+  it("applies a valid ?try mode through the settings setter and gates autoStart until the param is consumed", async () => {
+    await renderPage(`${ROUTES.spotCheck}?try=swapped`);
+
+    await waitFor(() => {
+      expect(handleModeChange).toHaveBeenCalledWith("swapped");
+    });
+    // While the param was pending, the session must not auto-start.
+    expect(capturedSessionCalls[0]?.autoStart).toBe(false);
+    // Once the layout effect strips the param, auto-start is released.
+    await waitFor(() => {
+      expect(capturedSessionCalls.at(-1)?.autoStart).toBe(true);
+    });
+  });
+
+  it("ignores an invalid ?try value but still strips it and releases autoStart", async () => {
+    await renderPage(`${ROUTES.spotCheck}?try=not-a-mode`);
+
+    await waitFor(() => {
+      expect(capturedSessionCalls.at(-1)?.autoStart).toBe(true);
+    });
+    expect(handleModeChange).not.toHaveBeenCalled();
+    // The pending param still gated the initial auto-start.
+    expect(capturedSessionCalls[0]?.autoStart).toBe(false);
+  });
+
+  it("auto-starts immediately when no deep-link params are present", async () => {
+    await renderPage(ROUTES.spotCheck);
+
+    await waitFor(() => {
+      expect(capturedSessionCalls.length).toBeGreaterThan(0);
+    });
+    expect(capturedSessionCalls[0]?.autoStart).toBe(true);
+    expect(handleModeChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/spot-check/spot-check.tsx
+++ b/src/pages/spot-check/spot-check.tsx
@@ -2,10 +2,12 @@ import { Space, Stack, Text } from "@mantine/core";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { CardSpread } from "../../components/card-spread/card-spread";
+import { buildBreadcrumbSchema, JsonLd } from "../../components/json-ld";
 import { RevealButton } from "../../components/reveal-button";
 import { SessionSummaryModal } from "../../components/session-summary-modal";
 import { TimerDisplay } from "../../components/timer-display";
 import { TrainingHeader } from "../../components/training-header";
+import { ROUTES } from "../../constants";
 import { useCardImagePreload } from "../../hooks/use-card-image-preload";
 import { useDocumentMeta } from "../../hooks/use-document-meta";
 import { useRequiredStack } from "../../hooks/use-selected-stack";
@@ -24,6 +26,8 @@ import { cardItems } from "../../types/typeguards";
 import { SpotCheckSettingsContent } from "./spot-check-settings-content";
 import { useSpotCheckGame } from "./use-spot-check-game";
 import { useSpotCheckSettings } from "./use-spot-check-settings";
+
+const breadcrumbSchema = buildBreadcrumbSchema("Spot Check", ROUTES.spotCheck);
 
 const MODE_INSTRUCTION_LABELS = {
   missing: "spotCheck.identifyMissing",
@@ -96,6 +100,7 @@ export const SpotCheck = () => {
 
   return (
     <div className="fullMantineContainerHeight">
+      <JsonLd data={breadcrumbSchema} />
       <Stack gap={0} h="100%" style={{ overflow: "hidden" }}>
         <TrainingHeader
           activeSession={activeSession}
@@ -137,7 +142,7 @@ export const SpotCheck = () => {
           </Text>
           <Space h="sm" />
         </div>
-        <div style={{ flex: 1 }}>
+        <div className="spotCheckSpread" style={{ flex: 1 }}>
           <CardSpread
             canMove
             degree={0.5}

--- a/src/pages/spot-check/use-spot-check-game.test.ts
+++ b/src/pages/spot-check/use-spot-check-game.test.ts
@@ -7,7 +7,7 @@ import { type Stack, stacks } from "../../types/stacks";
 import { useSpotCheckGame } from "./use-spot-check-game";
 
 vi.mock("@mantine/notifications", () => ({
-  notifications: { show: vi.fn() },
+  notifications: { show: vi.fn(), hide: vi.fn() },
 }));
 
 let capturedTimerOptions: Parameters<typeof useGameTimer>[0] | null = null;

--- a/src/pages/spot-check/use-spot-check-game.ts
+++ b/src/pages/spot-check/use-spot-check-game.ts
@@ -21,6 +21,10 @@ import {
 } from "./spot-check-game-reducer";
 import { isSpotCheckAnswerCorrect, type PuzzleState } from "./utils";
 
+// Fixed id so repeated Reveal taps replace the pinned toast instead of
+// stacking permanently-open notifications (Mantine shows at most 5).
+const SPOT_CHECK_REVEAL_NOTIFICATION_ID = "spot-check-reveal";
+
 // --- Hook ---
 
 type UseSpotCheckGameOptions = {
@@ -196,11 +200,18 @@ export const useSpotCheckGame = (
       }
     }
 
+    // show() is a no-op while a same-id toast is visible — hide first so only
+    // the latest reveal stays pinned.
+    notifications.hide(SPOT_CHECK_REVEAL_NOTIFICATION_ID);
     notifications.show({
+      id: SPOT_CHECK_REVEAL_NOTIFICATION_ID,
       color: "yellow",
       title: t("spotCheck.revealTitle"),
       message: revealMessage,
-      autoClose: NOTIFICATION_CLOSE_TIMEOUT,
+      // Position details take time to read — keep the notification open until
+      // the user dismisses it (WCAG 2.2 SC 2.2.1 Timing Adjustable).
+      autoClose: false,
+      withCloseButton: true,
     });
 
     const payload = generateNextRound();

--- a/src/pages/toolbox/card-spelling.tsx
+++ b/src/pages/toolbox/card-spelling.tsx
@@ -1,6 +1,6 @@
 import { Stack, Table, Text, TextInput, VisuallyHidden } from "@mantine/core";
 import { IconSearch } from "@tabler/icons-react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormatCardName } from "../../hooks/use-format-card-name";
 import { useRequiredStack } from "../../hooks/use-selected-stack";
@@ -38,9 +38,9 @@ export const CardSpelling = () => {
     setQuery(event.currentTarget.value);
   };
 
-  const handleRowToggle = (position: number) => {
+  const handleRowToggle = useCallback((position: number) => {
     setExpandedPosition((prev) => (prev === position ? null : position));
-  };
+  }, []);
 
   return (
     <Stack gap="md">

--- a/src/pages/toolbox/spelling-row.tsx
+++ b/src/pages/toolbox/spelling-row.tsx
@@ -1,6 +1,6 @@
 import { Badge, Image, Table, Text, useMatches } from "@mantine/core";
 import { IconChevronRight } from "@tabler/icons-react";
-import type { KeyboardEvent } from "react";
+import { type MouseEvent, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { CARD_ASPECT_RATIO } from "../../constants";
 import type { PlayingCard } from "../../types/playingcard";
@@ -16,10 +16,16 @@ const CARD_CELL_STYLE = {
   gap: 8,
 } as const;
 const ROW_CLICKABLE_STYLE = "clickableRow";
-const POSITION_CELL_STYLE = {
+const TOGGLE_BUTTON_STYLE = {
   display: "inline-flex",
   alignItems: "center",
   gap: 4,
+  background: "none",
+  border: 0,
+  padding: 0,
+  font: "inherit",
+  color: "inherit",
+  cursor: "pointer",
 } as const;
 const CHEVRON_EXPANDED_STYLE = {
   transition: "transform 200ms",
@@ -37,42 +43,40 @@ type SpellingRowProps = {
   stackOrder: Stack;
 };
 
-export const SpellingRow = ({
+export const SpellingRow = memo(function SpellingRow({
   entry,
   isExpanded,
   onToggle,
   formatCardName,
   stackOrder,
-}: SpellingRowProps) => {
+}: SpellingRowProps) {
   const { t } = useTranslation();
   const detailId = `spelling-detail-${entry.position}`;
   const detailColSpan = useMatches({ base: 3, xs: 4 });
 
-  const handleClick = () => {
+  // Pointer-only convenience; keyboard users toggle via the button in the
+  // first cell (ARIA disclosure pattern).
+  const handleRowClick = () => {
     onToggle(entry.position);
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLTableRowElement>) => {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-      onToggle(entry.position);
-    }
+  const handleToggleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    onToggle(entry.position);
   };
 
   return (
     <>
-      <Table.Tr
-        aria-controls={detailId}
-        aria-expanded={isExpanded}
-        aria-label={formatCardName(entry.card)}
-        className={ROW_CLICKABLE_STYLE}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        role="button"
-        tabIndex={0}
-      >
+      <Table.Tr className={ROW_CLICKABLE_STYLE} onClick={handleRowClick}>
         <Table.Td>
-          <span style={POSITION_CELL_STYLE}>
+          <button
+            aria-controls={isExpanded ? detailId : undefined}
+            aria-expanded={isExpanded}
+            aria-label={`${entry.position}, ${formatCardName(entry.card)}`}
+            onClick={handleToggleClick}
+            style={TOGGLE_BUTTON_STYLE}
+            type="button"
+          >
             <IconChevronRight
               aria-hidden="true"
               size={14}
@@ -81,7 +85,7 @@ export const SpellingRow = ({
               }
             />
             {entry.position}
-          </span>
+          </button>
         </Table.Td>
         <Table.Td style={CARD_CELL_STYLE}>
           <Image
@@ -130,4 +134,4 @@ export const SpellingRow = ({
       )}
     </>
   );
-};
+});

--- a/src/services/event-bus.ts
+++ b/src/services/event-bus.ts
@@ -3,6 +3,15 @@ import type { FlashcardMode, NeighborDirection } from "../types/flashcard";
 import type { SessionConfig, TrainingMode } from "../types/session";
 import type { SpotCheckMode } from "../types/spot-check";
 
+/**
+ * Two analytics pathways coexist by design:
+ * - Events listed here go through the bus: analytics subscribes to them, and
+ *   the bus is exposed as `window.__memdeckEventBus` (see main.tsx) so e2e
+ *   tests can assert they fired.
+ * - Direct `analytics.*` calls elsewhere are fire-and-forget telemetry and
+ *   are not e2e-observable.
+ * Route an event through the bus when e2e tests need to observe it.
+ */
 type AnalyticsEvents = {
   STACK_SELECTED: { stackName: string };
   FLASHCARD_ANSWER: { correct: boolean; stackName: string };

--- a/src/styles.css
+++ b/src/styles.css
@@ -50,8 +50,11 @@
   border: none;
   border-radius: 3%;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
-  transform: rotate(calc(var(--i) * var(--degree)))
-    translate(calc(var(--i) * 15px), 10px);
+  transform: rotate(calc((var(--i) + var(--offset, 0)) * var(--degree)))
+    translate(
+      calc((var(--i) + var(--offset, 0)) * var(--spread-gap, 15px)),
+      10px
+    );
   transform-origin: 50% 100%;
   -webkit-tap-highlight-color: transparent;
 }
@@ -60,6 +63,14 @@
   z-index: 1;
   outline: 3px solid var(--mantine-primary-color-filled, #228be6);
   outline-offset: 2px;
+}
+
+/* Spot Check spread: wider per-card offset so each overlapped card keeps a
+   ≥24px unobscured tap strip (WCAG 2.2 SC 2.5.8 Target Size Minimum).
+   26px (not 24px) leaves margin for the per-card rotation, which shrinks the
+   axis-aligned strip on outer cards. */
+.spotCheckSpread {
+  --spread-gap: 26px;
 }
 
 .cardShadow {

--- a/src/utils/lazy-with-reload.ts
+++ b/src/utils/lazy-with-reload.ts
@@ -17,7 +17,16 @@ export function lazyWithReload<T extends ComponentType<unknown>>(
       const key = `${CHUNK_RELOAD_SSK}${window.location.pathname}`;
       const params = new URLSearchParams(window.location.search);
 
-      if (sessionStorage.getItem(key) || params.has(CHUNK_RELOADED_PARAM)) {
+      let hasReloadSentinel = false;
+      try {
+        hasReloadSentinel = sessionStorage.getItem(key) !== null;
+      } catch {
+        // Accessing sessionStorage itself can throw (SecurityError when
+        // storage is disabled). Treat as "no sentinel present" — the setItem
+        // below fails the same way and falls back to the URL-param guard.
+      }
+
+      if (hasReloadSentinel || params.has(CHUNK_RELOADED_PARAM)) {
         throw error;
       }
 

--- a/src/utils/localstorage.test.ts
+++ b/src/utils/localstorage.test.ts
@@ -63,7 +63,10 @@ describe("getStoredValue", () => {
     const result = getStoredValue("test-key", "default", isString);
 
     expect(result).toBe("stored-value");
-    expect(mockReadLocalStorageValue).toHaveBeenCalledWith({ key: "test-key" });
+    expect(mockReadLocalStorageValue).toHaveBeenCalledWith({
+      key: "test-key",
+      deserialize: expect.any(Function),
+    });
   });
 
   it("returns default value when stored value is undefined", () => {

--- a/src/utils/localstorage.ts
+++ b/src/utils/localstorage.ts
@@ -44,7 +44,13 @@ export const probeStoredValue = <T>(
   validate: (value: unknown) => value is T
 ): StoredValueProbe<T> => {
   try {
-    const raw: unknown = readLocalStorageValue({ key });
+    // Custom `deserialize` so the prototype-stripping reviver applies on this
+    // path too — Mantine's default `deserializeJSON` parses without a reviver,
+    // which would hand probeStoredValue consumers unstripped objects.
+    const raw: unknown = readLocalStorageValue({
+      key,
+      deserialize: deserializeWithSafeReviver,
+    });
 
     if (raw === undefined || raw === null) {
       return { status: "absent" };
@@ -158,6 +164,21 @@ const safeJsonReviver = (key: string, value: unknown): unknown => {
     return;
   }
   return value;
+};
+
+// Reviver-applying replacement for Mantine's default `deserializeJSON`,
+// passed to `readLocalStorageValue` by `probeStoredValue` above. Mirrors
+// Mantine's malformed-JSON semantics — return the raw string so the caller's
+// validator fails on it and the probe classifies it as corrupt.
+const deserializeWithSafeReviver = (value: string | undefined): unknown => {
+  if (value === undefined) {
+    return;
+  }
+  try {
+    return JSON.parse(value, safeJsonReviver);
+  } catch {
+    return value;
+  }
 };
 
 const parseRawValue = <T>(

--- a/src/utils/notifications.test.ts
+++ b/src/utils/notifications.test.ts
@@ -1,0 +1,20 @@
+import type { TFunction } from "i18next";
+import { describe, expect, it } from "vitest";
+import { NOTIFICATION_CLOSE_TIMEOUT } from "../constants";
+import { buildWrongAnswerNotification } from "./notifications";
+
+describe("buildWrongAnswerNotification", () => {
+  it("returns a notification with translated title and message", () => {
+    // Mock t to return the key so we can verify which keys are looked up.
+    // `TFunction` is heavily overloaded and bound to the typed locale shape via
+    // `CustomTypeOptions`; satisfying that surface for a test mock would require
+    // duplicating its overload signatures. Test-only cast — justified.
+    const mockT = ((key: string) => key) as unknown as TFunction;
+    expect(buildWrongAnswerNotification(mockT)).toEqual({
+      color: "red",
+      title: "common.wrongAnswerTitle",
+      message: "common.wrongAnswerMessage",
+      autoClose: NOTIFICATION_CLOSE_TIMEOUT,
+    });
+  });
+});

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,9 @@
+import type { TFunction } from "i18next";
+import { NOTIFICATION_CLOSE_TIMEOUT } from "../constants";
+
+export const buildWrongAnswerNotification = (t: TFunction) => ({
+  color: "red" as const,
+  title: t("common.wrongAnswerTitle"),
+  message: t("common.wrongAnswerMessage"),
+  autoClose: NOTIFICATION_CLOSE_TIMEOUT,
+});

--- a/src/utils/session-breadcrumbs.ts
+++ b/src/utils/session-breadcrumbs.ts
@@ -90,6 +90,11 @@ export const readLastSaveFailedBreadcrumb =
         } catch {
           // Analytics MUST NOT break the read path.
         }
+        // Purge the unreadable blob so the trackError above fires once — not
+        // on every mount — and the slot is free for a future breadcrumb.
+        // clearLastSaveFailedBreadcrumb handles removeItem/sentinel failures
+        // internally.
+        clearLastSaveFailedBreadcrumb();
         return null;
       default:
         return null;


### PR DESCRIPTION
## Summary

Quality pass from the 2026-06-10 `/jr-audit` + `/jr-review` run (fable reviewers, 31 audit findings + 6 review-of-review findings). All verified through three `/jr-review` convergence passes — 0 regressions.

**Correctness / error-handling**
- Neighbor-mode render crash when stack range narrows past the on-screen card (flashcard)
- `startSession` silently discarded prior session on write-failure; now surfaces toast + telemetry
- `sessionStorage.getItem` unguarded in `lazy-with-reload` → `SecurityError` now falls through to url-param guard
- Corrupt breadcrumb never cleared → unbounded GA error spam; now purged after one `trackError`
- `useStackLimits` corrupt-locked `setLimits` silently no-oped → now re-shows id-deduped notification
- `usePwaInstall` `prompt()` rejection restored the consumed event, creating a futile retry loop → fixed

**Type safety**
- Distance game: fake "compute" round replaced with a proper `range-too-small` discriminated-union member
- `prerender.ts` replacer callbacks annotated (`_: string, p1: string, p2: string`) to eliminate implicit `any`
- `buildWrongAnswerNotification` moved from `flashcard/utils` to `src/utils/notifications` (only cross-page import in the graph)

**Security / hardening**
- `json-ld.tsx`: escapes `<` in `JSON.stringify` output to prevent `</script>` breakout in prerendered HTML
- `localstorage.ts` `probeStoredValue` now applies `safeJsonReviver` (prototype-pollution stripping)

**Accessibility (WCAG 2.2)**
- Collapsed navbar: `inert={!opened}` removes off-screen controls from tab order (SC 2.4.3)
- Spot-check card spread: `--spread-gap: 26px` for SC 2.5.8 (24px minimum + rotation-geometry margin)
- Timer text: urgent yellow mapped to `#996300` (5.07:1 on white), fixing the incomplete F12 fix where Mantine `yellow-9` was still 2.999:1
- Tools NavLink: controlled open state + explicit `aria-expanded` (SC 4.1.2)
- Spelling row: real `<button>` disclosure with `aria-expanded`/`aria-controls`, label includes visible position (SC 1.3.1 / 2.5.3 / no dangling idref)
- Reveal + PWA update toasts: `autoClose:false` (SC 2.2.1); reveal uses fixed `id` + hide-before-show to prevent accumulation

**Performance**
- CardSpread drag `offset` moved to container CSS var — 52 fewer child re-renders per rAF tick during Spot Check dragging
- `SpellingRow` wrapped in `React.memo` + `handleRowToggle` in `useCallback`

**Architecture / docs**
- Distance page: removed redundant nested `ErrorBoundary` (app-level covers it)
- `event-bus.ts`: documented the two-pathway rule (bus = e2e-observable; direct analytics = fire-and-forget)
- `CLAUDE.md` utils description updated to reflect deliberate side-effecting modules

**Test coverage** (7 new test files, existing updated)
- `use-card-image-preload`, `error-boundary`, `require-stack`, `flashcard` page, `spot-check` page, `acaan` page, `notifications` util, `use-session` write-failure branch (2 new tests)

## Test plan

- [x] `pnpm run typecheck` — 0 errors
- [x] `rtk proxy pnpm run lint` — 0 issues (368 files)
- [x] `pnpm run knip` — no dead exports/deps/files
- [x] `pnpm run fta` — no complexity regressions
- [x] `pnpm run test:coverage` — 128 test files, 2041 tests pass, per-dir ratchets met
- [x] `pnpm run lint:e2e-no-wait` — clean
- [x] `pnpm run build` — 12 routes prerendered, vite + PWA + sitemap + llms-full.txt OK
- [x] Three `/jr-review` convergence passes (fresh-eyes review + two convergence checks) — 0 findings on final pass