### PR TITLE
chore(deps): bump ultracite from 7.8.2 to 7.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "postcss-simple-vars": "7.0.1",
     "sharp": "0.34.5",
     "typescript": "6.0.3",
-    "ultracite": "7.8.2",
+    "ultracite": "7.8.3",
     "vite": "8.0.16",
     "vite-plugin-pwa": "1.3.0",
     "vitest": "4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       ultracite:
-        specifier: 7.8.2
-        version: 7.8.2(oxlint@1.38.0)
+        specifier: 7.8.3
+        version: 7.8.3(oxlint@1.38.0)
       vite:
         specifier: 8.0.16
         version: 8.0.16(@types/node@25.9.2)(esbuild@0.27.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.48.0)(yaml@2.9.0)
@@ -3960,8 +3960,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  ultracite@7.8.2:
-    resolution: {integrity: sha512-+XeWzAEsewEr/kM686bOIWWt5DN+Pww4JUEOQUqOx4p/Pi58FWV+vPtEo2wi5WVWSgIkf8NzfTWGXmJjdqMl8g==}
+  ultracite@7.8.3:
+    resolution: {integrity: sha512-Fsj9aYJfh57uDB6DrdKVafKhF0QNekwqTrZKoTMYePjZp1npyFCnfZVj2SnPZdOcxAGHJfmLYUIDq0YPh8acVA==}
     hasBin: true
     peerDependencies:
       oxfmt: '>=0.1.0'
@@ -8359,7 +8359,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  ultracite@7.8.2(oxlint@1.38.0):
+  ultracite@7.8.3(oxlint@1.38.0):
     dependencies:
       '@clack/prompts': 1.5.1
       commander: 15.0.0


### PR DESCRIPTION
## Summary

- Bumps `ultracite` from `7.8.2` to `7.8.3`.
- Updates `pnpm-lock.yaml` to match.

## Test plan

- [ ] CI passes (lint, typecheck, tests).