### PR TITLE
chore(deps): bump react-router to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-error-boundary": "6.1.2",
     "react-ga4": "3.0.1",
     "react-i18next": "17.0.8",
-    "react-router": "8.0.0",
+    "react-router": "8.0.1",
     "web-vitals": "5.3.0"
   },
   "browserslist": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 17.0.8
         version: 17.0.8(i18next@26.3.1(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       react-router:
-        specifier: 8.0.0
-        version: 8.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 8.0.1
+        version: 8.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       web-vitals:
         specifier: 5.3.0
         version: 5.3.0
@@ -3481,8 +3481,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-router@8.0.0:
-    resolution: {integrity: sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw==}
+  react-router@8.0.1:
+    resolution: {integrity: sha512-5EL/fANovVUhRK50NLS8RYfX0BxrimoKsHWUPPy8v5UEl8i6vzF7e4POo3u+AhPItDwccUAJjMfIOmydxBJmQw==}
     engines: {node: '>=22.22.0'}
     peerDependencies:
       react: '>=19.2.7'
@@ -7774,7 +7774,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  react-router@8.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@8.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       cookie-es: 3.1.1
       react: 19.2.7


### PR DESCRIPTION
## Summary

- Bumps `react-router` from `8.0.0` to `8.0.1`
- Updates `pnpm-lock.yaml` accordingly

## Test plan

- [ ] CI passes